### PR TITLE
feat(text): optional text-stroke for hollow/outlined glyphs

### DIFF
--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -117,6 +117,10 @@ export interface TextElement extends ElementBase {
   lineHeight: number
   /** px; optional tracking for letter-spaced caps labels */
   letterSpacing?: number
+  /** Outline / hollow glyphs via -webkit-text-stroke. `fill:'none'` makes the
+   *  interior transparent (the classic hollow section-break word); default keeps
+   *  the solid `color` fill and just adds an outline. */
+  textStroke?: { width: number; color: string; fill?: string }
   /**
    * Layout placeholder prompt ("Click to add title"). While the element's
    * html is empty: the editor shows this dimmed; present and print hide the

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -412,6 +412,11 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
       inner.style.fontFamily = el.fontFamily || doc.theme.fontFamily
       inner.style.fontWeight = String(el.fontWeight)
       inner.style.color = el.color
+      const ts = el.textStroke
+      if (ts && ts.width) {
+        inner.style.setProperty('-webkit-text-stroke', `${ts.width}px ${ts.color}`)
+        if (ts.fill === 'none') inner.style.color = 'transparent'
+      }
       inner.style.textAlign = el.align
       inner.style.lineHeight = String(el.lineHeight)
       if (el.letterSpacing) inner.style.letterSpacing = `${el.letterSpacing}px`


### PR DESCRIPTION
**What & why**
Adds `TextElement.textStroke?: { width: number; color: string; fill?: string }` so a
text element can have outlined / hollow glyphs (the classic gold hollow "section
break" word). `render.ts` sets `-webkit-text-stroke: <w>px <color>`, and when
`fill:'none'` sets `color:transparent` for a hollow interior; otherwise the solid
`color` fill stays and it just gains an outline. Composes with the glow `shadow`.

Additive + backward-compatible: absent field => no stroke; older shells ignore it.

**How I verified it**
- `npm run build:single` succeeds (tsc + vite).
- Headless: a `textStroke {width:3,color:'#D4AF37',fill:'none'}` element computes
  `-webkit-text-stroke: 3px rgb(212,175,55)` with `color: transparent`; a plain
  text element is unchanged (stroke-width 0, solid color); 0 console errors.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Ran test-sync if I touched sync/ -- n/a
- [x] New UI strings added to every catalog -- n/a (data-only field)
- [x] Document format changes are additive and backward-compatible
- [x] Did not bump the version or cut a release
