### PR TITLE
Fix: remote collab op no longer steals focus from an in-progress edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ below opens files from every earlier version, and unknown fields are preserved.
 This project's versions roughly follow semantic-ish `0.MINOR.PATCH` while it is
 pre-1.0.
 
+## [Unreleased]
+
+- **Fix: live edits no longer lose focus when a collaborator changes something.**
+  A remote collab op used to trigger a full canvas repaint that tore down the
+  text (or table-cell) node you were typing in — stealing focus and resetting
+  the caret. The canvas now defers the repaint while an inline edit is in
+  progress (a burst of remote ops coalesces into one repaint), and catches up
+  the instant the edit commits. Your edit is untouched; everyone else's changes
+  still land — you just see them when you finish typing. (The most-reported
+  rough edge from the Show HN launch.)
+
 ## [1.0.7] — 2026-07-22
 
 - **In-place update keeps its handle.** When a deck opened *without* a File

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -36,6 +36,10 @@ export class SlideCanvas {
   private editing: HTMLElement | null = null
   /** when editing a table cell, which cell (else null → text element edit) */
   private editingCell: { r: number; c: number } | null = null
+  /** a repaint arrived (e.g. a remote collab op) while an inline edit was in
+   *  progress and was deferred so it wouldn't tear the edited node out from
+   *  under the caret; flushed when the edit commits. */
+  private pendingRender = false
   private pathEditor!: PathEditor
   private lineEditor!: LineEditor
   private bezierEditor!: BezierEditor
@@ -429,7 +433,13 @@ export class SlideCanvas {
   }
 
   render() {
-    this.commitTextEdit()
+    // Don't repaint out from under an in-progress inline edit. A remote collab
+    // op landing must NOT tear down the text/cell node you're typing in — that
+    // steals focus and resets the caret (the #1 rough edge reported at launch).
+    // Defer the repaint and catch up the instant the edit commits; a burst of
+    // remote ops coalesces into a single repaint then.
+    if (this.editing) { this.pendingRender = true; return }
+    this.pendingRender = false
     if (this.pathEditor?.active) this.pathEditor.cancel() // doc changed under us
     const slide = this.store.slide
     const next = renderSlide(slide, this.store.doc)
@@ -966,6 +976,14 @@ export class SlideCanvas {
     } else {
       this.syncTargets()
     }
+    this.flushPendingRender()
+  }
+
+  /** Run a repaint that was deferred while an inline edit was in progress (a
+   *  remote op that arrived mid-edit). No-op when nothing is pending. Runs
+   *  after the commit above, so the repaint reflects the merged model. */
+  private flushPendingRender() {
+    if (this.pendingRender) { this.pendingRender = false; this.render() }
   }
 
   // --- table cell editing -----------------------------------------------------
@@ -1039,6 +1057,7 @@ export class SlideCanvas {
     } else {
       this.syncTargets()
     }
+    this.flushPendingRender()
   }
 
   /** Tab/Enter navigation between cells; Tab off the last cell appends a row. */


### PR DESCRIPTION
**The #1 rough edge reported at the Show HN launch.** Two people independently hit it: while you're typing in a text (or table) element, a collaborator changing *anything* stole your focus and reset your caret.

**Cause:** a remote op emits a `doc` event → canvas `render()` → it commits and rebuilds the whole surface, including the contentEditable node you were editing.

**Fix:** the canvas now **defers the repaint while an inline edit is in progress** rather than tearing down the node under the caret, and **flushes it the instant the edit commits** (`commitTextEdit`/`commitCellEdit` → `flushPendingRender`). A burst of remote ops coalesces into one repaint on commit. Your edit is untouched; everyone else's changes still apply and appear the moment you finish typing (no canvas-jumping while you type, either). Presence outlines keep updating live throughout.

**Verified in-browser** (simulating a remote op mid-edit):
- edited node preserved (same node, focus, caret, and uncommitted text all kept)
- a deferred change to *another* element does not paint mid-edit, and **does** paint on commit
- `build:single` passes (571 KB)

Scoped to the collab focus bug; no behavior change for solo editing.