### PR TITLE
CI: validation gates on every PR (typecheck · build · splice gate · sync rig)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+# CI validation gates — validate, never release.
+#
+# Every PR and every push to main runs: typecheck, the single-file build,
+# the splice conformance gate (scripts/shell-gate.mjs — same code the local
+# release runs before signing), and the CRDT convergence rig at CI depth.
+#
+# Deliberately absent: signing, publishing, deploying. Releases are cut
+# locally so the signing key never leaves the maintainer's machine and the
+# signed bytes are the served bytes (docs/RELEASING.md). Keep it that way —
+# do not add secrets or release steps to this workflow.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # ≥23.6 required: the sync rig runs TypeScript via native type
+          # stripping (node scripts/test-sync.ts).
+          node-version: 24
+          cache: npm
+          cache-dependency-path: slides/package-lock.json
+
+      - name: Install
+        working-directory: slides
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: slides
+        run: node_modules/.bin/tsc -b
+
+      - name: Build single-file shell
+        working-directory: slides
+        run: npm run build:single
+
+      - name: Splice conformance gate
+        run: node scripts/shell-gate.mjs slides/dist-single/Bento_Slides.bento.html
+
+      - name: CRDT convergence rig
+        # 40 seeds locally; deeper on CI where the seconds are free.
+        run: SEEDS=300 node scripts/test-sync.ts

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -25,6 +25,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } fr
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spliceDoc } from './guestbook-deck.mjs'
+import { gateShell } from './shell-gate.mjs'
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const args = process.argv.slice(2)
@@ -51,24 +52,9 @@ cpSync(shellSrc, join(site, 'releases/slides/Bento_Slides.bento.html'))
 cpSync(shellSrc, join(site, 'slides/index.html'))
 
 // CONFORMANCE GATE — old updaters are frozen code; every release must
-// satisfy the splice contract they rely on (see postbuild-compress.mjs):
-// plaintext #bento-doc, regex-extractable, balanced script tags, and a
-// v0.1.0-style text splice must produce a well-formed document.
-{
-  const shell = readFileSync(join(site, 'releases/slides/Bento_Slides.bento.html'), 'utf8')
-  const blockRe = /<script type="application\/bento\+json" id="bento-doc">[\s\S]*?<\/script>/
-  if (!blockRe.test(shell)) throw new Error('GATE: #bento-doc block not found/extractable')
-  const opens = (shell.match(/<script[\s>]/g) ?? []).length
-  const closes = shell.split('</scr' + 'ipt>').length - 1
-  if (opens !== closes) throw new Error(`GATE: script tag imbalance (${opens}/${closes})`)
-  const fakeDoc = JSON.stringify({ format: 'bento/slides', probe: '<tag> & </close>' }).replace(/</g, '\\u003c')
-  const spliced = shell.replace(blockRe, `<script type="application/bento+json" id="bento-doc">\n${fakeDoc}\n</scr` + 'ipt>')
-  if (!spliced.includes(fakeDoc)) throw new Error('GATE: splice failed')
-  const opens2 = (spliced.match(/<script[\s>]/g) ?? []).length
-  const closes2 = spliced.split('</scr' + 'ipt>').length - 1
-  if (opens2 !== closes2) throw new Error('GATE: spliced document imbalanced')
-  console.log('conformance gate: old-updater splice contract OK')
-}
+// satisfy the splice contract they rely on. The gate itself lives in
+// scripts/shell-gate.mjs (shared with CI, which runs it on every PR build).
+gateShell(join(site, 'releases/slides/Bento_Slides.bento.html'))
 
 // Sign the manifest against the staged bytes.
 const signArgs = [

--- a/scripts/shell-gate.mjs
+++ b/scripts/shell-gate.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento/Suite authors
+// CONFORMANCE GATE — old updaters are frozen code; every shell must satisfy
+// the splice contract they rely on (see postbuild-compress.mjs): plaintext
+// #bento-doc, regex-extractable, balanced script tags, and a v0.1.0-style
+// text splice must produce a well-formed document.
+//
+// One implementation, two callers: release.mjs runs it before signing, and
+// CI runs it on every PR's build (node scripts/shell-gate.mjs <shell.html>).
+// CI validating the contract is NOT a release — signing stays local-only
+// (docs/RELEASING.md); this file must never touch keys or manifests.
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/** Throws with a GATE: message on the first violated invariant. */
+export function gateShell(shellPath) {
+  const shell = readFileSync(shellPath, 'utf8')
+  const blockRe = /<script type="application\/bento\+json" id="bento-doc">[\s\S]*?<\/script>/
+  if (!blockRe.test(shell)) throw new Error('GATE: #bento-doc block not found/extractable')
+  const opens = (shell.match(/<script[\s>]/g) ?? []).length
+  const closes = shell.split('</scr' + 'ipt>').length - 1
+  if (opens !== closes) throw new Error(`GATE: script tag imbalance (${opens}/${closes})`)
+  const fakeDoc = JSON.stringify({ format: 'bento/slides', probe: '<tag> & </close>' }).replace(/</g, '\\u003c')
+  const spliced = shell.replace(blockRe, `<script type="application/bento+json" id="bento-doc">\n${fakeDoc}\n</scr` + 'ipt>')
+  if (!spliced.includes(fakeDoc)) throw new Error('GATE: splice failed')
+  const opens2 = (spliced.match(/<script[\s>]/g) ?? []).length
+  const closes2 = spliced.split('</scr' + 'ipt>').length - 1
+  if (opens2 !== closes2) throw new Error('GATE: spliced document imbalanced')
+  console.log('conformance gate: old-updater splice contract OK')
+}
+
+// CLI: node scripts/shell-gate.mjs <path-to-shell.html>
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const target = process.argv[2]
+  if (!target) {
+    console.error('usage: node scripts/shell-gate.mjs <shell.html>')
+    process.exit(2)
+  }
+  gateShell(target)
+}


### PR DESCRIPTION
The first of the two follow-ups from #34: automated validation that scales
where human review can't, ahead of the multi-agent fan-out.

## What runs (every PR + every push to main)
1. **Typecheck** — `tsc -b` in `slides/`
2. **Single-file build** — `npm run build:single` (the build IS the product)
3. **Splice conformance gate** — the frozen-updater contract checks
   (`#bento-doc` plaintext + extractable, balanced script tags, v0.1.0-style
   text splice produces a well-formed document)
4. **CRDT convergence rig** — `SEEDS=300` (deeper than the local default of
   40; still <1s)

## The refactor
The conformance gate moves out of `release.mjs` into **`scripts/shell-gate.mjs`**
— one implementation, two callers (release-before-signing, CI-on-every-PR), so
the checks can never drift apart. Also callable standalone:
`node scripts/shell-gate.mjs <shell.html>`.

## What deliberately does NOT run
No signing, no publishing, no deploying, no secrets. Releases stay local per
`docs/RELEASING.md` — the signing key never leaves the maintainer's machine
and the signed bytes are the served bytes. The workflow header documents this
so nobody adds release steps later.

## Verified locally
- Gate passes on the current v1.0.8 shell; **fails correctly** on a
  deliberately broken shell (exit 1, `GATE: #bento-doc block not found`);
  exit 2 usage without args.
- Refactored `release.mjs --no-build` runs end-to-end with the extracted gate.
- Rig at `SEEDS=300`: ALL PASS, 46,402 checks, 0.76s.
- Workflow YAML validates.

This PR is also the live test — CI should appear on it. Follow-up once
merged: mark `validate` as a required status check in branch protection.