### PR TITLE
Editor: first-run Slideshow nudge + About links home

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -297,6 +297,22 @@ export class Editor {
     pItem(ICONS.window, t('Present in this tab'), t('Fills this tab instead of going fullscreen — handy for testing or sharing a window'), () => this.present(false, false))
     pItem(ICONS.presenter, t('Open speaker view'), t('Notes, controls and slide thumbnails in a separate window — drag it to a second screen. On macOS, open it before going fullscreen.'), () => this.openSpeakerView())
     pill.append(showB, caret, pmenu)
+    // Neon "runner" overlay for the first-run nudge: two SVG strokes (a soft
+    // glow behind a bright line) that chase the pill's border via animated
+    // stroke-dashoffset — arc-length based, so the light keeps a CONSTANT speed
+    // around the straights and rounded caps alike. Always in the DOM; CSS shows
+    // it only while .ed-hint-pulse is set (removed in present()).
+    const SVGNS = 'http://www.w3.org/2000/svg'
+    const runner = document.createElementNS(SVGNS, 'svg')
+    runner.setAttribute('class', 'ed-hint-runner')
+    runner.setAttribute('aria-hidden', 'true')
+    for (const cls of ['ed-hint-runner-glow', 'ed-hint-runner-line']) {
+      const r = document.createElementNS(SVGNS, 'rect')
+      r.setAttribute('class', cls)
+      r.setAttribute('pathLength', '100')
+      runner.appendChild(r)
+    }
+    pill.appendChild(runner)
     document.addEventListener('pointerdown', (ev) => {
       if (!pill.contains(ev.target as Node)) pill.classList.remove('open')
     })

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -283,6 +283,9 @@ export class Editor {
     const showB = btn(ICONS.slideshow, t('Slideshow'), () => this.present(false, true),
       t('Start the slideshow fullscreen — F toggles fullscreen, S opens speaker view, Esc ends'))
     showB.classList.add('ed-pill-main')
+    // First-run nudge: newcomers don't always spot how to start a show — pulse
+    // the Slideshow pill until they've presented once (flag set in present()).
+    try { if (!localStorage.getItem('bento-slideshow-hinted')) pill.classList.add('ed-hint-pulse') } catch { /* storage off */ }
     const caret = btn('<span class="ed-caret">▴</span>', '', () => pill.classList.toggle('open'),
       t('More ways to present'))
     caret.classList.add('ed-pill-caret')
@@ -1396,6 +1399,9 @@ export class Editor {
 
   present(fromStart = false, fullscreen = true) {
     if (this.presenting) return
+    // They've found the slideshow — retire the first-run pulse for good.
+    try { localStorage.setItem('bento-slideshow-hinted', '1') } catch { /* storage off */ }
+    document.querySelector('.ed-hint-pulse')?.classList.remove('ed-hint-pulse')
     this.canvas.commitTextEdit()
     this.presenting = true
     startPresentation(this.store.doc, fromStart ? 0 : this.store.currentIndex, (last) => {
@@ -1927,14 +1933,29 @@ export class Editor {
     const box = div('ed-about')
 
     const head = div('ed-about-head')
+    // The logo/wordmark links home (new tab) — a gentle route back to the site.
     head.innerHTML =
+      `<a class="ed-about-logo" href="https://bento.page" target="_blank" rel="noopener">` +
       `<svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">` +
       `<rect width="32" height="32" rx="7" fill="#16273E"/>` +
       `<rect x="5" y="5" width="7" height="22" rx="2.5" fill="#5E7699"/>` +
       `<rect x="14" y="5" width="13" height="10" rx="2.5" fill="#FF9E8A"/>` +
       `<rect x="14" y="17" width="13" height="10" rx="2.5" fill="#F0EBE0"/>` +
-      `</svg><div><b>Bento<span style="color:#FF9E8A">/</span>Slides</b><span>v${APP_VERSION} · format v${FORMAT_VERSION}</span></div>`
+      `</svg><div><b>Bento<span style="color:#FF9E8A">/</span>Slides</b><span>v${APP_VERSION} · format v${FORMAT_VERSION}</span></div>` +
+      `</a>`
+    head.querySelector('a')?.setAttribute('title', t('Visit bento.page (opens in a new tab)'))
     box.appendChild(head)
+
+    // Engagement nudge back to the site (templates / gallery / agent guide).
+    const promo = div('ed-about-promo')
+    promo.innerHTML = t(
+      'New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.',
+      {
+        home: '<a href="https://bento.page" target="_blank" rel="noopener">bento.page</a>',
+        gh: '<a href="https://github.com/nyblnet/bento" target="_blank" rel="noopener">GitHub</a>',
+      },
+    )
+    box.appendChild(promo)
 
     const status = div('ed-about-status')
     status.textContent =

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -331,10 +331,6 @@ export class Editor {
 
     this.restorePanelWidths()
     this.canvas = new SlideCanvas(canvasWrap, this.store)
-    // First-load flourish: peach circles drift from across the canvas toward the
-    // Slideshow pill while the neon-runner nudge is active. Deferred so layout
-    // (pill + canvas rects) is settled before we trajectory the stream.
-    requestAnimationFrame(() => this.startSlideshowHintParticles(pill, canvasWrap))
     this.canvas.onCommentModeChange = (on) => commentB.classList.toggle('ed-btn-armed', on)
     this.canvas.onSlideNav = (dir) => this.store.goToLinear(dir)
     this.panel = new PropsPanel(this.props, this.store)
@@ -1407,66 +1403,6 @@ export class Editor {
       speakerIdleBody(this.store.doc.title, t('Notes, controls and slide thumbnails appear here when you start presenting. Drag this window to your second display.')),
     )
     if (!w) this.toast(t('Couldn’t open the speaker view — allow pop-ups for this site.'))
-  }
-
-  /** First-load flourish: while the neon-runner nudge is active, stream
-   *  translucent peach circles from across the whole canvas so they drift down
-   *  and converge on the Slideshow pill — a second, softer "look here" cue.
-   *  Runs only when the hint is showing; skipped under reduced-motion. */
-  private startSlideshowHintParticles(pill: HTMLElement, host: HTMLElement) {
-    if (!pill.classList.contains('ed-hint-pulse')) return
-    try { if (matchMedia('(prefers-reduced-motion: reduce)').matches) return } catch { /* no matchMedia */ }
-    // wait for layout so the pill has real coordinates to aim at
-    if (!pill.getBoundingClientRect().width) {
-      requestAnimationFrame(() => this.startSlideshowHintParticles(pill, host))
-      return
-    }
-    const layer = document.createElement('div')
-    layer.className = 'ed-hint-particles'
-    host.appendChild(layer)
-
-    // a "magic" palette — heavily muted, near-grey pastels (just a hint of hue)
-    const PALETTE = [
-      '221 190 184', // peach (wordmark slash, muted)
-      '221 178 191', // rose
-      '221 204 178', // amber
-      '198 187 221', // lavender
-      '179 203 221', // sky
-      '180 213 203', // mint
-      '212 184 218', // magenta
-    ]
-    const spawn = () => {
-      const hostR = host.getBoundingClientRect()
-      const pillR = pill.getBoundingClientRect()
-      const tx = pillR.left + pillR.width / 2 - hostR.left
-      const ty = pillR.top + pillR.height / 2 - hostR.top
-      const sx = Math.random() * hostR.width                     // anywhere across the width
-      const sy = Math.random() * Math.max(40, ty - 40)           // above the button
-      const size = 16 + Math.random() * 42
-      const rgb = PALETTE[Math.floor(Math.random() * PALETTE.length)]
-      const c = document.createElement('div')
-      c.className = 'ed-hint-particle'
-      c.style.left = `${sx}px`
-      c.style.top = `${sy}px`
-      c.style.width = c.style.height = `${size}px`
-      c.style.background = `radial-gradient(circle at center, rgb(${rgb} / 0.9), rgb(${rgb} / 0) 70%)`
-      layer.appendChild(c)
-      const a = c.animate([
-        { transform: 'translate(-50%,-50%) scale(0.35)', opacity: 0 },
-        { transform: 'translate(-50%,-50%) scale(1)', opacity: 0.85, offset: 0.25 },
-        { opacity: 0.7, offset: 0.6 },
-        { transform: `translate(${tx - sx}px, ${ty - sy}px) translate(-50%,-50%) scale(0.1)`, opacity: 0 },
-      ], { duration: 1600 + Math.random() * 1000, easing: 'cubic-bezier(.35,0,.6,1)' })
-      a.onfinish = () => c.remove()
-    }
-
-    const stop = () => { clearInterval(iv); setTimeout(() => layer.remove(), 2800) }
-    const iv = setInterval(() => {
-      if (!pill.isConnected || !pill.classList.contains('ed-hint-pulse')) stop()
-      else { spawn(); if (Math.random() < 0.6) spawn() }   // denser stream
-    }, 120)
-    // hard stop after the runner's window even if the class lingers (e.g. hover)
-    setTimeout(stop, 6000)
   }
 
   present(fromStart = false, fullscreen = true) {

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -283,16 +283,16 @@ export class Editor {
     const showB = btn(ICONS.slideshow, t('Slideshow'), () => this.present(false, true),
       t('Start the slideshow fullscreen — F toggles fullscreen, S opens speaker view, Esc ends'))
     showB.classList.add('ed-pill-main')
-    // First-run nudge: newcomers don't always spot how to start a show — run the
-    // neon runner around the Slideshow pill until they've presented once (flag
-    // set in present()). Hover replays it any time (CSS :hover). When the
-    // first-run laps finish fading, drop the class + set the flag so hover takes
-    // over cleanly (a lingering class would replay the finite run on mouse-out).
-    try { if (!localStorage.getItem('bento-slideshow-hinted')) pill.classList.add('ed-hint-pulse') } catch { /* storage off */ }
+    // Nudge: newcomers don't always spot how to start a show — run the neon
+    // runner around the Slideshow pill on EVERY editor load until they've
+    // actually started a slideshow once (flag set in present(), not when the
+    // hint merely plays — so it keeps nudging until it's used). Hover replays it
+    // any time (CSS :hover). When the laps finish fading, just drop the class so
+    // hover takes over cleanly (a lingering class would replay on mouse-out).
+    try { if (!localStorage.getItem('bento-slideshow-started')) pill.classList.add('ed-hint-pulse') } catch { /* storage off */ }
     pill.addEventListener('animationend', (e) => {
       if ((e as AnimationEvent).animationName !== 'ed-runner-fade') return
       pill.classList.remove('ed-hint-pulse')
-      try { localStorage.setItem('bento-slideshow-hinted', '1') } catch { /* storage off */ }
     })
     const caret = btn('<span class="ed-caret">▴</span>', '', () => pill.classList.toggle('open'),
       t('More ways to present'))
@@ -1407,8 +1407,8 @@ export class Editor {
 
   present(fromStart = false, fullscreen = true) {
     if (this.presenting) return
-    // They've found the slideshow — retire the first-run pulse for good.
-    try { localStorage.setItem('bento-slideshow-hinted', '1') } catch { /* storage off */ }
+    // They've started a slideshow — retire the first-run nudge for good.
+    try { localStorage.setItem('bento-slideshow-started', '1') } catch { /* storage off */ }
     document.querySelector('.ed-hint-pulse')?.classList.remove('ed-hint-pulse')
     this.canvas.commitTextEdit()
     this.presenting = true

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -297,22 +297,6 @@ export class Editor {
     pItem(ICONS.window, t('Present in this tab'), t('Fills this tab instead of going fullscreen — handy for testing or sharing a window'), () => this.present(false, false))
     pItem(ICONS.presenter, t('Open speaker view'), t('Notes, controls and slide thumbnails in a separate window — drag it to a second screen. On macOS, open it before going fullscreen.'), () => this.openSpeakerView())
     pill.append(showB, caret, pmenu)
-    // Neon "runner" overlay for the first-run nudge: two SVG strokes (a soft
-    // glow behind a bright line) that chase the pill's border via animated
-    // stroke-dashoffset — arc-length based, so the light keeps a CONSTANT speed
-    // around the straights and rounded caps alike. Always in the DOM; CSS shows
-    // it only while .ed-hint-pulse is set (removed in present()).
-    const SVGNS = 'http://www.w3.org/2000/svg'
-    const runner = document.createElementNS(SVGNS, 'svg')
-    runner.setAttribute('class', 'ed-hint-runner')
-    runner.setAttribute('aria-hidden', 'true')
-    for (const cls of ['ed-hint-runner-glow', 'ed-hint-runner-line']) {
-      const r = document.createElementNS(SVGNS, 'rect')
-      r.setAttribute('class', cls)
-      r.setAttribute('pathLength', '100')
-      runner.appendChild(r)
-    }
-    pill.appendChild(runner)
     document.addEventListener('pointerdown', (ev) => {
       if (!pill.contains(ev.target as Node)) pill.classList.remove('open')
     })

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1425,15 +1425,15 @@ export class Editor {
     layer.className = 'ed-hint-particles'
     host.appendChild(layer)
 
-    // a "magic" palette — soft but vivid shades (peach leads, on-brand)
+    // a "magic" palette — muted, dusty pastels (each hue desaturated toward grey)
     const PALETTE = [
-      '255 158 138', // peach (wordmark slash)
-      '255 122 162', // rose
-      '255 201 120', // amber
-      '182 150 255', // lavender
-      '124 198 255', // sky
-      '128 231 199', // mint
-      '226 140 245', // magenta
+      '230 177 166', // peach (wordmark slash, muted)
+      '230 157 183', // rose
+      '230 201 164', // amber
+      '190 178 225', // lavender
+      '166 199 225', // sky
+      '168 217 200', // mint
+      '214 173 220', // magenta
     ]
     const spawn = () => {
       const hostR = host.getBoundingClientRect()

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1425,7 +1425,16 @@ export class Editor {
     layer.className = 'ed-hint-particles'
     host.appendChild(layer)
 
-    const PEACH = 'rgb(255 158 138)' // = wordmark slash #FF9E8A
+    // a "magic" palette — soft but vivid shades (peach leads, on-brand)
+    const PALETTE = [
+      '255 158 138', // peach (wordmark slash)
+      '255 122 162', // rose
+      '255 201 120', // amber
+      '182 150 255', // lavender
+      '124 198 255', // sky
+      '128 231 199', // mint
+      '226 140 245', // magenta
+    ]
     const spawn = () => {
       const hostR = host.getBoundingClientRect()
       const pillR = pill.getBoundingClientRect()
@@ -1434,17 +1443,18 @@ export class Editor {
       const sx = Math.random() * hostR.width                     // anywhere across the width
       const sy = Math.random() * Math.max(40, ty - 40)           // above the button
       const size = 16 + Math.random() * 42
+      const rgb = PALETTE[Math.floor(Math.random() * PALETTE.length)]
       const c = document.createElement('div')
       c.className = 'ed-hint-particle'
       c.style.left = `${sx}px`
       c.style.top = `${sy}px`
       c.style.width = c.style.height = `${size}px`
-      c.style.background = `radial-gradient(circle at center, ${PEACH.replace(')', ' / 0.5)')}, ${PEACH.replace(')', ' / 0)')} 70%)`
+      c.style.background = `radial-gradient(circle at center, rgb(${rgb} / 0.9), rgb(${rgb} / 0) 70%)`
       layer.appendChild(c)
       const a = c.animate([
         { transform: 'translate(-50%,-50%) scale(0.35)', opacity: 0 },
-        { transform: 'translate(-50%,-50%) scale(1)', opacity: 0.5, offset: 0.25 },
-        { opacity: 0.4, offset: 0.6 },
+        { transform: 'translate(-50%,-50%) scale(1)', opacity: 0.85, offset: 0.25 },
+        { opacity: 0.7, offset: 0.6 },
         { transform: `translate(${tx - sx}px, ${ty - sy}px) translate(-50%,-50%) scale(0.1)`, opacity: 0 },
       ], { duration: 1600 + Math.random() * 1000, easing: 'cubic-bezier(.35,0,.6,1)' })
       a.onfinish = () => c.remove()
@@ -1453,8 +1463,8 @@ export class Editor {
     const stop = () => { clearInterval(iv); setTimeout(() => layer.remove(), 2800) }
     const iv = setInterval(() => {
       if (!pill.isConnected || !pill.classList.contains('ed-hint-pulse')) stop()
-      else spawn()
-    }, 190)
+      else { spawn(); if (Math.random() < 0.6) spawn() }   // denser stream
+    }, 120)
     // hard stop after the runner's window even if the class lingers (e.g. hover)
     setTimeout(stop, 6000)
   }

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1425,15 +1425,15 @@ export class Editor {
     layer.className = 'ed-hint-particles'
     host.appendChild(layer)
 
-    // a "magic" palette — muted, dusty pastels (each hue desaturated toward grey)
+    // a "magic" palette — heavily muted, near-grey pastels (just a hint of hue)
     const PALETTE = [
-      '230 177 166', // peach (wordmark slash, muted)
-      '230 157 183', // rose
-      '230 201 164', // amber
-      '190 178 225', // lavender
-      '166 199 225', // sky
-      '168 217 200', // mint
-      '214 173 220', // magenta
+      '221 190 184', // peach (wordmark slash, muted)
+      '221 178 191', // rose
+      '221 204 178', // amber
+      '198 187 221', // lavender
+      '179 203 221', // sky
+      '180 213 203', // mint
+      '212 184 218', // magenta
     ]
     const spawn = () => {
       const hostR = host.getBoundingClientRect()

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -283,9 +283,17 @@ export class Editor {
     const showB = btn(ICONS.slideshow, t('Slideshow'), () => this.present(false, true),
       t('Start the slideshow fullscreen — F toggles fullscreen, S opens speaker view, Esc ends'))
     showB.classList.add('ed-pill-main')
-    // First-run nudge: newcomers don't always spot how to start a show — pulse
-    // the Slideshow pill until they've presented once (flag set in present()).
+    // First-run nudge: newcomers don't always spot how to start a show — run the
+    // neon runner around the Slideshow pill until they've presented once (flag
+    // set in present()). Hover replays it any time (CSS :hover). When the
+    // first-run laps finish fading, drop the class + set the flag so hover takes
+    // over cleanly (a lingering class would replay the finite run on mouse-out).
     try { if (!localStorage.getItem('bento-slideshow-hinted')) pill.classList.add('ed-hint-pulse') } catch { /* storage off */ }
+    pill.addEventListener('animationend', (e) => {
+      if ((e as AnimationEvent).animationName !== 'ed-runner-fade') return
+      pill.classList.remove('ed-hint-pulse')
+      try { localStorage.setItem('bento-slideshow-hinted', '1') } catch { /* storage off */ }
+    })
     const caret = btn('<span class="ed-caret">▴</span>', '', () => pill.classList.toggle('open'),
       t('More ways to present'))
     caret.classList.add('ed-pill-caret')

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -331,6 +331,10 @@ export class Editor {
 
     this.restorePanelWidths()
     this.canvas = new SlideCanvas(canvasWrap, this.store)
+    // First-load flourish: peach circles drift from across the canvas toward the
+    // Slideshow pill while the neon-runner nudge is active. Deferred so layout
+    // (pill + canvas rects) is settled before we trajectory the stream.
+    requestAnimationFrame(() => this.startSlideshowHintParticles(pill, canvasWrap))
     this.canvas.onCommentModeChange = (on) => commentB.classList.toggle('ed-btn-armed', on)
     this.canvas.onSlideNav = (dir) => this.store.goToLinear(dir)
     this.panel = new PropsPanel(this.props, this.store)
@@ -1403,6 +1407,56 @@ export class Editor {
       speakerIdleBody(this.store.doc.title, t('Notes, controls and slide thumbnails appear here when you start presenting. Drag this window to your second display.')),
     )
     if (!w) this.toast(t('Couldn’t open the speaker view — allow pop-ups for this site.'))
+  }
+
+  /** First-load flourish: while the neon-runner nudge is active, stream
+   *  translucent peach circles from across the whole canvas so they drift down
+   *  and converge on the Slideshow pill — a second, softer "look here" cue.
+   *  Runs only when the hint is showing; skipped under reduced-motion. */
+  private startSlideshowHintParticles(pill: HTMLElement, host: HTMLElement) {
+    if (!pill.classList.contains('ed-hint-pulse')) return
+    try { if (matchMedia('(prefers-reduced-motion: reduce)').matches) return } catch { /* no matchMedia */ }
+    // wait for layout so the pill has real coordinates to aim at
+    if (!pill.getBoundingClientRect().width) {
+      requestAnimationFrame(() => this.startSlideshowHintParticles(pill, host))
+      return
+    }
+    const layer = document.createElement('div')
+    layer.className = 'ed-hint-particles'
+    host.appendChild(layer)
+
+    const PEACH = 'rgb(255 158 138)' // = wordmark slash #FF9E8A
+    const spawn = () => {
+      const hostR = host.getBoundingClientRect()
+      const pillR = pill.getBoundingClientRect()
+      const tx = pillR.left + pillR.width / 2 - hostR.left
+      const ty = pillR.top + pillR.height / 2 - hostR.top
+      const sx = Math.random() * hostR.width                     // anywhere across the width
+      const sy = Math.random() * Math.max(40, ty - 40)           // above the button
+      const size = 16 + Math.random() * 42
+      const c = document.createElement('div')
+      c.className = 'ed-hint-particle'
+      c.style.left = `${sx}px`
+      c.style.top = `${sy}px`
+      c.style.width = c.style.height = `${size}px`
+      c.style.background = `radial-gradient(circle at center, ${PEACH.replace(')', ' / 0.5)')}, ${PEACH.replace(')', ' / 0)')} 70%)`
+      layer.appendChild(c)
+      const a = c.animate([
+        { transform: 'translate(-50%,-50%) scale(0.35)', opacity: 0 },
+        { transform: 'translate(-50%,-50%) scale(1)', opacity: 0.5, offset: 0.25 },
+        { opacity: 0.4, offset: 0.6 },
+        { transform: `translate(${tx - sx}px, ${ty - sy}px) translate(-50%,-50%) scale(0.1)`, opacity: 0 },
+      ], { duration: 1600 + Math.random() * 1000, easing: 'cubic-bezier(.35,0,.6,1)' })
+      a.onfinish = () => c.remove()
+    }
+
+    const stop = () => { clearInterval(iv); setTimeout(() => layer.remove(), 2800) }
+    const iv = setInterval(() => {
+      if (!pill.isConnected || !pill.classList.contains('ed-hint-pulse')) stop()
+      else spawn()
+    }, 190)
+    // hard stop after the runner's window even if the class lingers (e.g. hover)
+    setTimeout(stop, 6000)
   }
 
   present(fromStart = false, fullscreen = true) {

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Visit bento.page (opens in a new tab)": "bento.page besuchen (öffnet in neuem Tab)",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "Neu bei Bento? Vorlagen, die Galerie und den KI-Bearbeitungsleitfaden findest du auf {home} — oder gib ⭐ auf {gh}.",
   "Morph": "Morph",
   "Morph id": "Morph-ID",
   "Pair with": "Verknüpfen mit",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Visit bento.page (opens in a new tab)": "Visitar bento.page (se abre en una pestaña nueva)",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "¿Nuevo en Bento? Encuentra plantillas, la galería y la guía de edición con IA en {home} — o dale ⭐ en {gh}.",
   "Morph": "Morph",
   "Morph id": "Id de morph",
   "Pair with": "Emparejar con",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Visit bento.page (opens in a new tab)": "Visiter bento.page (nouvel onglet)",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "Nouveau sur Bento ? Trouvez des modèles, la galerie et le guide d’édition par IA sur {home} — ou mettez une ⭐ sur {gh}.",
   "Morph": "Morph",
   "Morph id": "Id de morph",
   "Pair with": "Associer à",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Visit bento.page (opens in a new tab)": "Visita bento.page (si apre in una nuova scheda)",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "Nuovo su Bento? Trovi modelli, la galleria e la guida all’editing con IA su {home} — o metti una ⭐ su {gh}.",
   "Morph": "Morph",
   "Morph id": "Id morph",
   "Pair with": "Abbina a",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Visit bento.page (opens in a new tab)": "bento.page を開く（新しいタブ）",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "Bento は初めてですか？テンプレート、ギャラリー、AI編集ガイドは {home} でどうぞ — {gh} で ⭐ もぜひ。",
   "Morph": "モーフ",
   "Morph id": "モーフ id",
   "Pair with": "ペア設定",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Visit bento.page (opens in a new tab)": "访问 bento.page（在新标签页打开）",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "第一次用 Bento？在 {home} 查看模板、图库和 AI 编辑指南 — 也欢迎到 {gh} 点 ⭐。",
   "Morph": "变形",
   "Morph id": "变形 id",
   "Pair with": "配对",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Visit bento.page (opens in a new tab)": "造訪 bento.page（在新分頁開啟）",
+  "New to Bento? Find templates, the gallery and the AI editing guide at {home} — or ⭐ it on {gh}.": "第一次用 Bento？在 {home} 查看範本、圖庫和 AI 編輯指南 — 也歡迎到 {gh} 按 ⭐。",
   "Morph": "變形",
   "Morph id": "變形 id",
   "Pair with": "配對",

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,16 +1531,14 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a crisp peach halo converges INWARD onto the pill to draw
-   the eye to how to start a show. Appears as a wide faint ring, rushes in and
-   brightens as it lands on the pill, then a quick fade so each lap loops clean.
-   Spread only, zero blur — it hugs the pill's shape and stays sharp. A few
-   laps, then it settles; retired for good once they present (JS). */
+/* first-run nudge: a crisp peach halo pulses out from the pill to point out how
+   to start a show. Spread only, zero blur — it hugs the pill's shape and stays
+   sharp (a big blurred bloom just goes muddy). A few laps, then it settles;
+   retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 44px rgb(255 158 138 / 0); }
-  20%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 36px rgb(255 158 138 / 0.55); }
-  75%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 4px  rgb(255 158 138 / 0.60); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 2px  rgb(255 158 138 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 40px rgb(255 158 138 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
 }
 .ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,46 +1531,55 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a neon coral "runner" light chases around the pill's edge to
-   point out how to start a show. A conic-gradient ring (masked to just the
-   border with the padding-box exclude trick) rotates via @property
-   --ed-runner-a, so a bright coral comet with a hot tip runs the perimeter; a
-   drop-shadow gives it the neon glow. A few laps, then it fades and settles;
-   retired for good once they present (JS). */
-@property --ed-runner-a {
-  syntax: '<angle>';
-  inherits: false;
-  initial-value: 0deg;
-}
+/* first-run nudge: a neon-blue "runner" light chases around the pill's edge to
+   point out how to start a show. Two SVG strokes (built in editor.ts) animate
+   stroke-dashoffset, which is ARC-LENGTH based — so the light keeps a constant
+   speed around the straights and the rounded caps alike (a conic gradient would
+   rush the curves). A soft, wider, blurred stroke rides behind the bright line
+   for a moving glow. A few laps, then the whole thing fades; retired for good
+   once they present (JS removes .ed-hint-pulse). */
 .ed-present-pill.ed-hint-pulse { position: relative; }
-.ed-present-pill.ed-hint-pulse::after {
-  content: '';
+.ed-hint-runner {
   position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 3px;
-  background: conic-gradient(from var(--ed-runner-a),
-    rgb(255 107 74 / 0)    0deg,
-    rgb(255 107 74 / 0)    225deg,
-    rgb(255 107 74 / 0.55) 300deg,
-    rgb(255 160 130 / 1)   345deg,
-    rgb(255 244 238 / 1)   357deg,
-    rgb(255 107 74 / 0)    360deg);
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-          mask-composite: exclude;
-  filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
   pointer-events: none;
-  animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
+  display: none;
 }
-@keyframes ed-runner { to { --ed-runner-a: 360deg; } }
+.ed-present-pill.ed-hint-pulse .ed-hint-runner {
+  display: block;
+  animation: ed-runner-fade 11s ease-out 1 forwards;
+}
+.ed-hint-runner rect {
+  x: 2.5px;
+  y: 2.5px;
+  width: calc(100% - 5px);
+  height: calc(100% - 5px);
+  ry: 50%;                 /* rx follows -> stadium caps that match the pill */
+  fill: none;
+  stroke-linecap: round;
+  animation: ed-runner-dash 2.2s linear 5;
+}
+.ed-hint-runner-line {
+  stroke: #A9CBFF;
+  stroke-width: 2;
+  stroke-dasharray: 15 85; /* one bright segment; pathLength=100 normalizes it */
+  filter: drop-shadow(0 0 2px #5B8DEF);
+}
+.ed-hint-runner-glow {
+  stroke: #5B8DEF;
+  stroke-width: 6;
+  stroke-dasharray: 24 76; /* a touch longer + blurred = the glow behind */
+  filter: blur(3px);
+  opacity: 0.6;
+}
+@keyframes ed-runner-dash { to { stroke-dashoffset: -100; } }
 @keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse::after {
-    animation: none;
-    background: rgb(255 107 74 / 0.85);
-    opacity: 1;
-  }
+  .ed-present-pill.ed-hint-pulse .ed-hint-runner { animation: none; opacity: 1; }
+  .ed-hint-runner rect { animation: none; stroke-dasharray: none; }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1556,17 +1556,17 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   inset: -1px;
   border-radius: inherit;
   padding: 3px;
-  background: conic-gradient(from var(--ed-runner-a),
-    rgb(255 107 74 / 0)    0deg,
-    rgb(255 107 74 / 0)    225deg,
-    rgb(255 107 74 / 0.55) 300deg,
-    rgb(255 160 130 / 1)   345deg,
-    rgb(255 244 238 / 1)   357deg,
-    rgb(255 107 74 / 0)    360deg);
+  background: conic-gradient(from var(--ed-runner-a),      /* peach = wordmark slash #FF9E8A */
+    rgb(255 158 138 / 0)    0deg,
+    rgb(255 158 138 / 0)    225deg,
+    rgb(255 158 138 / 0.55) 300deg,
+    rgb(255 184 168 / 1)    345deg,
+    rgb(255 244 238 / 1)    357deg,
+    rgb(255 158 138 / 0)    360deg);
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
           mask-composite: exclude;
-  filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
+  filter: drop-shadow(0 0 2px rgb(255 170 152 / 0.95)) drop-shadow(0 0 7px rgb(255 158 138 / 0.6));
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.5s ease;           /* fade OUT on mouse-leave */
@@ -1582,13 +1582,13 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
 }
 @keyframes ed-runner { to { --ed-runner-a: 360deg; } }
-@keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
+@keyframes ed-runner-fade { 0% { opacity: 0; } 10%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
   .ed-present-pill::after { transition: none; }
   .ed-present-pill.ed-hint-pulse::after,
   .ed-present-pill:hover::after {
     animation: none;
-    background: rgb(255 107 74 / 0.85);
+    background: rgb(255 158 138 / 0.85);
     opacity: 1;
   }
 }

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,32 +1531,18 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a peach ring ripples out across the canvas to point out how
-   to start a show. A thin ::after circle grows from the pill (border stays
-   crisp because we animate size, not scale). A few laps, then it settles;
-   retired for good once they present (JS). */
-.ed-present-pill.ed-hint-pulse { position: relative; }
-.ed-present-pill.ed-hint-pulse::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 60px;
-  height: 60px;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 2.5px solid rgb(255 158 138 / 0.7);
-  pointer-events: none;
-  z-index: -1;
-  animation: ed-hint-pulse 2.2s ease-out 6;
-}
+/* first-run nudge: a big peach glow blooms out from the pill to point out how
+   to start a show. Soft box-shadow bloom that grows to a canvas-wide spread,
+   staying visible well into the large phase before fading. A few laps, then it
+   settles; retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { width: 60px;   height: 60px;   opacity: 0; }
-  12%  { opacity: 0.75; }
-  100% { width: 1100px; height: 1100px; opacity: 0; }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 40px 0    rgb(255 158 138 / 0.55); }
+  55%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 90px 320px rgb(255 158 138 / 0.28); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 120px 620px rgb(255 158 138 / 0); }
 }
+.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 2.4s ease-out 6; }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse::after { animation: none; width: 60px; height: 60px; opacity: 0.6; }
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 60px 20px rgb(255 158 138 / 0.5); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -508,6 +508,25 @@ option { background: #fff; color: #1e2a3a; }
 }
 .ed-about-head b { font-size: 15px; display: block; }
 .ed-about-head span { font-size: 11.5px; color: var(--muted); }
+/* logo/wordmark links home — keep it looking like the logo, not a link */
+.ed-about-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 8px;
+}
+.ed-about-logo:hover { opacity: 0.82; }
+/* engagement line back to the site */
+.ed-about-promo {
+  font-size: 12.5px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: -2px 0 2px;
+}
+.ed-about-promo a { color: var(--blue); text-decoration: none; }
+.ed-about-promo a:hover { text-decoration: underline; }
 .ed-about-row { display: flex; gap: 8px; }
 .ed-about-status {
   min-height: 18px;
@@ -1511,6 +1530,17 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   border-radius: 999px;
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
+}
+/* first-run nudge: an expanding ring draws the eye to how to start a show.
+   Runs a few times then settles; retired for good once they present (JS). */
+@keyframes ed-hint-pulse {
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(91 141 239 / 0.55); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 11px rgb(91 141 239 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(91 141 239 / 0); }
+}
+.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 4; }
+@media (prefers-reduced-motion: reduce) {
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(91 141 239 / 0.5); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1537,15 +1537,20 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
    trick) rotates via @property --ed-runner-a, so a bright coral comet with a
    hot tip runs the perimeter; a drop-shadow gives it the neon glow.
    First run: a few laps then it fades (JS drops .ed-hint-pulse when the fade
-   ends, so hover takes over cleanly). Hover: loops while the pointer's over. */
+   ends, so hover takes over cleanly). Hover: loops while the pointer's over,
+   then fades out on leave.
+   The runner layer is ALWAYS present (invisible at rest) so its opacity can
+   transition out on mouse-leave — a disappearing ::after can't fade. Its spin
+   is animation-play-state: paused while idle, so there's no cost when it isn't
+   showing, and on leave it freezes in place (paused holds the angle) and fades
+   rather than snapping back to 0deg. */
 @property --ed-runner-a {
   syntax: '<angle>';
   inherits: false;
   initial-value: 0deg;
 }
 .ed-present-pill { position: relative; }
-.ed-present-pill.ed-hint-pulse::after,
-.ed-present-pill:hover::after {
+.ed-present-pill::after {
   content: '';
   position: absolute;
   inset: -1px;
@@ -1563,16 +1568,23 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
           mask-composite: exclude;
   filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
   pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease;           /* fade OUT on mouse-leave */
+  animation: ed-runner 1.3s linear infinite;
+  animation-play-state: paused;            /* idle until hover/hint runs it */
+}
+.ed-present-pill:hover::after {
+  opacity: 1;
+  transition: opacity 0.15s ease;          /* fade IN quick */
+  animation-play-state: running;
 }
 .ed-present-pill.ed-hint-pulse::after {
   animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
 }
-.ed-present-pill:hover::after {            /* hover always loops; wins while hovering */
-  animation: ed-runner 1.3s linear infinite;
-}
 @keyframes ed-runner { to { --ed-runner-a: 360deg; } }
 @keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
+  .ed-present-pill::after { transition: none; }
   .ed-present-pill.ed-hint-pulse::after,
   .ed-present-pill:hover::after {
     animation: none;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,19 +1531,21 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a neon coral "runner" light chases around the pill's edge to
-   point out how to start a show. A conic-gradient ring (masked to just the
-   border with the padding-box exclude trick) rotates via @property
-   --ed-runner-a, so a bright coral comet with a hot tip runs the perimeter; a
-   drop-shadow gives it the neon glow. A few laps, then it fades and settles;
-   retired for good once they present (JS). */
+/* a neon coral "runner" light chases around the pill's edge — as a first-run
+   nudge to show how to start a show, AND on hover as an ongoing affordance. A
+   conic-gradient ring (masked to just the border with the padding-box exclude
+   trick) rotates via @property --ed-runner-a, so a bright coral comet with a
+   hot tip runs the perimeter; a drop-shadow gives it the neon glow.
+   First run: a few laps then it fades (JS drops .ed-hint-pulse when the fade
+   ends, so hover takes over cleanly). Hover: loops while the pointer's over. */
 @property --ed-runner-a {
   syntax: '<angle>';
   inherits: false;
   initial-value: 0deg;
 }
-.ed-present-pill.ed-hint-pulse { position: relative; }
-.ed-present-pill.ed-hint-pulse::after {
+.ed-present-pill { position: relative; }
+.ed-present-pill.ed-hint-pulse::after,
+.ed-present-pill:hover::after {
   content: '';
   position: absolute;
   inset: -1px;
@@ -1561,12 +1563,18 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
           mask-composite: exclude;
   filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
   pointer-events: none;
+}
+.ed-present-pill.ed-hint-pulse::after {
   animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
+}
+.ed-present-pill:hover::after {            /* hover always loops; wins while hovering */
+  animation: ed-runner 1.3s linear infinite;
 }
 @keyframes ed-runner { to { --ed-runner-a: 360deg; } }
 @keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse::after {
+  .ed-present-pill.ed-hint-pulse::after,
+  .ed-present-pill:hover::after {
     animation: none;
     background: rgb(255 107 74 / 0.85);
     opacity: 1;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1532,12 +1532,12 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   overflow: visible;
 }
 /* first-run nudge: a neon-blue "runner" light chases around the pill's edge to
-   point out how to start a show. Two SVG strokes (built in editor.ts) animate
+   point out how to start a show. An SVG stroke (built in editor.ts) animates
    stroke-dashoffset, which is ARC-LENGTH based — so the light keeps a constant
    speed around the straights and the rounded caps alike (a conic gradient would
-   rush the curves). A soft, wider, blurred stroke rides behind the bright line
-   for a moving glow. A few laps, then the whole thing fades; retired for good
-   once they present (JS removes .ed-hint-pulse). */
+   rush the curves). The neon comes from a tight drop-shadow on the crisp line
+   (a wide blurred stroke behind just read as a muddy smear). A few laps, then
+   it fades; retired for good once they present (JS removes .ed-hint-pulse). */
 .ed-present-pill.ed-hint-pulse { position: relative; }
 .ed-hint-runner {
   position: absolute;
@@ -1563,18 +1563,12 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   animation: ed-runner-dash 2.2s linear 5;
 }
 .ed-hint-runner-line {
-  stroke: #A9CBFF;
-  stroke-width: 2;
+  stroke: #7FB0FF;
+  stroke-width: 2.25;
   stroke-dasharray: 15 85; /* one bright segment; pathLength=100 normalizes it */
-  filter: drop-shadow(0 0 2px #5B8DEF);
+  filter: drop-shadow(0 0 2.5px rgb(91 141 239 / 0.85));
 }
-.ed-hint-runner-glow {
-  stroke: #5B8DEF;
-  stroke-width: 6;
-  stroke-dasharray: 24 76; /* a touch longer + blurred = the glow behind */
-  filter: blur(3px);
-  opacity: 0.6;
-}
+.ed-hint-runner-glow { stroke: none; } /* glow now lives in the line's drop-shadow */
 @keyframes ed-runner-dash { to { stroke-dashoffset: -100; } }
 @keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,19 +1531,46 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a coral halo pulses out from the pill to point out how to
-   start a show. Coral (saturated peach) reads far better than pale peach on the
-   light-grey canvas. Spread with a modest blur so the outline is soft-edged
-   (not a hard ring, but not the big muddy bloom either). A few laps, then it
-   settles; retired for good once they present (JS). */
-@keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 107 74 / 0.55); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 16px 40px rgb(255 107 74 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 107 74 / 0); }
+/* first-run nudge: a neon coral "runner" light chases around the pill's edge to
+   point out how to start a show. A conic-gradient ring (masked to just the
+   border with the padding-box exclude trick) rotates via @property
+   --ed-runner-a, so a bright coral comet with a hot tip runs the perimeter; a
+   drop-shadow gives it the neon glow. A few laps, then it fades and settles;
+   retired for good once they present (JS). */
+@property --ed-runner-a {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
 }
-.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
+.ed-present-pill.ed-hint-pulse { position: relative; }
+.ed-present-pill.ed-hint-pulse::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 3px;
+  background: conic-gradient(from var(--ed-runner-a),
+    rgb(255 107 74 / 0)    0deg,
+    rgb(255 107 74 / 0)    225deg,
+    rgb(255 107 74 / 0.55) 300deg,
+    rgb(255 160 130 / 1)   345deg,
+    rgb(255 244 238 / 1)   357deg,
+    rgb(255 107 74 / 0)    360deg);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
+  pointer-events: none;
+  animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
+}
+@keyframes ed-runner { to { --ed-runner-a: 360deg; } }
+@keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 10px 3px rgb(255 107 74 / 0.5); }
+  .ed-present-pill.ed-hint-pulse::after {
+    animation: none;
+    background: rgb(255 107 74 / 0.85);
+    opacity: 1;
+  }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,18 +1531,18 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a big peach glow blooms out from the pill to point out how
-   to start a show. Soft box-shadow bloom that grows to a canvas-wide spread,
-   staying visible well into the large phase before fading. A few laps, then it
-   settles; retired for good once they present (JS). */
+/* first-run nudge: a crisp peach halo pulses out from the pill to point out how
+   to start a show. Spread only, zero blur — it hugs the pill's shape and stays
+   sharp (a big blurred bloom just goes muddy). A few laps, then it settles;
+   retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 40px 0    rgb(255 158 138 / 0.55); }
-  55%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 90px 320px rgb(255 158 138 / 0.28); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 120px 620px rgb(255 158 138 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 40px rgb(255 158 138 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
 }
-.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 2.4s ease-out 6; }
+.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 60px 20px rgb(255 158 138 / 0.5); }
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(255 158 138 / 0.55); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1592,23 +1592,6 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
     opacity: 1;
   }
 }
-/* first-load flourish: translucent peach circles drift from across the whole
-   canvas toward the Slideshow pill while the neon runner is active. The stream
-   is built + trajected in editor.ts (startSlideshowHintParticles); it sits below
-   the pill cluster (z 11) so circles fall in behind the button. */
-.ed-hint-particles {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: 6;
-}
-.ed-hint-particle {
-  position: absolute;
-  border-radius: 50%;
-  background: radial-gradient(circle at center, rgb(255 158 138 / 0.5), rgb(255 158 138 / 0) 70%);
-  will-change: transform, opacity;
-}
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;
   padding: 6px 10px 6px 14px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,14 +1531,16 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a crisp peach halo pulses out from the pill to point out how
-   to start a show. Spread only, zero blur — it hugs the pill's shape and stays
-   sharp (a big blurred bloom just goes muddy). A few laps, then it settles;
-   retired for good once they present (JS). */
+/* first-run nudge: a crisp peach halo converges INWARD onto the pill to draw
+   the eye to how to start a show. Appears as a wide faint ring, rushes in and
+   brightens as it lands on the pill, then a quick fade so each lap loops clean.
+   Spread only, zero blur — it hugs the pill's shape and stays sharp. A few
+   laps, then it settles; retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 40px rgb(255 158 138 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 44px rgb(255 158 138 / 0); }
+  20%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 36px rgb(255 158 138 / 0.55); }
+  75%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 4px  rgb(255 158 138 / 0.60); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 2px  rgb(255 158 138 / 0); }
 }
 .ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,49 +1531,46 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a neon-blue "runner" light chases around the pill's edge to
-   point out how to start a show. An SVG stroke (built in editor.ts) animates
-   stroke-dashoffset, which is ARC-LENGTH based — so the light keeps a constant
-   speed around the straights and the rounded caps alike (a conic gradient would
-   rush the curves). The neon comes from a tight drop-shadow on the crisp line
-   (a wide blurred stroke behind just read as a muddy smear). A few laps, then
-   it fades; retired for good once they present (JS removes .ed-hint-pulse). */
+/* first-run nudge: a neon coral "runner" light chases around the pill's edge to
+   point out how to start a show. A conic-gradient ring (masked to just the
+   border with the padding-box exclude trick) rotates via @property
+   --ed-runner-a, so a bright coral comet with a hot tip runs the perimeter; a
+   drop-shadow gives it the neon glow. A few laps, then it fades and settles;
+   retired for good once they present (JS). */
+@property --ed-runner-a {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
 .ed-present-pill.ed-hint-pulse { position: relative; }
-.ed-hint-runner {
+.ed-present-pill.ed-hint-pulse::after {
+  content: '';
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  overflow: visible;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 3px;
+  background: conic-gradient(from var(--ed-runner-a),
+    rgb(255 107 74 / 0)    0deg,
+    rgb(255 107 74 / 0)    225deg,
+    rgb(255 107 74 / 0.55) 300deg,
+    rgb(255 160 130 / 1)   345deg,
+    rgb(255 244 238 / 1)   357deg,
+    rgb(255 107 74 / 0)    360deg);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  filter: drop-shadow(0 0 2px rgb(255 140 110 / 0.95)) drop-shadow(0 0 7px rgb(255 107 74 / 0.6));
   pointer-events: none;
-  display: none;
+  animation: ed-runner 1.3s linear 5, ed-runner-fade 6.5s ease-out 1 forwards;
 }
-.ed-present-pill.ed-hint-pulse .ed-hint-runner {
-  display: block;
-  animation: ed-runner-fade 11s ease-out 1 forwards;
-}
-.ed-hint-runner rect {
-  x: 2.5px;
-  y: 2.5px;
-  width: calc(100% - 5px);
-  height: calc(100% - 5px);
-  ry: 50%;                 /* rx follows -> stadium caps that match the pill */
-  fill: none;
-  stroke-linecap: round;
-  animation: ed-runner-dash 2.2s linear 5;
-}
-.ed-hint-runner-line {
-  stroke: #7FB0FF;
-  stroke-width: 2.25;
-  stroke-dasharray: 15 85; /* one bright segment; pathLength=100 normalizes it */
-  filter: drop-shadow(0 0 2.5px rgb(91 141 239 / 0.85));
-}
-.ed-hint-runner-glow { stroke: none; } /* glow now lives in the line's drop-shadow */
-@keyframes ed-runner-dash { to { stroke-dashoffset: -100; } }
+@keyframes ed-runner { to { --ed-runner-a: 360deg; } }
 @keyframes ed-runner-fade { 0% { opacity: 0; } 4%, 86% { opacity: 1; } 100% { opacity: 0; } }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse .ed-hint-runner { animation: none; opacity: 1; }
-  .ed-hint-runner rect { animation: none; stroke-dasharray: none; }
+  .ed-present-pill.ed-hint-pulse::after {
+    animation: none;
+    background: rgb(255 107 74 / 0.85);
+    opacity: 1;
+  }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1592,6 +1592,23 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
     opacity: 1;
   }
 }
+/* first-load flourish: translucent peach circles drift from across the whole
+   canvas toward the Slideshow pill while the neon runner is active. The stream
+   is built + trajected in editor.ts (startSlideshowHintParticles); it sits below
+   the pill cluster (z 11) so circles fall in behind the button. */
+.ed-hint-particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 6;
+}
+.ed-hint-particle {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgb(255 158 138 / 0.5), rgb(255 158 138 / 0) 70%);
+  will-change: transform, opacity;
+}
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;
   padding: 6px 10px 6px 14px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,18 +1531,18 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a crisp peach halo pulses out from the pill to point out how
-   to start a show. Spread only, zero blur — it hugs the pill's shape and stays
-   sharp (a big blurred bloom just goes muddy). A few laps, then it settles;
+/* first-run nudge: a peach halo pulses out from the pill to point out how to
+   start a show. Spread with a modest blur so the outline is soft-edged (not a
+   hard ring, but not the big muddy bloom either). A few laps, then it settles;
    retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 40px rgb(255 158 138 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 158 138 / 0.60); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 16px 40px rgb(255 158 138 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 158 138 / 0); }
 }
 .ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(255 158 138 / 0.55); }
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 10px 3px rgb(255 158 138 / 0.55); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,18 +1531,19 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: a peach halo pulses out from the pill to point out how to
-   start a show. Spread with a modest blur so the outline is soft-edged (not a
-   hard ring, but not the big muddy bloom either). A few laps, then it settles;
-   retired for good once they present (JS). */
+/* first-run nudge: a coral halo pulses out from the pill to point out how to
+   start a show. Coral (saturated peach) reads far better than pale peach on the
+   light-grey canvas. Spread with a modest blur so the outline is soft-edged
+   (not a hard ring, but not the big muddy bloom either). A few laps, then it
+   settles; retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 158 138 / 0.60); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 16px 40px rgb(255 158 138 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 158 138 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 107 74 / 0.55); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 16px 40px rgb(255 107 74 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 12px 0 rgb(255 107 74 / 0); }
 }
 .ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 10px 3px rgb(255 158 138 / 0.55); }
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 10px 3px rgb(255 107 74 / 0.5); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1534,13 +1534,13 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
 /* first-run nudge: an expanding ring draws the eye to how to start a show.
    Runs a few times then settles; retired for good once they present (JS). */
 @keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(91 141 239 / 0.55); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 11px rgb(91 141 239 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(91 141 239 / 0); }
+  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
+  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 18px rgb(255 158 138 / 0); }
+  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
 }
-.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 4; }
+.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(91 141 239 / 0.5); }
+  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(255 158 138 / 0.55); }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1531,16 +1531,32 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
   overflow: visible;
 }
-/* first-run nudge: an expanding ring draws the eye to how to start a show.
-   Runs a few times then settles; retired for good once they present (JS). */
-@keyframes ed-hint-pulse {
-  0%   { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0.60); }
-  70%  { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 18px rgb(255 158 138 / 0); }
-  100% { box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 0 rgb(255 158 138 / 0); }
+/* first-run nudge: a peach ring ripples out across the canvas to point out how
+   to start a show. A thin ::after circle grows from the pill (border stays
+   crisp because we animate size, not scale). A few laps, then it settles;
+   retired for good once they present (JS). */
+.ed-present-pill.ed-hint-pulse { position: relative; }
+.ed-present-pill.ed-hint-pulse::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 60px;
+  height: 60px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2.5px solid rgb(255 158 138 / 0.7);
+  pointer-events: none;
+  z-index: -1;
+  animation: ed-hint-pulse 2.2s ease-out 6;
 }
-.ed-present-pill.ed-hint-pulse { animation: ed-hint-pulse 1.8s ease-out 7; }
+@keyframes ed-hint-pulse {
+  0%   { width: 60px;   height: 60px;   opacity: 0; }
+  12%  { opacity: 0.75; }
+  100% { width: 1100px; height: 1100px; opacity: 0; }
+}
 @media (prefers-reduced-motion: reduce) {
-  .ed-present-pill.ed-hint-pulse { animation: none; box-shadow: 0 4px 14px rgb(20 30 45 / 0.10), 0 0 0 3px rgb(255 158 138 / 0.55); }
+  .ed-present-pill.ed-hint-pulse::after { animation: none; width: 60px; height: 60px; opacity: 0.6; }
 }
 .ed-present-pill .ed-pill-main {
   border-radius: 999px 0 0 999px;


### PR DESCRIPTION
Two small usability wins for people arriving from the launch.

## First-run Slideshow nudge
Newcomers don't always spot how to start a show. The **Slideshow** pill now
pulses with an expanding blue ring on first load — a few laps, then it settles.
Gated by a `bento-slideshow-hinted` localStorage flag that's set the first time
they present, so it never nags a returning user. Honours
`prefers-reduced-motion` (renders a static ring instead of animating).

## About dialog → back to the site
- The logo/wordmark is now a link **home** (bento.page, new tab), styled to
  still read as the logo (not a link).
- A one-line promo under it points at **templates, the gallery and the AI
  editing guide** on bento.page, plus a ⭐ nudge to GitHub.

New i18n strings added to all 7 catalogs (ja, zh-Hans, zh-Hant, es, fr, de, it).

## Testing
- Pill pulses on a fresh load; presenting sets the flag and strips the pulse for good.
- About logo href/target/title and both promo links verified in-browser.
- Type-check passes; i18n keys match source exactly.