### PR TITLE
feat(element): optional per-element blur + mix-blend-mode

### DIFF
--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -35,6 +35,12 @@ export interface ElementBase {
    * white glow.
    */
   shadow?: ShadowSpec | ShadowSpec[]
+  /** Gaussian blur ON this element, in px. Composed into the SAME CSS `filter`
+   *  as `shadow` (both apply). Survives PDF/print, unlike backdrop blur. */
+  blur?: number
+  /** CSS mix-blend-mode for this element ('screen' for neon light glows,
+   *  'multiply'/'overlay' for editorial duotones). Omitted/'' = normal. */
+  blend?: string
   /** presentation effects, run in present mode only */
   fx?: {
     /** entrance animation when the slide is shown. fade-* nudge ~16px; slide-*

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -129,9 +129,10 @@ export function applyElementFrame(node: HTMLElement, el: SlideElement) {
   node.style.transform = el.rotation ? `rotate(${el.rotation}deg)` : ''
   node.style.opacity = String(el.opacity)
   const shadows = Array.isArray(el.shadow) ? el.shadow : el.shadow ? [el.shadow] : []
-  node.style.filter = shadows.length
-    ? shadows.map((s) => `drop-shadow(${s.x ?? 0}px ${s.y ?? 0}px ${s.blur}px ${s.color})`).join(' ')
-    : ''
+  const parts = shadows.map((s) => `drop-shadow(${s.x ?? 0}px ${s.y ?? 0}px ${s.blur}px ${s.color})`)
+  if (el.blur) parts.push(`blur(${el.blur}px)`)
+  node.style.filter = parts.length ? parts.join(' ') : ''
+  node.style.mixBlendMode = el.blend || ''
 }
 
 // Gradient ids must be unique per rendered instance: the same element renders


### PR DESCRIPTION
**What & why**

Adds two optional fields to `ElementBase` so ANY element can carry a Gaussian
blur and/or a CSS blend mode: `blur?: number` and `blend?: string`
(`mix-blend-mode`). Useful for cinematic depth (soft out-of-focus shapes), neon
light glows (`mix-blend-mode: screen`), and editorial duotones -- effects that
aren't expressible today.

- `model.ts`: `blur?: number` and `blend?: string` on `ElementBase`.
- `render.ts`: `applyElementFrame` builds the CSS `filter` as a parts array and
  appends `blur(<n>px)` alongside the existing drop-shadows (shadow + blur
  compose), and sets `node.style.mixBlendMode = el.blend || ''`.

`filter: blur()` survives the print/PDF path (unlike `backdrop-filter`). Additive
and backward-compatible: absent fields => no blur, normal blend; older shells
ignore the fields.

**How I verified it**

- `npm run build:single` succeeds (tsc + vite).
- Authored a deck with a screen-blended, blurred shape and checked in a headless
  browser: the element wrapper computes `filter: blur(90px)` and
  `mix-blend-mode: screen`; an element without the fields stays
  `mix-blend-mode: normal` with a shadow-only `filter` (regression); no console
  errors.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/` -- n/a (no sync changes)
- [x] New UI strings added to every catalog -- n/a (data-only fields, no UI/strings)
- [x] Document format changes are additive and backward-compatible
- [x] Did not bump the version or cut a release
