### PR TITLE
Editable morph id: decouple the morph key from element id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Editable morph id.** Elements now carry an optional `morphId` that
+  overrides which element they morph into across slides, so two
+  independently-created elements can be paired without the duplicate-a-slide
+  dance. The element panel gains a **Morph** section: a "Morph id" field (set it
+  back to the element's own id to clear the override) and a "Pair with" picker
+  that adopts another slide element's key. `id` stays the stable identity —
+  selection, connectors, comments and live-collab node identity are untouched —
+  and the default morph (elements sharing an `id`) is unchanged, so existing
+  decks behave identically. Same-slide key collisions are rejected inline.
+
 - **True bezier curve editing.** Selecting a curve now shows real pen-tool
   control handles (in/out tangents) on each anchor — drag a handle to bend the
   curve exactly. Smooth anchors mirror the opposite handle; Alt breaks a corner.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,17 @@ One HTML file = the document + viewer + editor. See `README.md` for the vision.
   cross-reload-recover, by design.
 - `src/render.ts` — single model→DOM renderer shared by editor canvas, thumbnails, and
   Reveal sections. Elements carry `data-el-id` (editing) and `data-flip-id` (morph).
+  **Morph key (v1.0.7)**: `data-flip-id = el.morphId || el.id`. `id` stays the
+  stable identity (selection, connector/comment anchors, CRDT node key); the
+  DEFAULT morph key is still `id` (the duplicate-a-slide idiom, old files have no
+  `morphId`), but an optional `morphId` re-targets the pairing WITHOUT mutating
+  `id` — so two independently-created elements on different slides can morph. This
+  one line is the whole engine change; everything downstream reads `data-flip-id`.
+  Edited in the panel's Morph section (`panels.ts buildMorphProps`): a "Morph id"
+  field (writing the element's own id clears the override) + a "Pair with" picker
+  that adopts another slide element's key; both reject a key that would collide
+  with another element's effective key on the SAME slide (present.ts maps by flip
+  id, so same-slide dupes would break pairing).
   **Dynamic fields (v0.9.12, doc-props v1.0.2)**: text resolves `{{page}}`,
   `{{pages}}`, `{{title}}`, `{{date}}`, `{{time}}` plus the document-property
   tokens `{{author}}`, `{{company}}`, `{{subject}}`, `{{event}}` at render time

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -423,11 +423,111 @@ export class PropsPanel {
     this.arrangeRows([el])
 
     this.buildPresentingProps(el)
+    this.buildMorphProps(el)
+  }
 
-    const morph = document.createElement('p')
-    morph.className = 'ed-hint'
-    morph.innerHTML = `${t('Morph id:')} <code>${el.id}</code>`
-    this.host.appendChild(morph)
+  /**
+   * Morph section. The morph key is `morphId ?? id`: by default an element
+   * morphs with same-id elements on adjacent slides (the duplicate-a-slide
+   * idiom), but setting a `morphId` re-targets the pairing WITHOUT mutating
+   * `id` (which stays the stable identity used by selection, connectors,
+   * comments and the CRDT). The text field edits the key directly; the picker
+   * adopts another slide element's key. Writing the element's own id clears
+   * the override.
+   */
+  private buildMorphProps(el: SlideElement) {
+    this.section(t('Morph'))
+    const effective = el.morphId || el.id
+
+    const warn = document.createElement('p')
+    warn.className = 'ed-hint ed-morph-warn'
+    warn.style.display = 'none'
+
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.value = effective
+    input.spellcheck = false
+    input.addEventListener('change', () => {
+      const err = this.setMorphId(el, input.value)
+      if (err) { warn.textContent = err; warn.style.display = ''; input.value = effective }
+    })
+    this.row('Morph id', input)
+
+    const targets = this.morphTargets(el)
+    if (targets.length) {
+      const sel = document.createElement('select')
+      const none = document.createElement('option')
+      none.value = ''
+      none.textContent = t('(pick an element)')
+      sel.appendChild(none)
+      for (const tgt of targets) {
+        const o = document.createElement('option')
+        o.value = tgt.key
+        o.textContent = tgt.label
+        if (tgt.key === effective) o.selected = true
+        sel.appendChild(o)
+      }
+      sel.addEventListener('change', () => {
+        if (!sel.value) return
+        const err = this.setMorphId(el, sel.value)
+        if (err) { warn.textContent = err; warn.style.display = '' }
+      })
+      this.row('Pair with', sel)
+    }
+
+    this.host.appendChild(warn)
+
+    const hint = document.createElement('p')
+    hint.className = 'ed-hint'
+    hint.innerHTML = el.morphId
+      ? t('Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.', { id: effective, own: el.id })
+      : t('Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.')
+    this.host.appendChild(hint)
+  }
+
+  /** Set or clear an element's morph-key override. Writing the element's own
+   *  id clears it. Returns an inline error message, or null on success. */
+  private setMorphId(el: SlideElement, raw: string): string | null {
+    const clean = raw.trim().replace(/[^A-Za-z0-9._-]/g, '')
+    if (!clean) return t('Morph id can’t be empty.')
+    const next = clean === el.id ? undefined : clean
+    const effective = next ?? el.id
+    const clash = this.store.slide.elements.some(
+      (e) => e.id !== el.id && (e.morphId || e.id) === effective)
+    if (clash) return t('Another element on this slide already uses that morph id.')
+    this.mutate(el.id, (e) => {
+      if (next === undefined) delete e.morphId
+      else e.morphId = next
+    }, true)
+    return null
+  }
+
+  /** Distinct morph keys present on OTHER slides, each with a readable label,
+   *  for the "Pair with" picker. Skips keys that already sit on this slide
+   *  (they'd collide) and our own default key. */
+  private morphTargets(el: SlideElement): Array<{ key: string; label: string }> {
+    const here = new Set(
+      this.store.slide.elements.filter((e) => e.id !== el.id).map((e) => e.morphId || e.id))
+    const seen = new Map<string, string>()
+    this.store.doc.slides.forEach((s, i) => {
+      if (s.id === this.store.slide.id) return
+      for (const e of s.elements) {
+        const key = e.morphId || e.id
+        if (key === el.id || here.has(key) || seen.has(key)) continue
+        seen.set(key, `${t('Slide')} ${i + 1} · ${this.morphElDesc(e)}`)
+      }
+    })
+    return [...seen].map(([key, label]) => ({ key, label }))
+  }
+
+  /** Short human label for an element in the morph picker. */
+  private morphElDesc(e: SlideElement): string {
+    if (e.type === 'text') {
+      const txt = (e as TextElement).html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+      if (txt) return `"${txt.slice(0, 24)}"`
+    }
+    // Capitalize to hit the existing insert-menu catalog keys (Text/Image/…).
+    return t(e.type.charAt(0).toUpperCase() + e.type.slice(1))
   }
 
   /** fx + link — how the element behaves while presenting. */

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Morph": "Morph",
+  "Morph id": "Morph-ID",
+  "Pair with": "Verknüpfen mit",
+  "(pick an element)": "(Element wählen)",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "Morpht als <code>{id}</code> und überschreibt die eigene ID. Auf <code>{own}</code> zurücksetzen zum Entfernen.",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "Elemente mit gleicher Morph-ID morphen folienübergreifend ineinander. Ändere dies (oder wähle unten), um mit einem Element auf einer anderen Folie zu paaren.",
+  "Morph id can’t be empty.": "Die Morph-ID darf nicht leer sein.",
+  "Another element on this slide already uses that morph id.": "Ein anderes Element auf dieser Folie verwendet diese Morph-ID bereits.",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> animiert Elemente, die auf dieser und der vorherigen Folie vorkommen (Folie duplizieren, dann Dinge verschieben).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Ein <b>Zustand</b> liegt außerhalb des Pfeiltasten-Flusses — erreichbar per Klick auf ein verlinktes Element. Gemeinsame IDs morphen zwischen Zuständen.",
   "A deck needs at least one slide": "Eine Präsentation braucht mindestens eine Folie",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Morph": "Morph",
+  "Morph id": "Id de morph",
+  "Pair with": "Emparejar con",
+  "(pick an element)": "(elige un elemento)",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "Se transforma como <code>{id}</code>, anulando su propio id. Vuelve a ponerlo en <code>{own}</code> para quitarlo.",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "Los elementos que comparten un id de morph se transforman entre sí a través de las diapositivas. Cambia esto (o elige abajo) para emparejarlo con un elemento de otra diapositiva.",
+  "Morph id can’t be empty.": "El id de morph no puede estar vacío.",
+  "Another element on this slide already uses that morph id.": "Otro elemento de esta diapositiva ya usa ese id de morph.",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anima los elementos presentes en esta diapositiva y en la anterior (duplica una diapositiva y mueve cosas).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Un <b>estado</b> queda fuera del flujo de flechas — se llega haciendo clic en un elemento enlazado. Los ids compartidos se transforman entre estados.",
   "A deck needs at least one slide": "Una presentación necesita al menos una diapositiva",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Morph": "Morph",
+  "Morph id": "Id de morph",
+  "Pair with": "Associer à",
+  "(pick an element)": "(choisir un élément)",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "Se transforme en tant que <code>{id}</code>, remplaçant son propre id. Remettez-le à <code>{own}</code> pour l’annuler.",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "Les éléments partageant un id de morph se transforment entre eux d’une diapositive à l’autre. Modifiez ceci (ou choisissez ci-dessous) pour l’associer à un élément d’une autre diapositive.",
+  "Morph id can’t be empty.": "L’id de morph ne peut pas être vide.",
+  "Another element on this slide already uses that morph id.": "Un autre élément de cette diapositive utilise déjà cet id de morph.",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anime les éléments présents sur cette diapositive et la précédente (dupliquez une diapositive puis déplacez des éléments).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Un <b>état</b> est hors du flux des flèches — on l'atteint en cliquant un élément lié. Les ids partagés se transforment entre états.",
   "A deck needs at least one slide": "Une présentation doit contenir au moins une diapositive",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Morph": "Morph",
+  "Morph id": "Id morph",
+  "Pair with": "Abbina a",
+  "(pick an element)": "(scegli un elemento)",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "Si trasforma come <code>{id}</code>, sovrascrivendo il proprio id. Riportalo a <code>{own}</code> per rimuoverlo.",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "Gli elementi che condividono un id morph si trasformano tra loro tra le diapositive. Cambia questo (o scegli sotto) per abbinarlo a un elemento di un’altra diapositiva.",
+  "Morph id can’t be empty.": "L’id morph non può essere vuoto.",
+  "Another element on this slide already uses that morph id.": "Un altro elemento di questa diapositiva usa già quell’id morph.",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anima gli elementi presenti sia in questa diapositiva sia nella precedente (duplica una diapositiva e sposta gli elementi).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Uno <b>stato</b> è escluso dal flusso delle frecce — vi si arriva facendo clic su un elemento collegato. Gli id condivisi si trasformano tra stati.",
   "A deck needs at least one slide": "Una presentazione richiede almeno una diapositiva",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Morph": "モーフ",
+  "Morph id": "モーフ id",
+  "Pair with": "ペア設定",
+  "(pick an element)": "（要素を選択）",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "<code>{id}</code> としてモーフし、自身の id を上書きします。<code>{own}</code> に戻すと解除されます。",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "同じモーフ id を持つ要素はスライド間で相互にモーフします。これを変更（または下で選択）して、別のスライドの要素とペアにできます。",
+  "Morph id can’t be empty.": "モーフ id は空にできません。",
+  "Another element on this slide already uses that morph id.": "このスライドの別の要素がすでにそのモーフ id を使用しています。",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>モーフ</b>は、このスライドと前のスライドの両方にある要素をアニメーションします（スライドを複製してから配置を変えてみてください）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>ステート</b>は矢印キーの流れに現れません — リンクされた要素のクリックで到達します。共有 id の要素はステート間でモーフします。",
   "A deck needs at least one slide": "デッキには最低1枚のスライドが必要です",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Morph": "变形",
+  "Morph id": "变形 id",
+  "Pair with": "配对",
+  "(pick an element)": "（选择一个元素）",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "以 <code>{id}</code> 变形，覆盖其自身 id。设回 <code>{own}</code> 即可清除。",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "共享同一变形 id 的元素会在幻灯片之间相互变形。更改此项（或在下方选择）以与其他幻灯片上的元素配对。",
+  "Morph id can’t be empty.": "变形 id 不能为空。",
+  "Another element on this slide already uses that morph id.": "此幻灯片上的另一个元素已在使用该变形 id。",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>变形</b>会为同时出现在此幻灯片和上一张中的元素做动画（复制一张幻灯片，然后移动内容试试）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>状态</b>不出现在方向键流程中 — 观众通过点击链接元素到达。共享 id 的元素会在状态间变形。",
   "A deck needs at least one slide": "演示文稿至少需要一张幻灯片",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,14 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Morph": "變形",
+  "Morph id": "變形 id",
+  "Pair with": "配對",
+  "(pick an element)": "（選擇一個元素）",
+  "Morphs as <code>{id}</code>, overriding its own id. Set it back to <code>{own}</code> to clear.": "以 <code>{id}</code> 變形，覆蓋其自身 id。設回 <code>{own}</code> 即可清除。",
+  "Elements sharing a morph id morph into each other across slides. Change this (or pick below) to pair with an element on another slide.": "共享同一變形 id 的元素會在投影片之間相互變形。變更此項（或在下方選擇）以與其他投影片上的元素配對。",
+  "Morph id can’t be empty.": "變形 id 不能為空。",
+  "Another element on this slide already uses that morph id.": "此投影片上的另一個元素已在使用該變形 id。",
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>變形</b>會為同時出現在此投影片與上一張的元素製作動畫（複製一張投影片，然後移動內容試試）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>狀態</b>不會出現在方向鍵流程中 — 觀眾透過點按連結元素到達。共享 id 的元素會在狀態間變形。",
   "A deck needs at least one slide": "簡報至少需要一張投影片",

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -9,8 +9,18 @@ export const FORMAT_VERSION = 1
 export type TransitionKind = 'none' | 'fade' | 'slide' | 'zoom' | 'morph'
 
 export interface ElementBase {
-  /** Stable id. Elements sharing an id across adjacent slides morph into each other. */
+  /** Stable per-slide identity: `data-el-id`, selection, connector/comment
+   *  anchors, and the CRDT node key. Also the DEFAULT morph key — elements
+   *  sharing an id across adjacent slides morph into each other (the
+   *  duplicate-a-slide idiom). Never mutate it to re-pair a morph; set
+   *  `morphId` instead so identity stays stable. */
   id: string
+  /** Optional morph-key override. When set, this element morphs with elements
+   *  whose effective morph key (`morphId ?? id`) matches — letting two
+   *  independently-created elements on different slides be paired without
+   *  touching either's `id`. Omitted = fall back to `id` (the common case).
+   *  Must not collide with another element's effective key on the SAME slide. */
+  morphId?: string
   x: number
   y: number
   w: number

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -387,13 +387,15 @@ export function renderTableHtml(el: TableElement, doc: BentoDoc): string {
 
 /**
  * Render one element. The wrapper carries data-el-id (edit-time selection)
- * and data-flip-id (GSAP Flip morph matching across slides).
+ * and data-flip-id (morph matching across slides). The flip id is the
+ * element's `morphId` when set, else its `id` — so morph pairing can be
+ * re-targeted without disturbing the stable identity used everywhere else.
  */
 export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts = {}): HTMLElement {
   const node = document.createElement('div')
   node.className = `bento-el bento-el-${el.type}`
   node.dataset.elId = el.id
-  node.dataset.flipId = el.id
+  node.dataset.flipId = el.morphId || el.id
   if (el.link) node.dataset.link = el.link
   if (el.group) node.dataset.group = el.group
   if (el.showOnHover) node.dataset.showOnHover = el.showOnHover

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -438,6 +438,7 @@ option { background: #fff; color: #1e2a3a; }
   padding: 8px 10px;
 }
 .ed-hint code { font-size: 10.5px; word-break: break-all; }
+.ed-morph-warn { color: #C0392B; background: rgba(192, 57, 43, 0.08); }
 
 .ed-btn-update {
   background: #FF9E8A !important;


### PR DESCRIPTION
Adds an optional `morphId` so two independently-created elements can be paired to morph across slides without mutating `id` (which stays the stable identity used by selection, connectors, comments and the CRDT). `data-flip-id = morphId || id` — one line in render.ts; everything downstream reads it. Default id-based morph is unchanged; old decks behave identically.

Editor: element panel gains a **Morph** section — a "Morph id" field (writing the element's own id clears the override) and a "Pair with" picker that adopts another slide element's key. Same-slide key collisions are rejected inline. Strings added to all 7 catalogs.

Verified in-browser: section renders, setting morphId updates model + live data-flip-id, collisions rejected, clearing falls back, picker works, default sd-tile morph across all 16 starter slides unbroken. build:single passes.