### PR TITLE
Charts: fix negative-value bars (anchor to zero, not the range floor)

### DIFF
--- a/slides/src/charts.ts
+++ b/slides/src/charts.ts
@@ -296,7 +296,12 @@ function renderCartesian(svg: SVGSVGElement, d: Digest, sweep: number, view: Vie
     const r = ranges[a] ?? r0
     return G.y + G.h - ((v - r.lo) / (r.hi - r.lo || 1)) * G.h
   }
-  const baseOf = (a = 0) => yOf((ranges[a] ?? r0).lo, a)
+  // baseline for bars / area fill = the ZERO line, clamped into the axis range
+  // (so bars grow up/down from zero, not from the range floor — the negatives fix)
+  const baseOf = (a = 0) => {
+    const r = ranges[a] ?? r0
+    return yOf(Math.min(Math.max(0, r.lo), r.hi), a)
+  }
 
   // shared gridlines at k evenly spaced rows; labels on the matching side(s)
   for (let j = 0; j < k; j++) {
@@ -358,9 +363,10 @@ function renderCartesian(svg: SVGSVGElement, d: Digest, sweep: number, view: Vie
       const data: number[] = (s.data ?? []).slice(i0, i0 + nCat).map((v: unknown) => num(v, 0))
       data.forEach((v, i) => {
         const x = G.x + band * i + (band - groupW) / 2 + barW * si
-        const hv = (base - yOf(v, ax)) * sweep
+        // grow the bar from the zero baseline toward the value (up for +, down for -)
+        const tip = base + (yOf(v, ax) - base) * sweep
         const r = elNS('rect', {
-          x: x + 1, y: base - hv, width: Math.max(1, barW - 2), height: Math.max(0, hv),
+          x: x + 1, y: Math.min(base, tip), width: Math.max(1, barW - 2), height: Math.max(0, Math.abs(tip - base)),
           rx: Math.min(radius, barW / 2), fill: color,
         })
         ;(r as any).__cat = i


### PR DESCRIPTION
## Problem
Bars with negative data render wrong. They were anchored to the axis
**range floor** (`baseOf = yOf(range.lo)`) instead of the **zero line**, so
with any negatives:

- positive bars started at the chart floor and stretched up *through* zero (far too tall)
- a bar equal to the range minimum had zero height (invisible)
- negative bars sat on the floor instead of hanging down from zero

(The line *stroke* was already correct — `yOf` handles negatives — but the
line **area fill** shared the same floor baseline, so it was wrong too.)

## Fix
Make `baseOf` return the **zero line**, clamped into the axis range
(`yOf(min(max(0, lo), hi))`), and grow each bar from there toward its value —
up for positive, down for negative. The area fill uses the same baseline, so
areas now fill to zero as well.

All-positive charts are unaffected: with `lo = 0`, `baseOf` still resolves to
the chart floor exactly as before.

## Verification
Repro deck with `bar: [50, -40, 30, -20, 60]` + `line: [20, -25, 45, -10, 35]`:
- **Before:** every bar anchored to the −40 floor; −40 bar invisible; positives crossed zero.
- **After:** +bars grow up from zero, −bars hang down from zero, line crosses zero correctly.

Type-check clean. Independent of the open Slideshow-runner PR (#27).