### PR TITLE
Editor: panel UI for text gradient, outline, blur/blend/backdrop

### DIFF
--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -418,6 +418,28 @@ export class PropsPanel {
       this.row('Color', this.colorAlpha(sh.color, (v, fin) => setShadow(i, { color: v }, fin)))
     })
 
+    // Blur (on the element) / frosted-glass backdrop (behind it) / blend mode —
+    // available on any element. 0 clears blur/backdrop; 'normal' clears blend.
+    const fxGrid = document.createElement('div')
+    fxGrid.className = 'ed-grid2'
+    fxGrid.append(
+      this.mini(t('Blur'), el.blur ?? 0, (v) => this.mutate(el.id, (e) => {
+        if (v > 0) e.blur = v
+        else delete e.blur
+      }, true)),
+      this.mini(t('Backdrop'), el.backdropFilter ?? 0, (v) => this.mutate(el.id, (e) => {
+        if (v > 0) e.backdropFilter = v
+        else delete e.backdropFilter
+      }, true)),
+    )
+    this.host.appendChild(fxGrid)
+    this.row('Blend', this.select(
+      ['normal', 'multiply', 'screen', 'overlay', 'darken', 'lighten', 'difference', 'exclusion'],
+      el.blend || 'normal',
+      (v) => this.mutate(el.id, (e) => {
+        if (v === 'normal') delete e.blend
+        else e.blend = v
+      }, true)))
 
     this.section(t('Arrange'))
     this.arrangeRows([el])
@@ -783,14 +805,103 @@ export class PropsPanel {
         (e as TextElement).fontSize = Math.round(Math.max(v, 3) * (4 / 3) * 100) / 100
       }, fin)))
     this.row('Weight', this.weightSelect(el))
-    this.row('Color', this.color(el.color, (v, fin) =>
-      this.mutate(el.id, (e) => { (e as TextElement).color = v }, fin)))
+    // Text fill: a solid colour, or a multi-stop gradient painted into the glyphs.
+    const tgrad = el.colorGradient
+    this.row('Fill style', this.select(['solid', 'gradient'], tgrad ? 'gradient' : 'solid', (v) =>
+      this.mutate(el.id, (e) => {
+        const tx = e as TextElement
+        if (v === 'gradient') {
+          const base = parseColor(tx.color)
+          tx.colorGradient ??= {
+            angle: 90,
+            stops: [
+              { at: 0, color: combineColor(base.hex, Math.max(base.a, 1)) },
+              { at: 1, color: '#5B8DEF' },
+            ],
+          }
+        } else {
+          delete tx.colorGradient
+        }
+      }, true)))
+    if (!tgrad) {
+      this.row('Color', this.color(el.color, (v, fin) =>
+        this.mutate(el.id, (e) => { (e as TextElement).color = v }, fin)))
+    } else {
+      this.row('Grad. angle', this.number(tgrad.angle, 1, (v, fin) =>
+        this.mutate(el.id, (e) => {
+          const g = (e as TextElement).colorGradient
+          if (g) g.angle = v
+        }, fin)))
+      tgrad.stops.forEach((stop, i) => {
+        const wrap = document.createElement('div')
+        wrap.className = 'ed-gradstop'
+        const at = this.number(Math.round(stop.at * 100), 1, (v, fin) =>
+          this.mutate(el.id, (e) => {
+            const g = (e as TextElement).colorGradient
+            if (g?.stops[i]) g.stops[i].at = Math.min(Math.max(v / 100, 0), 1)
+          }, fin))
+        at.title = t('Position %')
+        const color = this.colorAlpha(stop.color, (v, fin) =>
+          this.mutate(el.id, (e) => {
+            const g = (e as TextElement).colorGradient
+            if (g?.stops[i]) g.stops[i].color = v
+          }, fin))
+        wrap.append(at, color)
+        if (tgrad.stops.length > 2) {
+          const del = document.createElement('button')
+          del.className = 'ed-btn ed-btn-icon'
+          del.textContent = '✕'
+          del.title = t('Remove stop')
+          del.addEventListener('click', () =>
+            this.mutate(el.id, (e) => {
+              const g = (e as TextElement).colorGradient
+              if (g && g.stops.length > 2) g.stops.splice(i, 1)
+            }, true))
+          wrap.appendChild(del)
+        }
+        this.row(`Stop ${i + 1}`, wrap)
+      })
+      const addStop = document.createElement('button')
+      addStop.className = 'ed-btn ed-btn-block'
+      addStop.textContent = t('＋ Add stop')
+      addStop.addEventListener('click', () =>
+        this.mutate(el.id, (e) => {
+          const g = (e as TextElement).colorGradient
+          if (!g) return
+          const mid = g.stops[Math.floor(g.stops.length / 2)]
+          g.stops.push({ at: 0.5, color: mid?.color ?? '#808080' })
+          g.stops.sort((a, b) => a.at - b.at)
+        }, true))
+      this.host.appendChild(addStop)
+    }
     this.row('Align', this.select(['left', 'center', 'right'], el.align, (v) =>
       this.mutate(el.id, (e) => { (e as TextElement).align = v as TextElement['align'] }, true)))
     this.row('V-align', this.select(['top', 'middle', 'bottom'], el.valign, (v) =>
       this.mutate(el.id, (e) => { (e as TextElement).valign = v as TextElement['valign'] }, true)))
     this.row('Line height', this.number(el.lineHeight, 0.05, (v, fin) =>
       this.mutate(el.id, (e) => { (e as TextElement).lineHeight = Math.max(v, 0.5) }, fin)))
+
+    // Outline / hollow glyphs via -webkit-text-stroke. Width 0 = off; 'hollow'
+    // makes the glyph interior transparent (the classic outlined section word).
+    const ts = el.textStroke
+    this.row('Outline', this.number(ts?.width ?? 0, 0.5, (v, fin) =>
+      this.mutate(el.id, (e) => {
+        const tx = e as TextElement
+        if (v > 0) tx.textStroke = { color: '#1E2A3A', ...(tx.textStroke ?? {}), width: v }
+        else delete tx.textStroke
+      }, fin)))
+    if (ts && ts.width) {
+      this.row('Outline color', this.colorAlpha(ts.color, (v, fin) =>
+        this.mutate(el.id, (e) => {
+          const g = (e as TextElement).textStroke
+          if (g) g.color = v
+        }, fin)))
+      this.row('Interior', this.select(['filled', 'hollow'], ts.fill === 'none' ? 'hollow' : 'filled', (v) =>
+        this.mutate(el.id, (e) => {
+          const g = (e as TextElement).textStroke
+          if (g) { if (v === 'hollow') g.fill = 'none'; else delete g.fill }
+        }, true)))
+    }
 
     const embed = document.createElement('button')
     embed.className = 'ed-btn ed-btn-block'

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Backdrop": "Hintergrund",
+  "Blend": "Mischmodus",
+  "Outline": "Kontur",
+  "Outline color": "Konturfarbe",
+  "Interior": "Innenfläche",
+  "filled": "gefüllt",
+  "hollow": "hohl",
   "Reduced motion: on": "Bewegung reduziert: an",
   "Reduced motion: off": "Bewegung reduziert: aus",
   "Reduce motion — pause animations (also honours your OS setting)": "Bewegung reduzieren — Animationen pausieren (berücksichtigt auch die OS-Einstellung)",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Backdrop": "Fondo",
+  "Blend": "Fusión",
+  "Outline": "Contorno",
+  "Outline color": "Color del contorno",
+  "Interior": "Interior",
+  "filled": "relleno",
+  "hollow": "hueco",
   "Reduced motion: on": "Movimiento reducido: activado",
   "Reduced motion: off": "Movimiento reducido: desactivado",
   "Reduce motion — pause animations (also honours your OS setting)": "Reducir movimiento — pausa las animaciones (respeta también el ajuste del sistema)",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Backdrop": "Arrière-plan",
+  "Blend": "Fusion",
+  "Outline": "Contour",
+  "Outline color": "Couleur du contour",
+  "Interior": "Intérieur",
+  "filled": "plein",
+  "hollow": "creux",
   "Reduced motion: on": "Animations réduites : activées",
   "Reduced motion: off": "Animations réduites : désactivées",
   "Reduce motion — pause animations (also honours your OS setting)": "Réduire les animations — met en pause les animations (respecte aussi le réglage du système)",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Backdrop": "Sfondo",
+  "Blend": "Fusione",
+  "Outline": "Contorno",
+  "Outline color": "Colore contorno",
+  "Interior": "Interno",
+  "filled": "pieno",
+  "hollow": "vuoto",
   "Reduced motion: on": "Movimento ridotto: attivo",
   "Reduced motion: off": "Movimento ridotto: disattivato",
   "Reduce motion — pause animations (also honours your OS setting)": "Riduci il movimento — mette in pausa le animazioni (rispetta anche l’impostazione del sistema)",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Backdrop": "背景ぼかし",
+  "Blend": "描画モード",
+  "Outline": "縁取り",
+  "Outline color": "縁取りの色",
+  "Interior": "内側",
+  "filled": "塗りつぶし",
+  "hollow": "中抜き",
   "Reduced motion: on": "モーション軽減：オン",
   "Reduced motion: off": "モーション軽減：オフ",
   "Reduce motion — pause animations (also honours your OS setting)": "モーションを減らす — アニメーションを一時停止（OS設定にも従います）",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Backdrop": "背景模糊",
+  "Blend": "混合模式",
+  "Outline": "描边",
+  "Outline color": "描边颜色",
+  "Interior": "内部",
+  "filled": "填充",
+  "hollow": "空心",
   "Reduced motion: on": "减少动态效果：开",
   "Reduced motion: off": "减少动态效果：关",
   "Reduce motion — pause animations (also honours your OS setting)": "减少动态效果 — 暂停动画（也遵循系统设置）",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,13 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Backdrop": "背景模糊",
+  "Blend": "混合模式",
+  "Outline": "外框",
+  "Outline color": "外框顏色",
+  "Interior": "內部",
+  "filled": "填滿",
+  "hollow": "空心",
   "Reduced motion: on": "減少動態效果：開",
   "Reduced motion: off": "減少動態效果：關",
   "Reduce motion — pause animations (also honours your OS setting)": "減少動態效果 — 暫停動畫（也遵循系統設定）",


### PR DESCRIPTION
Adds the missing editor panel controls for the format features that landed
as JSON-only in #23–26, so they're usable before v1.0.8 ships.

## Text (Typography section)
- **Fill style** → solid ⇄ gradient. Gradient reveals angle + per-stop
  position/colour rows and Add/Remove stop, reusing the shape gradient editor.
- **Outline** (text-stroke): width, colour, and a filled/hollow interior toggle.

## Any element (Effects section)
- **Blur** — Gaussian blur on the element.
- **Backdrop** — frosted-glass blur behind it.
- **Blend** — mix-blend-mode select (screen for neon glows, multiply/overlay for duotones).

## Verified
Applied all five via the panel and confirmed rendering: text `color:transparent`
+ `linear-gradient(...)`, `-webkit-text-stroke`, `filter: blur()`,
`mix-blend-mode`, `backdrop-filter: blur()`. Type-check clean.

New i18n keys added to all 7 catalogs. Blend-mode option values are left as
English fallback (standardized technical terms; safer than risking a wrong
localization) — a good follow-up for a native reviewer per locale.