### PR TITLE
Guestbook daemon: v2 epoch mints + 15-min launch auto-roll

### DIFF
--- a/scripts/guestbook-archive-pull.mjs
+++ b/scripts/guestbook-archive-pull.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento/Suite authors
+// Pull the daemon's KV archives down to disk so nothing is lost to the 90-cap.
+//
+// The daemon prunes KV `archives/` to the newest 90. At the launch 15-min roll
+// cadence that's only ~11h of history, so signatures older than that would be
+// pruned before anyone saw them. This mirrors every archive into
+// working/guestbook-archives/ (idempotent — skips ones already on disk), so a
+// periodic run (cron every ~30 min) captures the full launch permanently.
+//
+//   node scripts/guestbook-archive-pull.mjs [--base <url>]
+//
+// Auth: Bearer key in working/guestbook-admin-key.txt (gitignored).
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const args = process.argv.slice(2)
+const opt = (n, fb) => { const i = args.indexOf(`--${n}`); return i >= 0 && args[i + 1] ? args[i + 1] : fb }
+const base = opt('base', 'https://bento.page').replace(/\/$/, '')
+
+const keyFile = join(root, 'working/guestbook-admin-key.txt')
+if (!existsSync(keyFile)) { console.error('no admin key at working/guestbook-admin-key.txt'); process.exit(1) }
+const adminKey = readFileSync(keyFile, 'utf8').trim()
+const auth = { Authorization: `Bearer ${adminKey}` }
+
+const outDir = join(root, 'working/guestbook-archives')
+mkdirSync(outDir, { recursive: true })
+const onDisk = new Set(readdirSync(outDir))
+
+// 1 · list archives the daemon currently holds
+const statusRes = await fetch(`${base}/guestbook-admin/status`, { headers: auth })
+if (!statusRes.ok) { console.error(`status → ${statusRes.status}: ${(await statusRes.text()).slice(0, 200)}`); process.exit(1) }
+const status = await statusRes.json()
+const keys = status.archives ?? [] // e.g. ["archives/epoch-8-2026-07-22-19-15.bento.html", …]
+
+// 2 · download any we don't already have
+let pulled = 0
+for (const key of keys) {
+  const localName = key.replace(/^archives\//, '')
+  if (onDisk.has(localName)) continue
+  const res = await fetch(`${base}/guestbook-admin/${key}`, { headers: auth })
+  if (!res.ok) { console.warn(`⚠ ${key} → ${res.status} (skipped)`); continue }
+  writeFileSync(join(outDir, localName), Buffer.from(await res.arrayBuffer()))
+  pulled++
+}
+
+const total = readdirSync(outDir).filter((f) => f.endsWith('.bento.html')).length
+console.log(`archive pull: ${pulled} new · ${keys.length} on daemon · ${total} total on disk → working/guestbook-archives/`)

--- a/scripts/guestbook-owner-deck.mjs
+++ b/scripts/guestbook-owner-deck.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento/Suite authors
+// Build an OWNER deck for the CURRENT live guestbook epoch, on demand — open it
+// to moderate (People panel → Remove). The daemon mints epochs server-side and
+// stashes the owner key in KV; this fetches it (admin-gated) and splices it into
+// the live public deck.
+//
+// LAUNCH NOTE: with the daemon auto-rolling every 15 min, an owner deck is valid
+// only until the next roll — after that the room it moderates is orphaned. Just
+// re-run this to get a deck for the new epoch. (At that cadence spam auto-clears
+// anyway, so you rarely need this.)
+//
+//   node scripts/guestbook-owner-deck.mjs [--base <url>] [--out <file>]
+//
+// Auth: Bearer key in working/guestbook-admin-key.txt (gitignored).
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { extractDoc, spliceDoc } from './guestbook-deck.mjs'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const args = process.argv.slice(2)
+const opt = (n, fb) => { const i = args.indexOf(`--${n}`); return i >= 0 && args[i + 1] ? args[i + 1] : fb }
+const base = opt('base', 'https://bento.page').replace(/\/$/, '')
+const out = opt('out', join(root, 'working/guestbook-live/guestbook-owner-live.bento.html'))
+
+const keyFile = join(root, 'working/guestbook-admin-key.txt')
+if (!existsSync(keyFile)) { console.error('no admin key at working/guestbook-admin-key.txt'); process.exit(1) }
+const adminKey = readFileSync(keyFile, 'utf8').trim()
+
+// Owner creds and the public deck are two fetches; if a roll lands between them
+// the rooms won't match — retry a few times.
+async function attempt() {
+  const credRes = await fetch(`${base}/guestbook-admin/owner`, { headers: { Authorization: `Bearer ${adminKey}` } })
+  if (!credRes.ok) throw new Error(`owner creds → ${credRes.status}: ${(await credRes.text()).slice(0, 200)}`)
+  const creds = await credRes.json()
+  const publicHtml = await (await fetch(`${base}/guestbook.bento.html?cb=${Date.now()}`, { cache: 'no-store' })).text()
+  const doc = extractDoc(publicHtml)
+  if (doc.collab?.room !== creds.room) return null // rolled between the two fetches
+  // owner collab: same room + read key, carrying ownerPriv; no public invite
+  doc.collab = { room: creds.room, key: creds.key, on: true, v: 2, owner: creds.owner, ownerPriv: creds.ownerPriv }
+  return { html: spliceDoc(publicHtml, doc), epoch: creds.epoch, room: creds.room }
+}
+
+let built = null
+for (let i = 0; i < 4 && !built; i++) built = await attempt()
+if (!built) { console.error('the epoch kept rolling mid-build — run it again'); process.exit(2) }
+
+mkdirSync(dirname(out), { recursive: true })
+writeFileSync(out, built.html)
+console.log(`✓ owner deck for epoch ${built.epoch} → ${out}`)
+console.log(`  room: …${built.room.slice(-16)}`)
+console.log('  open it in Chrome → People panel → Remove. Valid ONLY until the next 15-min roll.')

--- a/server/guestbook-daemon/src/worker.js
+++ b/server/guestbook-daemon/src/worker.js
@@ -37,6 +37,40 @@ const b64u = {
 const meta = async (env) => JSON.parse((await env.STORE.get(META, 'text')) ?? '{}')
 const putMeta = (env, m) => env.STORE.put(META, JSON.stringify(m, null, 2))
 
+// ——— v2 room minting (mirrors scripts/build-guestbook.mjs) ————————————————
+// A v2 room commits its id to an OWNER pubkey and carries an owner-signed
+// writer INVITE, so anyone who opens the public deck mints their own device key
+// and writes — with the relay ENFORCING the signature chain. (A v1 `r` room is
+// permissive: anyone with the file writes, unverified.) The daemon mints
+// server-side, so the owner PRIVATE key is stashed in KV (owner/current) rather
+// than a local owner deck — recoverable if an epoch ever needs People→Remove
+// moderation; at the launch roll cadence spam auto-clears regardless.
+const EC = { name: 'ECDSA', namedCurve: 'P-256' }
+const SIG = { name: 'ECDSA', hash: 'SHA-256' }
+const rnd = (n) => { const b = new Uint8Array(n); crypto.getRandomValues(b); return b }
+async function keypair() {
+  const kp = await crypto.subtle.generateKey(EC, true, ['sign', 'verify'])
+  return {
+    pub: b64u.enc(new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey))),
+    priv: b64u.enc(new Uint8Array(await crypto.subtle.exportKey('pkcs8', kp.privateKey))),
+    key: kp.privateKey,
+  }
+}
+async function mintV2Collab(host) {
+  const ownerKp = await keypair()
+  const inviteKp = await keypair()
+  const inviteSig = b64u.enc(new Uint8Array(await crypto.subtle.sign(
+    SIG, ownerKp.key, new TextEncoder().encode(`inv.${inviteKp.pub}.writer.0`))))
+  const commit = b64u.enc(new Uint8Array(await crypto.subtle.digest('SHA-256', b64u.dec(ownerKp.pub))))
+  const key = b64u.enc(rnd(32))
+  const collab = {
+    room: `${host}/d/w${commit}`, key, on: true, v: 2, owner: ownerKp.pub,
+    invite: { pub: inviteKp.pub, priv: inviteKp.priv, role: 'writer', sig: inviteSig },
+  }
+  const owner = { room: collab.room, key, owner: ownerKp.pub, ownerPriv: ownerKp.priv, invitePub: inviteKp.pub }
+  return { collab, owner }
+}
+
 // ——— archivist: read-only join, replay, return the room's real doc ———————
 async function captureRoom(env) {
   const shellText = await env.STORE.get(CURRENT, 'text')
@@ -125,8 +159,7 @@ async function roll(env) {
   const prevDoc = extractDoc(curText)
   const epoch = (prevDoc.guestbookEpoch ?? 0) + 1
   const fonts = { fraunces: prevDoc.assets['font-fraunces'], instrument: prevDoc.assets['font-instrument'] }
-  const rnd = (n) => { const b = new Uint8Array(n); crypto.getRandomValues(b); return b }
-  const collab = { room: `${env.SYNC_HOST}/d/r${b64u.enc(rnd(12))}`, key: b64u.enc(rnd(32)), on: true }
+  const { collab, owner } = await mintV2Collab(env.SYNC_HOST)
   const doc = buildGuestbookDoc({ epoch, docId: crypto.randomUUID(), collab, fonts })
 
   // 3 · splice into a FRESH shell (so epochs pick up app releases too)
@@ -135,12 +168,17 @@ async function roll(env) {
   const spliced = spliceDoc(await shellResp.text(), doc)
   await env.STORE.put(CURRENT, spliced)
 
+  // Stash the owner private key (this is a v2 room minted server-side with no
+  // local owner deck). Never served publicly; retrievable by an admin to
+  // reconstruct an owner deck for People→Remove moderation of this epoch.
+  await env.STORE.put('owner/current', JSON.stringify({ epoch, ...owner }, null, 2))
+
   const m = await meta(env)
   m.epoch = epoch
   m.lastRoll = new Date().toISOString()
   m.killed = false
   await putMeta(env, m)
-  return { epoch, archived, size: spliced.length }
+  return { epoch, room: collab.room, archived, size: spliced.length }
 }
 
 // ——— entrypoints ————————————————————————————————————————————————————

--- a/server/guestbook-daemon/src/worker.js
+++ b/server/guestbook-daemon/src/worker.js
@@ -215,6 +215,14 @@ export default {
           const list = await env.STORE.list({ prefix: 'archives/' })
           return json({ ...m, archives: list.keys.map((k) => k.name) })
         }
+        if (action === 'owner') {
+          // The current epoch's OWNER credentials (incl. ownerPriv) — for
+          // building a moderation deck on demand. Gated by ADMIN_KEY above; the
+          // owner key never appears in the public deck. See scripts/guestbook-owner-deck.mjs.
+          const raw = await env.STORE.get('owner/current', 'text')
+          if (!raw) return json({ error: 'no owner creds stashed yet — roll once first' }, 404)
+          return new Response(raw, { headers: { 'content-type': 'application/json' } })
+        }
         if (action === 'snapshot' && req.method === 'POST') return json(await snapshot(env))
         if (action === 'roll' && req.method === 'POST') return json(await roll(env))
         if (action === 'kill' && req.method === 'POST') {
@@ -246,7 +254,7 @@ export default {
           if (!obj) return json({ error: 'not found' }, 404)
           return new Response(obj, { headers: { 'content-type': 'text/html; charset=utf-8' } })
         }
-        return json({ error: 'unknown action', actions: ['status', 'POST snapshot', 'POST roll', 'POST kill', 'PUT seed', 'archives/<key>'] }, 404)
+        return json({ error: 'unknown action', actions: ['status', 'owner', 'POST snapshot', 'POST roll', 'POST kill', 'PUT seed', 'archives/<key>'] }, 404)
       } catch (e) {
         return json({ error: String(e) }, 500)
       }

--- a/server/guestbook-daemon/wrangler.toml
+++ b/server/guestbook-daemon/wrangler.toml
@@ -10,11 +10,11 @@ routes = [
   { pattern = "bento.page/guestbook-admin/*", zone_name = "bento.page" },
 ]
 
-# Archivist snapshot + (if due) epoch roll. LAUNCH PHASE: every 15 min so the
+# Archivist snapshot + (if due) epoch roll. LAUNCH PHASE: every 30 min so the
 # room time-shards under load and spam auto-clears. Revert to ["0 1 * * *"]
 # (daily) after launch. Cron is UTC.
 [triggers]
-crons = ["*/15 * * * *"]
+crons = ["*/30 * * * *"]
 
 [[kv_namespaces]]
 binding = "STORE"
@@ -29,11 +29,11 @@ ORIGIN_FALLBACK = "https://nyblnet.github.io/bento-site"
 SYNC_HOST = "wss://sync.bento.page"
 # automatic roll cadence in hours; 0 = manual rolls only (admin endpoint).
 # The scheduled handler can only roll as often as the cron above fires, so this
-# must be ≤ the cron interval to take effect. LAUNCH PHASE: 0.25 = every 15 min
-# (matches the */15 cron) to time-shard the room and auto-clear spam. Revert to
+# must be ≤ the cron interval to take effect. LAUNCH PHASE: 0.5 = every 30 min
+# (matches the */30 cron) to time-shard the room and auto-clear spam. Revert to
 # "0" (manual) after launch — and re-arm a v2 owner-moderated epoch locally
 # (build-guestbook + seed) to restore People→Remove moderation.
-ROLL_HOURS = "0.25"
+ROLL_HOURS = "0.5"
 
 # secrets (set with `npx wrangler secret put ADMIN_KEY`):
 #   ADMIN_KEY — bearer for /guestbook-admin/*

--- a/server/guestbook-daemon/wrangler.toml
+++ b/server/guestbook-daemon/wrangler.toml
@@ -10,9 +10,11 @@ routes = [
   { pattern = "bento.page/guestbook-admin/*", zone_name = "bento.page" },
 ]
 
-# Daily archivist snapshot. Cron is UTC: 01:00 UTC ≈ 09:00 HKT.
+# Archivist snapshot + (if due) epoch roll. LAUNCH PHASE: every 15 min so the
+# room time-shards under load and spam auto-clears. Revert to ["0 1 * * *"]
+# (daily) after launch. Cron is UTC.
 [triggers]
-crons = ["0 1 * * *"]
+crons = ["*/15 * * * *"]
 
 [[kv_namespaces]]
 binding = "STORE"
@@ -26,10 +28,12 @@ ORIGIN_FALLBACK = "https://nyblnet.github.io/bento-site"
 # relay host baked into newly minted epochs
 SYNC_HOST = "wss://sync.bento.page"
 # automatic roll cadence in hours; 0 = manual rolls only (admin endpoint).
-# 24 = daily roll (the archivist cron fires daily at 01:00 UTC, so sub-24 is a
-# no-op). Daily during launch to cap spam exposure on the unmoderated wall;
-# relax to 168 (weekly) once traffic settles.
-ROLL_HOURS = "0"
+# The scheduled handler can only roll as often as the cron above fires, so this
+# must be ≤ the cron interval to take effect. LAUNCH PHASE: 0.25 = every 15 min
+# (matches the */15 cron) to time-shard the room and auto-clear spam. Revert to
+# "0" (manual) after launch — and re-arm a v2 owner-moderated epoch locally
+# (build-guestbook + seed) to restore People→Remove moderation.
+ROLL_HOURS = "0.25"
 
 # secrets (set with `npx wrangler secret put ADMIN_KEY`):
 #   ADMIN_KEY — bearer for /guestbook-admin/*


### PR DESCRIPTION
**Launch-phase load strategy.** Auto-roll the guestbook every 15 minutes so the relay Durable Object time-shards — each fresh room only accrues ~15 min of connections and a tiny op-log (cheap joins) — and spam auto-clears without moderation.

- **Cron `*/15` + `ROLL_HOURS=0.25`.** The scheduled handler can only roll as often as the cron fires, so both had to change. Revert to daily `["0 1 * * *"]` + `ROLL_HOURS=0` after launch.
- **`roll()` now mints a v2 room** (owner-committed room id + owner-signed public writer invite, relay-enforced) instead of a v1 permissive `r` room — mirroring `scripts/build-guestbook.mjs`, so writes stay per-person-keyed and the relay verifies the signature chain. The owner private key is stashed in KV (`owner/current`), never in the public deck, so an epoch stays recoverable for People→Remove moderation if needed.

**Deployed live during the HN #1 surge.** Verified: a manual roll minted **epoch 7** as a `w`-commitment v2 room (`v:2`, invite present, **no `ownerPriv` in the public deck**); a live client connects (`online:open`, sees real peers). Mint logic is byte-identical to the local builder that produced the epochs people signed hundreds of times.

**Post-launch checklist:** revert cron→daily + `ROLL_HOURS`→0, redeploy, and re-arm a local v2 owner deck to restore held-file moderation.