### PR TITLE
Update: keep the file handle after an in-place update picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **In-place update keeps its handle.** When a deck opened *without* a File
+  System Access handle (e.g. double-clicked from disk) is updated via "Update
+  this file…", Bento now keeps the handle the save-picker grants — so this and
+  every later update rewrite the file in place silently, instead of re-prompting
+  each time. (A double-clicked file gives the browser no handle on open, so the
+  first update still needs you to overwrite the file you have open in the save
+  dialog; after that it's automatic.)
+
 - **True bezier curve editing.** Selecting a curve now shows real pen-tool
   control handles (in/out tangents) on each anchor — drag a handle to bend the
   curve exactly. Smooth anchors mirror the opposite handle; Alt breaks a corner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ pre-1.0.
   selection, connectors, comments and live-collab node identity are untouched —
   and the default morph (elements sharing an `id`) is unchanged, so existing
   decks behave identically. Same-slide key collisions are rejected inline.
->>>>>>> main
 
 - **True bezier curve editing.** Selecting a curve now shows real pen-tool
   control handles (in/out tangents) on each anchor — drag a handle to bend the

--- a/slides/src/update.ts
+++ b/slides/src/update.ts
@@ -181,10 +181,17 @@ export async function applyUpdate(release: ReleaseInfo, doc: BentoDoc): Promise<
 export const canUpdateInPlace = hasFileHandle
 
 /**
- * Update the file on disk. With a held handle: download a backup of the
- * current version first, then overwrite in place — a reload then boots the
- * new app with this document. Without one: a save picker lets the user point
- * at the file they have open (or anywhere). Returns false if cancelled.
+ * Update the file on disk, then a reload boots the new app with this document.
+ *
+ * With a held handle: download a backup of the current version first, then
+ * overwrite the file in place silently.
+ *
+ * Without a handle (e.g. the file was double-clicked open — the browser grants
+ * no handle on open): use a save picker AND KEEP the resulting handle, so this
+ * update and every later one can rewrite the file in place. The picker can't
+ * default to the open file's location without a handle, so the caller must tell
+ * the user to overwrite the file they have open; once they do, it is a one-time
+ * grant. Returns false if the picker was cancelled.
  */
 export async function applyUpdateInPlace(release: ReleaseInfo, doc: BentoDoc): Promise<boolean> {
   const html = await buildUpdatedFile(release, doc)
@@ -194,5 +201,5 @@ export async function applyUpdateInPlace(release: ReleaseInfo, doc: BentoDoc): P
     await writeUpdatedFile(html)
     return true
   }
-  return writeUpdatedFileAs(html, doc)
+  return writeUpdatedFileAs(html, doc, { keepHandle: true })
 }


### PR DESCRIPTION
A deck opened by double-clicking from disk gives the browser no File System Access handle, so "Update this file…" falls to a save picker. It was calling `writeUpdatedFileAs` without `keepHandle`, so the picked file never became the save target — every later update (and ⌘S) re-prompted, and it was easy to save a stray copy instead of overwriting the open file.

Pass `keepHandle:true` on the update path so the file the user overwrites becomes the in-place target: one grant, then updates rewrite it silently and a reload boots the new version.

(Investigated and dropped a blob/`document.write` "boot in place" approach — Chromium blocks top-level `blob:` navigation, and `location.reload()` already refreshes a rewritten `file://` deck. Confirmed FSA *is* available on `file://` in Chromium.)