### PR TITLE
True bezier curve editing with control handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ below opens files from every earlier version, and unknown fields are preserved.
 This project's versions roughly follow semantic-ish `0.MINOR.PATCH` while it is
 pre-1.0.
 
+## [Unreleased]
+
+- **True bezier curve editing.** Selecting a curve now shows real pen-tool
+  control handles (in/out tangents) on each anchor — drag a handle to bend the
+  curve exactly. Smooth anchors mirror the opposite handle; Alt breaks a corner.
+  Double-click a segment to insert an anchor (a de Casteljau split that
+  preserves the shape), double-click an anchor to remove it. Replaces the old
+  Catmull-Rom anchor editing, which sampled the rendered curve into approximate
+  points and re-smoothed on every drag — lossy, drifting, no real handles. The
+  new model parses the path's actual control points and round-trips losslessly.
+
 ## [1.0.6] — 2026-07-21
 
 - **Fix: topbar menus were icon-only on narrow screens.** The responsive rule

--- a/slides/src/editor/bezier.ts
+++ b/slides/src/editor/bezier.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento/Suite authors
+// Exact cubic-bezier path model for true pen-tool editing. Unlike the old
+// Catmull-Rom approach (which SAMPLED the rendered curve back into approximate
+// anchors and re-smoothed on every edit — lossy, drifting, no real handles),
+// this parses the path's actual control points and edits them directly, so the
+// on-screen handles ARE the curve and a round-trip is byte-stable.
+//
+// Coordinates here are path-local (the space of ShapeElement.d / pathBox); the
+// editor maps to/from slide coords. Segments are always cubic; straight bits
+// are cubics whose handles sit on the chord, so everything edits uniformly.
+
+export type Pt = { x: number; y: number }
+
+/** One on-curve anchor with its incoming/outgoing control handles (absolute
+ *  path coords). `in` is undefined on the first node of an open path, `out` on
+ *  the last. `corner` = handles move independently (no smooth mirroring). */
+export interface BezNode {
+  p: Pt
+  in?: Pt
+  out?: Pt
+  corner?: boolean
+}
+
+const lerp = (a: Pt, b: Pt, t: number): Pt => ({ x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t })
+const r = (v: number) => Math.round(v * 100) / 100
+
+/** Parse an SVG path of M / L / C (+ optional trailing Z) into cubic nodes.
+ *  L segments become cubics with handles on the chord (thirds) so they edit
+ *  like everything else. Our own generators only emit these commands; exotic
+ *  commands (Q/S/T/A) are ignored gracefully (their endpoints still land). */
+export function parseBezier(d: string): { nodes: BezNode[]; closed: boolean } {
+  const tokens = d.match(/[A-Za-z]|-?\d*\.?\d+(?:e-?\d+)?/g) ?? []
+  const nodes: BezNode[] = []
+  let closed = false
+  let i = 0
+  let cmd = ''
+  const num = () => Number(tokens[i++])
+  while (i < tokens.length) {
+    const tk = tokens[i]
+    if (/^[A-Za-z]$/.test(tk)) {
+      cmd = tk
+      i++
+      if (/z/i.test(cmd)) closed = true
+      continue
+    }
+    const C = cmd.toUpperCase()
+    if (C === 'M') {
+      nodes.push({ p: { x: num(), y: num() } })
+    } else if (C === 'L') {
+      const p = { x: num(), y: num() }
+      const prev = nodes[nodes.length - 1]
+      if (prev) prev.out = prev.out ?? lerp(prev.p, p, 1 / 3)
+      nodes.push({ p, in: lerp(prev ? prev.p : p, p, 2 / 3) })
+    } else if (C === 'C') {
+      const c1 = { x: num(), y: num() }
+      const c2 = { x: num(), y: num() }
+      const p = { x: num(), y: num() }
+      const prev = nodes[nodes.length - 1]
+      if (prev) prev.out = c1
+      nodes.push({ p, in: c2 })
+    } else {
+      // unknown command: consume two numbers as an endpoint so we stay in sync
+      const p = { x: num(), y: num() }
+      if (!Number.isNaN(p.x) && !Number.isNaN(p.y)) nodes.push({ p })
+    }
+  }
+  return { nodes, closed }
+}
+
+/** Serialize nodes back to a path string. Missing handles fall back to the
+ *  chord thirds (a straight segment), so partial nodes never crash the render. */
+export function serializeBezier(nodes: BezNode[], closed: boolean): string {
+  if (!nodes.length) return ''
+  if (nodes.length === 1) return `M ${r(nodes[0].p.x)} ${r(nodes[0].p.y)}`
+  const seg = (a: BezNode, b: BezNode) => {
+    const c1 = a.out ?? lerp(a.p, b.p, 1 / 3)
+    const c2 = b.in ?? lerp(a.p, b.p, 2 / 3)
+    return ` C ${r(c1.x)} ${r(c1.y)} ${r(c2.x)} ${r(c2.y)} ${r(b.p.x)} ${r(b.p.y)}`
+  }
+  let d = `M ${r(nodes[0].p.x)} ${r(nodes[0].p.y)}`
+  for (let i = 0; i < nodes.length - 1; i++) d += seg(nodes[i], nodes[i + 1])
+  if (closed && nodes.length > 2) {
+    d += seg(nodes[nodes.length - 1], nodes[0])
+    d += ' Z'
+  }
+  return d
+}
+
+/** Evaluate the cubic p0→p3 (controls c1,c2) at parameter t. */
+export function cubicAt(p0: Pt, c1: Pt, c2: Pt, p3: Pt, t: number): Pt {
+  const u = 1 - t
+  const a = u * u * u
+  const b = 3 * u * u * t
+  const c = 3 * u * t * t
+  const dd = t * t * t
+  return {
+    x: a * p0.x + b * c1.x + c * c2.x + dd * p3.x,
+    y: a * p0.y + b * c1.y + c * c2.y + dd * p3.y,
+  }
+}
+
+/** Nearest parameter t on the cubic to point q (coarse sample + local refine). */
+export function nearestT(p0: Pt, c1: Pt, c2: Pt, p3: Pt, q: Pt): number {
+  const N = 24
+  let bestT = 0
+  let bestD = Infinity
+  for (let i = 0; i <= N; i++) {
+    const t = i / N
+    const pt = cubicAt(p0, c1, c2, p3, t)
+    const d = (pt.x - q.x) ** 2 + (pt.y - q.y) ** 2
+    if (d < bestD) { bestD = d; bestT = t }
+  }
+  let step = 1 / N
+  for (let iter = 0; iter < 12; iter++) {
+    step /= 2
+    for (const t of [bestT - step, bestT + step]) {
+      if (t < 0 || t > 1) continue
+      const pt = cubicAt(p0, c1, c2, p3, t)
+      const d = (pt.x - q.x) ** 2 + (pt.y - q.y) ** 2
+      if (d < bestD) { bestD = d; bestT = t }
+    }
+  }
+  return bestT
+}
+
+/** de Casteljau split of the segment a→b at t. Returns updated a/b (their inner
+ *  handles shrink to the split) and the new middle node — shape is preserved
+ *  exactly. The middle node is smooth. */
+export function splitSegment(a: BezNode, b: BezNode, t: number): { a: BezNode; mid: BezNode; b: BezNode } {
+  const p0 = a.p
+  const c1 = a.out ?? lerp(a.p, b.p, 1 / 3)
+  const c2 = b.in ?? lerp(a.p, b.p, 2 / 3)
+  const p3 = b.p
+  const q0 = lerp(p0, c1, t)
+  const q1 = lerp(c1, c2, t)
+  const q2 = lerp(c2, p3, t)
+  const s0 = lerp(q0, q1, t)
+  const s1 = lerp(q1, q2, t)
+  const mid = lerp(s0, s1, t)
+  return {
+    a: { ...a, out: q0 },
+    mid: { p: mid, in: s0, out: s1 },
+    b: { ...b, in: q2 },
+  }
+}
+
+/** Mirror handle `h` about anchor `p` (for smooth-node symmetry), preserving the
+ *  opposite handle's original length so a smooth node isn't forced symmetric. */
+export function mirrorHandle(p: Pt, h: Pt, oppLen: number): Pt {
+  const dx = p.x - h.x
+  const dy = p.y - h.y
+  const len = Math.hypot(dx, dy)
+  if (!len) return { ...p }
+  const k = oppLen / len
+  return { x: p.x + dx * k, y: p.y + dy * k }
+}
+
+export const handleLen = (p: Pt, h?: Pt): number => (h ? Math.hypot(h.x - p.x, h.y - p.y) : 0)

--- a/slides/src/editor/beziereditor.ts
+++ b/slides/src/editor/beziereditor.ts
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento/Suite authors
+// True pen-tool editing for curve (path) shapes. Each on-curve anchor shows its
+// in/out control handles; dragging a handle bends the curve exactly (the path
+// IS the handles — no sampling, no re-smoothing, no drift). Smooth anchors
+// mirror the opposite handle; Alt breaks symmetry into a corner. Double-click a
+// segment to insert an anchor (the split preserves the shape via de Casteljau);
+// double-click an anchor to remove it; drag the body to move the whole shape.
+//
+// Replaces the old Catmull-Rom anchor editing for curves (which sampled the
+// rendered path and re-smoothed on every drag). Lines and straight polygons
+// keep using LineEditor; this takes over only for curved paths.
+
+import type { Store } from '../store'
+import type { ShapeElement } from '../model'
+import { type BezNode, type Pt, handleLen, mirrorHandle, nearestT, parseBezier, serializeBezier, splitSegment } from './bezier'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+const rnd = (v: number) => Math.round(v * 100) / 100
+
+/** A curve is a path shape that carries actual bezier commands. */
+export function isCurve(el: { type: string; shape?: string; d?: string }): boolean {
+  return el.type === 'shape' && el.shape === 'path' && /[csq]/i.test(el.d ?? '')
+}
+
+export class BezierEditor {
+  private overlay: SVGSVGElement | null = null
+  private elId = ''
+  private nodes: BezNode[] = [] // slide coords
+  private closed = false
+  private scale = () => 1
+
+  constructor(
+    private scaleHost: HTMLElement,
+    private store: Store,
+  ) {}
+
+  get active() {
+    return !!this.overlay
+  }
+  get elementId() {
+    return this.elId
+  }
+  setScaleGetter(fn: () => number) {
+    this.scale = fn
+  }
+
+  attach(elId: string) {
+    const el = this.store.element(elId) as ShapeElement | undefined
+    if (!el || !isCurve(el)) return this.detach()
+    this.elId = elId
+    const { nodes, closed } = parseBezier(el.d ?? '')
+    this.closed = closed
+    const map = this.toSlideFn(el)
+    this.nodes = nodes.map((n) => this.mark({ p: map(n.p), in: n.in && map(n.in), out: n.out && map(n.out) }))
+    if (!this.overlay) {
+      const svg = document.createElementNS(SVG_NS, 'svg')
+      svg.classList.add('ed-bezedit')
+      const { width, height } = this.store.doc.size
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+      svg.style.cssText = `position:absolute;left:0;top:0;width:${width}px;height:${height}px;overflow:visible;z-index:49;pointer-events:none`
+      svg.addEventListener('dblclick', (ev) => this.onDblClick(ev))
+      this.scaleHost.appendChild(svg)
+      this.overlay = svg
+    }
+    this.draw()
+  }
+
+  detach() {
+    this.overlay?.remove()
+    this.overlay = null
+    this.elId = ''
+  }
+
+  // --- coordinate mapping (path-local ⇄ slide) --------------------------------
+
+  private toSlideFn(el: ShapeElement): (p: Pt) => Pt {
+    const [px, py, pw, ph] = el.pathBox ?? [0, 0, el.w || 1, el.h || 1]
+    const sx = el.w / (pw || 1)
+    const sy = el.h / (ph || 1)
+    return (p) => ({ x: el.x + (p.x - px) * sx, y: el.y + (p.y - py) * sy })
+  }
+
+  /** Mark a node corner if its two handles aren't (roughly) collinear. */
+  private mark(n: BezNode): BezNode {
+    if (n.in && n.out) {
+      const a = Math.atan2(n.p.y - n.in.y, n.p.x - n.in.x)
+      const b = Math.atan2(n.out.y - n.p.y, n.out.x - n.p.x)
+      let d = Math.abs(a - b)
+      if (d > Math.PI) d = 2 * Math.PI - d
+      n.corner = d > 0.14 // ~8°
+    }
+    return n
+  }
+
+  // --- rendering --------------------------------------------------------------
+
+  private draw() {
+    const svg = this.overlay
+    if (!svg) return
+    svg.innerHTML = ''
+    const k = 1 / this.scale()
+    const mk = (tag: string) => document.createElementNS(SVG_NS, tag)
+    const d = serializeBezier(this.nodes, this.closed)
+
+    // fat invisible hit line — drag the whole shape / double-click to insert
+    const hit = mk('path')
+    hit.setAttribute('d', d)
+    hit.setAttribute('fill', 'none')
+    hit.setAttribute('stroke', 'transparent')
+    hit.setAttribute('stroke-width', String(16 * k))
+    hit.classList.add('ed-bz-body')
+    hit.style.cssText = 'cursor:move;pointer-events:stroke'
+    hit.addEventListener('mousedown', (ev) => this.dragBody(ev))
+    svg.appendChild(hit)
+
+    // visible guide
+    const guide = mk('path')
+    guide.setAttribute('d', d)
+    guide.setAttribute('fill', 'none')
+    guide.setAttribute('stroke', '#5b8def')
+    guide.setAttribute('stroke-width', String(1.5 * k))
+    guide.style.pointerEvents = 'none'
+    svg.appendChild(guide)
+
+    // handles (drawn under anchors)
+    this.nodes.forEach((n, i) => {
+      for (const which of ['in', 'out'] as const) {
+        const h = n[which]
+        if (!h) continue
+        const stem = mk('line')
+        stem.setAttribute('x1', String(n.p.x))
+        stem.setAttribute('y1', String(n.p.y))
+        stem.setAttribute('x2', String(h.x))
+        stem.setAttribute('y2', String(h.y))
+        stem.setAttribute('stroke', '#8aa9e6')
+        stem.setAttribute('stroke-width', String(1 * k))
+        stem.style.pointerEvents = 'none'
+        svg.appendChild(stem)
+        const hd = mk('circle')
+        hd.setAttribute('cx', String(h.x))
+        hd.setAttribute('cy', String(h.y))
+        hd.setAttribute('r', String(4.5 * k))
+        hd.setAttribute('fill', '#5b8def')
+        hd.setAttribute('stroke', '#fff')
+        hd.setAttribute('stroke-width', String(1.5 * k))
+        hd.style.cssText = 'cursor:crosshair;pointer-events:all'
+        hd.addEventListener('mousedown', (ev) => this.dragHandle(ev, i, which))
+        svg.appendChild(hd)
+      }
+    })
+
+    // anchors (on top)
+    this.nodes.forEach((n, i) => {
+      const dot = mk(n.corner ? 'rect' : 'circle')
+      const rad = 6 * k
+      if (n.corner) {
+        dot.setAttribute('x', String(n.p.x - rad))
+        dot.setAttribute('y', String(n.p.y - rad))
+        dot.setAttribute('width', String(rad * 2))
+        dot.setAttribute('height', String(rad * 2))
+      } else {
+        dot.setAttribute('cx', String(n.p.x))
+        dot.setAttribute('cy', String(n.p.y))
+        dot.setAttribute('r', String(rad))
+      }
+      dot.setAttribute('fill', '#fff')
+      dot.setAttribute('stroke', '#2f6df6')
+      dot.setAttribute('stroke-width', String(2 * k))
+      dot.classList.add('ed-bz-anchor')
+      dot.dataset.idx = String(i)
+      dot.style.cssText = 'cursor:grab;pointer-events:all'
+      dot.addEventListener('mousedown', (ev) => this.dragAnchor(ev, i))
+      svg.appendChild(dot)
+    })
+  }
+
+  // --- interaction ------------------------------------------------------------
+
+  private toSlide(ev: MouseEvent): Pt {
+    const rect = this.scaleHost.getBoundingClientRect()
+    const s = this.scale()
+    return { x: (ev.clientX - rect.left) / s, y: (ev.clientY - rect.top) / s }
+  }
+  private elNode(): HTMLElement | null {
+    return this.scaleHost.querySelector<HTMLElement>(`[data-el-id="${CSS.escape(this.elId)}"]`)
+  }
+
+  private dragAnchor(down: MouseEvent, idx: number) {
+    down.stopPropagation()
+    down.preventDefault()
+    // Alt-click (no drag) toggles corner/smooth
+    const start = this.toSlide(down)
+    const n = this.nodes[idx]
+    const orig = { p: { ...n.p }, in: n.in && { ...n.in }, out: n.out && { ...n.out } }
+    const node = this.elNode()
+    if (node) node.style.opacity = '0.4'
+    let moved = false
+    const move = (ev: MouseEvent) => {
+      const p = this.toSlide(ev)
+      const dx = p.x - start.x
+      const dy = p.y - start.y
+      if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) moved = true
+      n.p = { x: orig.p.x + dx, y: orig.p.y + dy }
+      if (orig.in) n.in = { x: orig.in.x + dx, y: orig.in.y + dy }
+      if (orig.out) n.out = { x: orig.out.x + dx, y: orig.out.y + dy }
+      this.draw()
+    }
+    const up = (ev: MouseEvent) => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+      if (node) node.style.opacity = ''
+      if (!moved && ev.altKey) {
+        n.corner = !n.corner
+        this.draw()
+      }
+      this.commit(moved || (!moved && ev.altKey))
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  private dragHandle(down: MouseEvent, idx: number, which: 'in' | 'out') {
+    down.stopPropagation()
+    down.preventDefault()
+    const n = this.nodes[idx]
+    const other = which === 'in' ? 'out' : 'in'
+    const oppLen = handleLen(n.p, n[other])
+    const node = this.elNode()
+    if (node) node.style.opacity = '0.4'
+    const move = (ev: MouseEvent) => {
+      const p = this.toSlide(ev)
+      n[which] = p
+      if (ev.altKey) n.corner = true // Alt breaks smooth symmetry into a corner
+      // smooth node: mirror the opposite handle's direction, keep its length
+      if (!n.corner && n[other]) n[other] = mirrorHandle(n.p, p, oppLen)
+      this.draw()
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+      if (node) node.style.opacity = ''
+      this.commit(true)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  private dragBody(down: MouseEvent) {
+    down.stopPropagation()
+    down.preventDefault()
+    const start = this.toSlide(down)
+    const orig = this.nodes.map((n) => ({ p: { ...n.p }, in: n.in && { ...n.in }, out: n.out && { ...n.out }, corner: n.corner }))
+    const node = this.elNode()
+    if (node) node.style.opacity = '0.4'
+    let moved = false
+    const move = (ev: MouseEvent) => {
+      const p = this.toSlide(ev)
+      const dx = p.x - start.x
+      const dy = p.y - start.y
+      moved = true
+      this.nodes = orig.map((o) => ({
+        p: { x: o.p.x + dx, y: o.p.y + dy },
+        in: o.in && { x: o.in.x + dx, y: o.in.y + dy },
+        out: o.out && { x: o.out.x + dx, y: o.out.y + dy },
+        corner: o.corner,
+      }))
+      this.draw()
+    }
+    const up = () => {
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+      if (node) node.style.opacity = ''
+      if (moved) this.commit(true)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
+
+  private onDblClick(ev: MouseEvent) {
+    ev.preventDefault()
+    ev.stopPropagation()
+    const target = ev.target as Element
+    if (target.classList.contains('ed-bz-anchor')) {
+      const idx = Number((target as SVGElement).dataset.idx)
+      if (this.nodes.length > 2) {
+        this.nodes.splice(idx, 1)
+        this.commit(true)
+      }
+      return
+    }
+    // insert: find the segment nearest the click, split it at the nearest t
+    const q = this.toSlide(ev)
+    const segs = this.closed ? this.nodes.length : this.nodes.length - 1
+    let best = 0
+    let bestT = 0.5
+    let bestD = Infinity
+    for (let i = 0; i < segs; i++) {
+      const a = this.nodes[i]
+      const b = this.nodes[(i + 1) % this.nodes.length]
+      const c1 = a.out ?? a.p
+      const c2 = b.in ?? b.p
+      const t = nearestT(a.p, c1, c2, b.p, q)
+      const pt = cubicPoint(a.p, c1, c2, b.p, t)
+      const dd = (pt.x - q.x) ** 2 + (pt.y - q.y) ** 2
+      if (dd < bestD) { bestD = dd; best = i; bestT = t }
+    }
+    const a = this.nodes[best]
+    const b = this.nodes[(best + 1) % this.nodes.length]
+    const split = splitSegment(a, b, bestT)
+    this.nodes[best] = split.a
+    this.nodes[(best + 1) % this.nodes.length] = split.b
+    this.nodes.splice(best + 1, 0, split.mid)
+    this.commit(true)
+  }
+
+  /** Write nodes back to the model: bbox of anchor POINTS → element box +
+   *  pathBox, handles stored relative (may fall outside the box, which is fine).
+   *  Dragging an endpoint detaches that end of a connector. */
+  private commit(dirty: boolean) {
+    if (!dirty) return
+    const id = this.elId
+    const nodes = this.nodes.map((n) => ({ p: { ...n.p }, in: n.in && { ...n.in }, out: n.out && { ...n.out } }))
+    const closed = this.closed
+    this.store.commit(() => {
+      const el = this.store.element(id) as ShapeElement | undefined
+      if (!el || nodes.length < 2) return
+      // Element box = the TRUE geometric bounds of the curve (getBBox includes
+      // the control-point bulge), not just the anchor points — so selection and
+      // pathBox fit the visible shape. pathBox size == box size ⇒ 1:1 render.
+      const bb = curveBBox(serializeBezier(nodes, closed))
+      const minX = bb.x
+      const minY = bb.y
+      const w = Math.max(bb.width, 1)
+      const h = Math.max(bb.height, 1)
+      const loc = (p: Pt) => ({ x: rnd(p.x - minX), y: rnd(p.y - minY) })
+      const local = nodes.map((n) => ({ p: loc(n.p), in: n.in && loc(n.in), out: n.out && loc(n.out) }))
+      el.x = rnd(minX)
+      el.y = rnd(minY)
+      el.w = rnd(w)
+      el.h = rnd(h)
+      el.pathBox = [0, 0, rnd(w), rnd(h)]
+      el.d = serializeBezier(local, closed)
+    })
+    // re-read (bbox may have shifted) so handles track the new element frame
+    this.attach(id)
+  }
+}
+
+/** Geometric bbox of a path (includes curve bulge, via SVG getBBox). */
+function curveBBox(d: string): { x: number; y: number; width: number; height: number } {
+  const svg = document.createElementNS(SVG_NS, 'svg')
+  svg.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden'
+  const path = document.createElementNS(SVG_NS, 'path')
+  path.setAttribute('d', d)
+  svg.appendChild(path)
+  document.body.appendChild(svg)
+  try {
+    return path.getBBox()
+  } finally {
+    svg.remove()
+  }
+}
+
+function cubicPoint(p0: Pt, c1: Pt, c2: Pt, p3: Pt, t: number): Pt {
+  const u = 1 - t
+  return {
+    x: u * u * u * p0.x + 3 * u * u * t * c1.x + 3 * u * t * t * c2.x + t * t * t * p3.x,
+    y: u * u * u * p0.y + 3 * u * u * t * c1.y + 3 * u * t * t * c2.y + t * t * t * p3.y,
+  }
+}

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -13,6 +13,7 @@ import { renderSlide, sanitizeHtml } from '../render'
 import { autoformatAtCaret, clearAutoformat, markdownToHtml, undoAutoformat } from './markdown'
 import { PathEditor } from './patheditor'
 import { LineEditor, isLineLike, setLineEndpoints, setPathAnchors } from './lineedit'
+import { BezierEditor, isCurve } from './beziereditor'
 import { simplifyPoints } from './patheditor'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
@@ -37,6 +38,7 @@ export class SlideCanvas {
   private editingCell: { r: number; c: number } | null = null
   private pathEditor!: PathEditor
   private lineEditor!: LineEditor
+  private bezierEditor!: BezierEditor
   private drawOverlay: HTMLElement | null = null
   private comments!: CommentsUI
 
@@ -146,6 +148,8 @@ export class SlideCanvas {
     this.pathEditor.setScaleGetter(() => this.scale)
     this.lineEditor = new LineEditor(this.scaleHost, store)
     this.lineEditor.setScaleGetter(() => this.scale)
+    this.bezierEditor = new BezierEditor(this.scaleHost, store)
+    this.bezierEditor.setScaleGetter(() => this.scale)
     document.addEventListener('bento:edit-path', ((ev: CustomEvent) => {
       this.startPathEdit(ev.detail.id)
     }) as EventListener)
@@ -157,7 +161,7 @@ export class SlideCanvas {
     // Capture phase so it wins over Selecto AND Moveable's control-box area,
     // which otherwise swallows clicks over the current selection.
     document.addEventListener('mousedown', (ev) => {
-      if (!ev.altKey || ev.button !== 0 || this.pathEditor.active) return
+      if (!ev.altKey || ev.button !== 0 || this.pathEditor.active || this.bezierEditor.active) return
       // Alt on a resize/rotate handle means center-scale, not deep-select
       if (ev.target instanceof Element && ev.target.closest('.moveable-control-box')) return
       const r = this.scaleHost.getBoundingClientRect()
@@ -551,10 +555,16 @@ export class SlideCanvas {
     // A single selected line/curve/connector is edited with endpoint handles
     // (LineEditor), not Moveable's box — grab an end and drag it.
     const sel = this.store.selectedElements
-    const lineLike = sel.length === 1 && isLineLike(sel[0]) && !this.editing && !this.pathEditor.active
-    if (lineLike) this.lineEditor.attach(sel[0].id)
-    else this.lineEditor.detach()
-    const targets = this.editing || this.pathEditor?.active || lineLike ? [] : this.selectedNodes()
+    const one = sel.length === 1 && !this.editing && !this.pathEditor.active ? sel[0] : null
+    // Curves get true bezier handles (BezierEditor); lines and straight polygons
+    // keep endpoint/anchor handles (LineEditor).
+    const curve = !!one && isCurve(one)
+    const lineLike = !!one && !curve && isLineLike(one)
+    if (curve) { this.bezierEditor.attach(one!.id); this.lineEditor.detach() }
+    else if (lineLike) { this.lineEditor.attach(one!.id); this.bezierEditor.detach() }
+    else { this.lineEditor.detach(); this.bezierEditor.detach() }
+    const handled = curve || lineLike
+    const targets = this.editing || this.pathEditor?.active || handled ? [] : this.selectedNodes()
     // snap against slide bounds/center and every non-selected element
     const others = this.surface
       ? [this.surface, ...Array.from(this.surface.querySelectorAll<HTMLElement>('.bento-el'))].filter(


### PR DESCRIPTION
## True bezier curve editing with control handles

Replaces the old Catmull-Rom curve editing (which sampled the *rendered* curve back into approximate anchors and re-smoothed on every edit — lossy, drifting, no real handles) with an exact cubic-bezier pen-tool model.

### What changed
- **`src/editor/bezier.ts`** (new) — pure exact-cubic path core: `parseBezier` / `serializeBezier` (M/L/C + Z), `cubicAt`, `nearestT`, `splitSegment` (de Casteljau), `mirrorHandle`. Round-trips a path byte-for-byte.
- **`src/editor/beziereditor.ts`** (new) — `BezierEditor`: selecting a curve shows real in/out control handles on each anchor. Drag a handle to bend the curve exactly; smooth anchors mirror the opposite handle, **Alt** breaks a corner. Double-click a segment to insert an anchor (shape-preserving split), double-click an anchor to remove it. Element box recomputed via `getBBox` so a bulging curve still selects correctly.
- **`src/editor/canvas.ts`** — route a selected curve to `BezierEditor`; lines / straight polygons stay on the existing `LineEditor`.

### Verification
- Round-trip parse→serialize byte-identical; max geometric error 0px.
- Insert-by-split preserves the trajectory to 0.0001px.
- `tsc` clean; `build:single` clean.

On-canvas drag interaction needs real-mouse QA (synthetic events don't drive Selecto/Moveable in automation).
