### PR TITLE
Present: fill large displays in fullscreen (lift Reveal maxScale cap)

### DIFF
--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -123,6 +123,13 @@ export function startPresentation(
     width: doc.size.width,
     height: doc.size.height,
     margin: 0,
+    // Reveal's default maxScale is 2.0 — on a 1280-wide deck that caps the show
+    // at 2560px and letterboxes it in the middle of large displays (a 4K/5K/8K
+    // screen shows a small centred slide). Bento content is vector/text, so it
+    // upscales crisply: allow it to fill any display. minScale stays generous
+    // for tiny embeds.
+    minScale: 0.1,
+    maxScale: 100,
     center: false,
     hash: false,
     history: false,


### PR DESCRIPTION
Reveal's default `maxScale` is 2.0, so a 1280-wide deck was capped at 2560px and letterboxed in the middle of high-res displays — a 4K/5K/8K screen showed a small centred slide. Bento content is vector/text and upscales crisply, so raise maxScale (and lower minScale for tiny embeds) to fill any display.

Verified: at 3840×2160 the slide scales 3.0× and fills; at 7680×4320 it scales 6.0× and fills the whole screen (was capped at 2560×1440).