### PR TITLE
Docs: launch-readiness pass across the markdown set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ One HTML file = the document + viewer + editor. See `README.md` for the vision.
   across the element box (vertical lines = rotation), keep 96px side margins
   (x ≤ 1184 for right-most content).
 - `src/save.ts` — the self-save trick: clone the document at boot (`capturePristine`),
-  swap the `#bento-doc` data block, re-serialize. JSON is `<`-escaped (`<`) so it can
+  swap the `#bento-doc` data block, re-serialize. JSON is `<`-escaped (`\u003c`) so it can
   never contain `</script>`. File System Access API first, download fallback.
 - `src/autosave.ts` (v0.9.8) — auto-save + local version history, IndexedDB
   (`bento-autosave`, two stores: `recovery` single-latest-per-docId, `versions`
@@ -491,7 +491,7 @@ One HTML file = the document + viewer + editor. See `README.md` for the vision.
   build:single) deflates runtime JS+CSS into base64 `bento/deflate-b64` script
   blocks + ~1KB loader (DecompressionStream → blob import; pre-2023 browsers
   get a plain-HTML message). Byte order: chrome → NOTICE → tooling comment →
-  PLAINTEXT #bento-doc → splash → payloads last. Shell ~478KB (was 1.33MB).
+  PLAINTEXT #bento-doc → splash → payloads last. Shell ~560KB (was 1.33MB).
   SPLICE CONTRACT (old updaters are frozen code): #bento-doc stays plaintext/
   same id, file survives DOMParser→splice→outerHTML, no stray script-close —
   release.mjs runs a conformance GATE before signing every release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ run and no account to create — the whole app builds to one HTML file.
 git clone https://github.com/nyblnet/bento.git
 cd bento/slides
 npm install
-npm run dev            # dev server at http://localhost:5199
+npm run dev            # dev server at http://localhost:5173
 ```
 
 The current app lives in `slides/`. Common commands (run from `slides/`):
@@ -23,7 +23,7 @@ The current app lives in `slides/`. Common commands (run from `slides/`):
 |---|---|
 | `npm run dev` | Vite dev server with hot reload. |
 | `npm run build:single` | Produces the shippable `dist-single/Bento_Slides.bento.html` — one file with the runtime, editor, and an empty document block. |
-| `node scripts/test-sync.ts` | The CRDT convergence rig. Run it after **any** change to `slides/src/sync/crdt.ts`; it has caught many ordering bugs. `SEEDS`, `STEPS`, and `ACTORS` env vars tune the fuzzing. |
+| `node ../scripts/test-sync.ts` | The CRDT convergence rig. Run it after **any** change to `slides/src/sync/crdt.ts`; it has caught many ordering bugs. `SEEDS`, `STEPS`, and `ACTORS` env vars tune the fuzzing. |
 
 ## Where things live
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ feature tour. Or grab a designed template from the
 **Download the app:** grab the single `Bento_Slides.bento.html` from the
 [GitHub Releases](https://github.com/nyblnet/bento/releases) page or straight
 from [bento.page](https://bento.page/releases/slides/Bento_Slides.bento.html)
-(~470 KB, no account, no installer). Open it in any modern browser and it *is*
+(~560 KB, no account, no installer). Open it in any modern browser and it *is*
 the editor. Save, and it rewrites itself with your deck inside.
 
 ## Why this exists
@@ -41,7 +41,7 @@ company keeps its servers on. Bento takes the other path:
 | **Charts, built in** | Bar / line / pie / scatter drawn by our own dependency-free engine, live during presentations: tooltips, zoom, and data that morphs when a bar chart becomes a pie. |
 | **Designed for AI** | The document is plain JSON in the file, so agents edit `.bento.html` files in place and chatbots round-trip the JSON (`window.bento.loadDoc`). See [docs/agents.md](docs/agents.md). |
 | **Signed self-updates** | Releases are ECDSA-signed and offered in-app. Updating writes a *new* file — the old one stays as your rollback. No server ever touches your documents. |
-| **Everything else** | Speaker view, comments, layouts, hidden interactive states, hover reveals, motion paths, PDF export, page sizes, 8 UI languages — in a ~400 KB shell. |
+| **Everything else** | Speaker view, comments, layouts, hidden interactive states, hover reveals, motion paths, PDF export, page sizes, 8 UI languages — in a ~560 KB shell. |
 
 ## Use it with AI
 
@@ -71,7 +71,7 @@ this repo at [docs/agents.md](docs/agents.md)).
 DOM). Animation is an in-house engine (`anim.ts`), charts are in-house
 (`charts.ts`), collaboration is an in-house CRDT (`sync/crdt.ts` — pure
 data, fuzz-tested by `scripts/test-sync.ts` across hundreds of thousands of
-convergence checks). The shell compresses to ~400 KB with the document block
+convergence checks). The shell compresses to ~560 KB with the document block
 left as plaintext so old files and outside tools can always splice it. The
 deep dive: [docs/architecture.md](docs/architecture.md).
 
@@ -97,7 +97,7 @@ backend to stand up.
 ```bash
 cd slides
 npm install
-npm run dev            # dev server (http://localhost:5199)
+npm run dev            # dev server (http://localhost:5173)
 npm run build:single   # → dist-single/Bento_Slides.bento.html (the product)
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ block-beta
   chrome["hdr"]:3
   notice["NOTICE"]:4
   doc["#bento-doc — THE DOCUMENT (0 → n MB)"]:14
-  js["runtime JS — app + Reveal + Moveable/Selecto + ECharts (1.17 MB)"]:26
+  js["runtime JS — app + Reveal + Moveable/Selecto + charts-lite (~560 KB)"]:26
   css["CSS (62 KB)"]:6
   splash["splash"]:3
 
@@ -72,7 +72,7 @@ else is the fixed *shell*. Skeleton of the actual markup
   </script>
 
   <!-- ═══ THE RUNTIME ═══ viewer + presenter + editor, one inlined bundle -->
-  <script type="module">/* ≈1.17 MB minified JS */</script>
+  <script type="module">/* ≈560 KB minified JS */</script>
   <style>/* ≈62 KB minified CSS — editor chrome, present overlay, print rules */</style>
   <style>/* splash CSS — paints before the bundle parses */</style>
 </head>
@@ -83,19 +83,22 @@ else is the fixed *shell*. Skeleton of the actual markup
 </html>
 ```
 
-Layout and sizes, in file order (byte offsets measured on the 1.24 MB shell;
-they shift with the data block's size — the *order* is fixed):
+Layout and sizes, in file order — illustrative figures for the *uncompressed*
+runtime (the shipped shell is DEFLATE-compressed, see the v0.7.0 note above; the
+*order* is what's fixed, byte offsets shift with the data block's size):
 
-| # | Part | Offset (shell) | ≈ size (raw) | What it is |
-|---|---|---|---|---|
-| 1 | Head chrome | 0 | 0.7 KB | doctype, metas, favicon, title |
-| 2 | NOTICE comment | 653 | 2 KB | bundled-library license notices |
-| 3 | **`#bento-doc` data block** | 2,825 | **0 → *n* MB** | **the document** — JSON, `<` escaped; assets are data URIs, so image-heavy decks dominate the file |
-| 4 | Runtime JS | 2,854 | 1.17 MB | app (~120 KB) + Reveal.js + Moveable/Selecto family + ECharts/zrender (~610 KB) |
-| 5 | Runtime CSS | 1,124,504 | 62 KB | editor + present + print styles |
-| 6 | Splash CSS + body mounts | 1,186,508 | 2 KB | splash `<style>`/`<div>`, `#app` mount |
+| # | Part | ≈ size (raw) | What it is |
+|---|---|---|---|
+| 1 | Head chrome | 0.7 KB | doctype, metas, favicon, title |
+| 2 | NOTICE comment | 2 KB | bundled-library license notices |
+| 3 | **`#bento-doc` data block** | **0 → *n* MB** | **the document** — JSON, `<` escaped; assets are data URIs, so image-heavy decks dominate the file |
+| 4 | Runtime JS | ~560 KB | app (~120 KB) + Reveal.js + Moveable/Selecto family + charts-lite (in-house SVG charts, replaced ECharts in v0.7.0) |
+| 5 | Runtime CSS | 62 KB | editor + present + print styles |
+| 6 | Splash CSS + body mounts | 2 KB | splash `<style>`/`<div>`, `#app` mount |
 
-Whole shell: 1.24 MB raw, ≈392 KB gzipped, before any document content.
+Once DEFLATE-compressed for shipping, the whole shell is well under 600 KB on
+disk before any document content (≈558 KB in the current build; it grows slowly
+as features land — the v0.7.0 note records the compression milestone).
 
 Two hard rules keep the file well-formed:
 
@@ -181,7 +184,7 @@ BentoDoc
 ├─ theme: { fontFamily, … }
 ├─ present?: { slideNumber?, controls?, progress? }
 ├─ assets?: { key → data URI }        ← images, fonts; referenced as "asset:key"
-├─ fonts?: [{ family, assetKey }]     ← @font-face injected at boot
+├─ fonts?: [{ family, asset, weight?, style? }]  ← @font-face injected at boot
 ├─ layouts?: Slide[]                  ← templates; instantiation KEEPS element ids (lineage → morph continuity)
 └─ slides: Slide[]                 ← linear order; states sit right after their parent
    ├─ id                           ← stable; morph matches elements ACROSS slides by element id

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,7 +1,7 @@
 # The `bento/slides` document format
 
 *Normative reference for the JSON document model, current as of Bento Slides
-**v0.9.20** (format version `1`). The authoritative source is
+**v1.0.6** (format version `1`). The authoritative source is
 [`slides/src/model.ts`](../slides/src/model.ts) — this document tracks it. If
 the two disagree, the code wins; please file that as a docs bug.*
 
@@ -44,7 +44,7 @@ dry reference of every field.
   references (image/media URLs) are allowed but break the offline guarantee;
   embedded `data:`/`asset:` sources keep it intact.
 
-When writing the JSON into the file block, **escape every `<` as `<`** so
+When writing the JSON into the file block, **escape every `<` as `\u003c`** so
 the string `</script>` can never appear and terminate the block.
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -174,7 +174,7 @@ point.
 None of the above asks for trust. The relevant code is small and public:
 
 - [`server/sync-worker/src/worker.js`](../server/sync-worker/src/worker.js) —
-  the entire relay (~250 lines): ciphertext storage, token check, signature
+  the entire relay (~300 lines): ciphertext storage, token check, signature
   verification.
 - [`slides/src/sync/online.ts`](../slides/src/sync/online.ts) — client E2EE,
   key minting, frame signing.

--- a/plugins/bento-slides/skills/bento-slides/SKILL.md
+++ b/plugins/bento-slides/skills/bento-slides/SKILL.md
@@ -21,7 +21,7 @@ JSON in a single block:
 ```
 
 You edit **that block only**, in place. Escape every `<` in the JSON as
-`<` so it can never contain a literal `</script>`. Leave the rest of the
+`\u003c` so it can never contain a literal `</script>`. Leave the rest of the
 file (the compressed runtime) untouched. In a chat context instead, the user
 copies the JSON out (*Save ▾ → Copy document JSON*) and pastes your
 replacement back (*Save ▾ → Replace from JSON…*); `window.bento.loadDoc(json)`

--- a/server/guestbook-daemon/README.md
+++ b/server/guestbook-daemon/README.md
@@ -1,7 +1,7 @@
 # bento-guestbook-daemon
 
 The sustainable home of the public guestbook (see `working/guestbook-design.md`):
-a Cloudflare Worker that serves the current epoch from R2, archives the live
+a Cloudflare Worker that serves the current epoch from Workers KV, archives the live
 room daily (read-only CRDT replay), and rolls epochs with fresh credentials.
 
 ## One-time setup


### PR DESCRIPTION
- Fix the agent-facing JSON escape guidance: escape < as < (not a no-op < -> <) in SKILL.md, docs/format.md, and CLAUDE.md — matches save.ts and stops agents corrupting decks that use inline tags.
- docs/format.md: version dateline v0.9.20 -> v1.0.6.
- docs/architecture.md: drop removed ECharts from the on-disk anatomy (diagram, skeleton, size table) -> charts-lite; refresh stale 1.24 MB/1.17 MB sizes to the current ~560 KB shell; fix fonts field assetKey -> asset.
- Shell size consistency: ~470/~400/~478 KB -> ~560 KB (README, CLAUDE.md).
- README/CONTRIBUTING: npm run dev is :5173 (only launch.json forces 5199); test-sync.ts is ../scripts from slides/.
- docs/security.md: relay ~250 -> ~300 lines (worker.js is 316).
- guestbook-daemon README: serves from Workers KV, not R2.

<!-- Thanks for contributing! Keep PRs focused — one concern each. -->

**What & why**
What does this change, and what problem does it solve?

**How I verified it**
<!-- e.g. ran `npm run build:single`; for CRDT changes ran `node scripts/test-sync.ts`;
     real-mouse QA for canvas/Moveable changes -->

**Checklist**
- [ ] Read the relevant parts of CLAUDE.md / docs before changing them
- [ ] `npm run build:single` succeeds (from `slides/`)
- [ ] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/`
- [ ] New UI strings added to every catalog in `slides/src/i18n/`
- [ ] Document format changes are additive and backward-compatible
- [ ] Did not bump the version or cut a release (maintainers sign releases)
