### PR TITLE
Fix: dash-march animation loops seamlessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ below opens files from every earlier version, and unknown fields are preserved.
 This project's versions roughly follow semantic-ish `0.MINOR.PATCH` while it is
 pre-1.0.
 
+## [Unreleased]
+
+- **Fix: dash-march loop was janky / looked incomplete.** The marching-ants
+  animation moved `strokeDashoffset` by a fixed distance that wasn't a whole
+  multiple of the stroke's dash+gap period, so the pattern snapped back
+  mid-cycle on every repeat. The offset travel now snaps to a whole number of
+  dash periods, making the loop seamless.
+
 ## [1.0.6] — 2026-07-21
 
 - **Fix: topbar menus were icon-only on narrow screens.** The responsive rule

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -751,11 +751,24 @@ function runAmbientFx(slide: Slide, section: HTMLElement) {
       }
     }
     if (fx.loop?.type === 'dash-march') {
-      const target = node.querySelector('path, line, rect, ellipse, polygon')
+      const target = node.querySelector('path, line, rect, ellipse, polygon') as SVGElement | null
       if (target) {
+        // Seamless marching ants: the offset must travel a WHOLE number of
+        // dash+gap periods, or the pattern snaps back mid-cycle each loop and
+        // reads as an incomplete/janky loop. Snap the requested distance to
+        // the nearest whole multiple of the element's dasharray period.
+        const da = target.getAttribute('stroke-dasharray') || getComputedStyle(target).strokeDasharray || ''
+        const parts = da.split(/[\s,]+/).map(parseFloat).filter((n) => n > 0)
+        const period = parts.reduce((a, b) => a + b, 0)
+        let travel = fx.loop.distance ?? 18
+        if (period > 0) {
+          // SVG doubles an odd-count dasharray, so one visual period is 2× then.
+          const unit = parts.length % 2 ? period * 2 : period
+          travel = Math.max(1, Math.round(travel / unit)) * unit
+        }
         anim.fromTo(
           target,
-          { strokeDashoffset: fx.loop.distance ?? 18 },
+          { strokeDashoffset: travel },
           { strokeDashoffset: 0, duration: fx.loop.duration ?? 1.4, ease: 'none', repeat: -1 },
         )
       }


### PR DESCRIPTION
## Fix: dash-march animation loops seamlessly

The marching-dashes loop (`fx.loop` dash-march) looked smooth for a few seconds then visibly hitched — an incomplete loop. The `strokeDashoffset` travel wasn't a whole multiple of the dash pattern period, so each repeat jumped.

### Fix
Snap the offset travel to a whole multiple of the dasharray period (`travel = round(distance / unit) * unit`, where `unit` = the pattern period, or 2× for odd-count dasharrays). The dashes now line up exactly across the loop boundary.

### Verification
- e.g. travel 20 → 24 = 2× period-12. `tsc` clean.
- Independent of the bezier branches — targets `main` directly.
