### PR TITLE
Rebrand: lowercase everywhere — bento/slides, bento/spaces, bento/.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to **Bento Slides**. The app version is baked into every
+All notable changes to **bento/slides**. The app version is baked into every
 shell as `APP_VERSION` (from `slides/package.json`) and shown in the About
 dialog; a shipped file updates itself through the signed release channel.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-Bento Slides is MIT-licensed (© 2026 The Bento/Suite authors; see `LICENSE`).
+bento/slides is MIT-licensed (© 2026 The Bento/Suite authors; see `LICENSE`).
 The shippable single-file shell (`Bento_Slides.bento.html`) bundles the
 following third-party open-source components. Their license terms require that
 these notices accompany copies, so the same text is embedded as a `NOTICE`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Bento docs
 
-Engineering and format documentation for Bento Slides. Start here.
+Engineering and format documentation for bento/slides. Start here.
 
 | Document | What it covers |
 |---|---|

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing Bento Slides
+# Releasing bento/slides
 
 Releases are cut **locally** — the signing key never leaves the maintainer's
 machine, and the signed bytes are exactly the served bytes (no CI rebuild can

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,7 +1,7 @@
-# Bento Slides — for AI agents
+# bento/slides — for AI agents
 
 **Guide version `__APP_VERSION__`** · document format `bento/slides` (v1). This
-guide matches the Bento Slides shell of the same version. A deck's `#bento-doc`
+guide matches the bento/slides shell of the same version. A deck's `#bento-doc`
 JSON is always the source of truth — if it was written by a newer shell it may
 carry features beyond this guide; unknown keys are ignored, never fatal.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Bento Slides — architecture
+# bento/slides — architecture
 
 *Engineering reference, current as of July 2026. Covers how a `.bento.html`
 file is constructed, what the on-disk format looks like, and how the runtime
@@ -61,7 +61,7 @@ else is the fixed *shell*. Skeleton of the actual markup
 <head>
   <meta charset="UTF-8"> <meta name="viewport" …> <meta name="generator" content="bento-slides">
   <link rel="icon" href="data:image/svg+xml,…">
-  <title>Deck title — Bento Slides</title>
+  <title>Deck title — bento/slides</title>
 
   <!-- NOTICE — bundled open-source components …
        (license notices; part of the shell, so they travel with every copy) -->

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,6 +1,6 @@
 # The `bento/slides` document format
 
-*Normative reference for the JSON document model, current as of Bento Slides
+*Normative reference for the JSON document model, current as of bento/slides
 **v1.0.6** (format version `1`). The authoritative source is
 [`slides/src/model.ts`](../slides/src/model.ts) — this document tracks it. If
 the two disagree, the code wins; please file that as a docs bug.*

--- a/scripts/postbuild-compress.mjs
+++ b/scripts/postbuild-compress.mjs
@@ -40,7 +40,7 @@ const flag = (name, fallback) => {
   return i > 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
 }
 const generator = flag('generator', 'bento-slides')
-const titleFallback = flag('title', 'Bento Slides')
+const titleFallback = flag('title', 'bento/slides')
 
 const html = readFileSync(path, 'utf8')
 if (html.includes('id="bento-rt"')) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 The Bento/Suite authors
-// Cut a Bento Slides release: build the shell, sign the manifest, and
+// Cut a bento/slides release: build the shell, sign the manifest, and
 // assemble the complete static site for bento.page into ./site/.
 //
 //   node scripts/release.mjs [--no-build] [--key path]

--- a/scripts/sign-release.mjs
+++ b/scripts/sign-release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 The Bento/Suite authors
-// Sign a Bento Slides release: produce the manifest.json that shipped files
+// Sign a bento/slides release: produce the manifest.json that shipped files
 // poll (on user request only) to learn about updates.
 //
 //   node scripts/sign-release.mjs slides/dist-single/Bento_Slides.bento.html \

--- a/site-src/help.html
+++ b/site-src/help.html
@@ -3,15 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Help — Bento Slides — bento.page</title>
-<meta name="description" content="How to use Bento Slides: elements, morph, charts, tables, media, presenting, live collaboration, building with AI, and keyboard shortcuts.">
+<title>Help — bento/slides — bento.page</title>
+<meta name="description" content="How to use bento/slides: elements, morph, charts, tables, media, presenting, live collaboration, building with AI, and keyboard shortcuts.">
 <link rel="canonical" href="https://bento.page/help">
 <meta name="theme-color" content="#0D1B2E">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="Bento/Suite">
 <meta property="og:url" content="https://bento.page/help">
-<meta property="og:title" content="Help — Bento Slides">
-<meta property="og:description" content="How to use Bento Slides: elements, morph, charts, tables, media, presenting, live collaboration, building with AI, and keyboard shortcuts.">
+<meta property="og:title" content="Help — bento/slides">
+<meta property="og:description" content="How to use bento/slides: elements, morph, charts, tables, media, presenting, live collaboration, building with AI, and keyboard shortcuts.">
 <meta property="og:image" content="https://bento.page/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://bento.page/og.png">
@@ -91,7 +91,7 @@ footer a{color:var(--dim)}
   <div class="wrap bar">
     <a class="mark" href="/">
       <svg width="30" height="30" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#16273E"/><rect x="5" y="5" width="7" height="22" rx="2.5" fill="#5E7699"/><rect x="14" y="5" width="13" height="10" rx="2.5" fill="#FF9E8A"/><rect x="14" y="17" width="13" height="10" rx="2.5" fill="#F0EBE0"/></svg>
-      Bento<span style="color:var(--dim);font-weight:500">/Help</span>
+      bento<span style="color:var(--dim);font-weight:500">/help</span>
     </a>
     <div class="spacer"></div>
     <a class="nav" href="https://github.com/nyblnet/bento" target="_blank" rel="noopener">GitHub</a>
@@ -104,7 +104,7 @@ footer a{color:var(--dim)}
   <div class="wrap">
     <div class="kick">BENTO SLIDES</div>
     <h1>Everything you need to<br>build a deck.</h1>
-    <p class="lede">Bento Slides is one HTML file that is the document, the viewer and the editor at once. Open it, edit it, present it — it saves itself. Here's how each piece works.</p>
+    <p class="lede">bento/slides is one HTML file that is the document, the viewer and the editor at once. Open it, edit it, present it — it saves itself. Here's how each piece works.</p>
   </div>
 </div>
 

--- a/site-src/landing.html
+++ b/site-src/landing.html
@@ -548,7 +548,7 @@ body.kdeck header, body.kdeck footer { display: none; }
   <div class="hbar">
     <a class="mark" href="/">
       <svg viewBox="0 0 32 32" width="30" height="30" aria-hidden="true"><rect width="32" height="32" rx="7" fill="#16273E"/><rect x="5" y="5" width="7" height="22" rx="2.5" fill="#5E7699"/><rect x="14" y="5" width="13" height="10" rx="2.5" fill="#FF9E8A"/><rect x="14" y="17" width="13" height="10" rx="2.5" fill="#F0EBE0"/></svg>
-      <span>Bento<span class="slash">/</span>Suite</span>
+      <span>bento<span class="slash">/</span>.</span>
     </a>
     <div class="nav-cta">
       <a class="btn ghost-btn nav-ghost" href="/help">Help</a>

--- a/slides/index.html
+++ b/slides/index.html
@@ -10,9 +10,9 @@
     <meta name="color-scheme" content="only light" />
     <meta name="generator" content="bento-slides" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect x='2' y='2' width='28' height='28' rx='6' fill='%2316273E'/%3E%3Crect x='6' y='6' width='6' height='20' rx='2' fill='%235E7699'/%3E%3Crect x='14' y='6' width='12' height='9' rx='2' fill='%23FF9E8A'/%3E%3Crect x='14' y='17' width='12' height='9' rx='2' fill='%23F0EBE0'/%3E%3C/svg%3E" />
-    <title>Bento Slides</title>
+    <title>bento/slides</title>
     <!--
-      NOTICE — Bento Slides
+      NOTICE — bento/slides
       MIT License — © 2026 The Bento/Suite authors
       Full license text: the LICENSE file in the source tree, or https://bento.page
       Source & third-party notices: https://bento.page

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -24,6 +24,7 @@ import { openSpeakerWindow, speakerIdleBody } from '../screens'
 import { borderPoint, boxCenter, lineEndpoints, setLineEndpoints, sideMidpoint } from './lineedit'
 import { ICONS } from '../icons'
 import { t, setLocale, locale, LOCALE_CHOICES } from '../i18n'
+import { appConfig } from '../../../kernel/src/app.ts'
 import { disconnectOnline, joinFromDoc, mintCollab, mintInvite, onlineTransport, rotateKeys, sharingOn, startSharing, stopSharing } from '../sync/online'
 
 const i18nT = t
@@ -195,8 +196,8 @@ export class Editor {
       `<rect x="5" y="5" width="7" height="22" rx="2.5" fill="#5E7699"/>` +
       `<rect x="14" y="5" width="13" height="10" rx="2.5" fill="#FF9E8A"/>` +
       `<rect x="14" y="17" width="13" height="10" rx="2.5" fill="#F0EBE0"/>` +
-      `</svg> <b>Bento<span style="color:#FF9E8A">/</span>Slides</b>`
-    logo.title = t('About Bento Slides — version, updates, licenses')
+      `</svg> <b>bento<span style="color:#FF9E8A">/</span>slides</b>`
+    logo.title = t('About bento/slides — version, updates, licenses')
     logo.style.cursor = 'pointer'
     logo.addEventListener('click', () => this.openAbout())
     const title = document.createElement('input')
@@ -206,13 +207,13 @@ export class Editor {
     title.spellcheck = false
     title.addEventListener('change', () => {
       this.store.commit(() => { this.store.doc.title = title.value || 'Untitled' })
-      document.title = `${this.store.doc.title} — Bento Slides`
+      document.title = `${this.store.doc.title} — ${appConfig().appName}`
     })
     // remote/programmatic title changes reflect live (unless being typed in)
     this.store.on('doc', () => {
       if (document.activeElement !== title && title.value !== this.store.doc.title) {
         title.value = this.store.doc.title
-        document.title = `${this.store.doc.title} — Bento Slides`
+        document.title = `${this.store.doc.title} — ${appConfig().appName}`
       }
     })
     this.dirtyDot = div('ed-dirty')
@@ -1950,7 +1951,7 @@ export class Editor {
       `<rect x="5" y="5" width="7" height="22" rx="2.5" fill="#5E7699"/>` +
       `<rect x="14" y="5" width="13" height="10" rx="2.5" fill="#FF9E8A"/>` +
       `<rect x="14" y="17" width="13" height="10" rx="2.5" fill="#F0EBE0"/>` +
-      `</svg><div><b>Bento<span style="color:#FF9E8A">/</span>Slides</b><span>v${APP_VERSION} · format v${FORMAT_VERSION}</span></div>` +
+      `</svg><div><b>bento<span style="color:#FF9E8A">/</span>slides</b><span>v${APP_VERSION} · format v${FORMAT_VERSION}</span></div>` +
       `</a>`
     head.querySelector('a')?.setAttribute('title', t('Visit bento.page (opens in a new tab)'))
     box.appendChild(head)

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -28,7 +28,7 @@ export const de: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> animiert Elemente, die auf dieser und der vorherigen Folie vorkommen (Folie duplizieren, dann Dinge verschieben).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Ein <b>Zustand</b> liegt außerhalb des Pfeiltasten-Flusses — erreichbar per Klick auf ein verlinktes Element. Gemeinsame IDs morphen zwischen Zuständen.",
   "A deck needs at least one slide": "Eine Präsentation braucht mindestens eine Folie",
-  "About Bento Slides — version, updates, licenses": "Über Bento Slides — Version, Updates, Lizenzen",
+  "About bento/slides — version, updates, licenses": "Über bento/slides — Version, Updates, Lizenzen",
   "Align": "Ausrichten",
   "Ambient": "Ambiente",
   "Angle": "Winkel",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -28,7 +28,7 @@ export const es: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anima los elementos presentes en esta diapositiva y en la anterior (duplica una diapositiva y mueve cosas).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Un <b>estado</b> queda fuera del flujo de flechas — se llega haciendo clic en un elemento enlazado. Los ids compartidos se transforman entre estados.",
   "A deck needs at least one slide": "Una presentación necesita al menos una diapositiva",
-  "About Bento Slides — version, updates, licenses": "Acerca de Bento Slides — versión, actualizaciones, licencias",
+  "About bento/slides — version, updates, licenses": "Acerca de bento/slides — versión, actualizaciones, licencias",
   "Align": "Alinear",
   "Ambient": "Ambiente",
   "Angle": "Ángulo",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -28,7 +28,7 @@ export const fr: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anime les éléments présents sur cette diapositive et la précédente (dupliquez une diapositive puis déplacez des éléments).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Un <b>état</b> est hors du flux des flèches — on l'atteint en cliquant un élément lié. Les ids partagés se transforment entre états.",
   "A deck needs at least one slide": "Une présentation doit contenir au moins une diapositive",
-  "About Bento Slides — version, updates, licenses": "À propos de Bento Slides — version, mises à jour, licences",
+  "About bento/slides — version, updates, licenses": "À propos de bento/slides — version, mises à jour, licences",
   "Align": "Aligner",
   "Ambient": "Ambiance",
   "Angle": "Angle",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -28,7 +28,7 @@ export const it: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>Morph</b> anima gli elementi presenti sia in questa diapositiva sia nella precedente (duplica una diapositiva e sposta gli elementi).",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "Uno <b>stato</b> è escluso dal flusso delle frecce — vi si arriva facendo clic su un elemento collegato. Gli id condivisi si trasformano tra stati.",
   "A deck needs at least one slide": "Una presentazione richiede almeno una diapositiva",
-  "About Bento Slides — version, updates, licenses": "Informazioni su Bento Slides — versione, aggiornamenti, licenze",
+  "About bento/slides — version, updates, licenses": "Informazioni su bento/slides — versione, aggiornamenti, licenze",
   "Align": "Allinea",
   "Ambient": "Ambiente",
   "Angle": "Angolo",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -28,7 +28,7 @@ export const ja: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>モーフ</b>は、このスライドと前のスライドの両方にある要素をアニメーションします（スライドを複製してから配置を変えてみてください）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>ステート</b>は矢印キーの流れに現れません — リンクされた要素のクリックで到達します。共有 id の要素はステート間でモーフします。",
   "A deck needs at least one slide": "デッキには最低1枚のスライドが必要です",
-  "About Bento Slides — version, updates, licenses": "Bento Slides について — バージョン・更新・ライセンス",
+  "About bento/slides — version, updates, licenses": "bento/slides について — バージョン・更新・ライセンス",
   "Align": "整列",
   "Ambient": "アンビエント",
   "Angle": "角度",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -28,7 +28,7 @@ export const zhHans: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>变形</b>会为同时出现在此幻灯片和上一张中的元素做动画（复制一张幻灯片，然后移动内容试试）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>状态</b>不出现在方向键流程中 — 观众通过点击链接元素到达。共享 id 的元素会在状态间变形。",
   "A deck needs at least one slide": "演示文稿至少需要一张幻灯片",
-  "About Bento Slides — version, updates, licenses": "关于 Bento Slides — 版本、更新、许可证",
+  "About bento/slides — version, updates, licenses": "关于 bento/slides — 版本、更新、许可证",
   "Align": "对齐",
   "Ambient": "氛围",
   "Angle": "角度",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -28,7 +28,7 @@ export const zhHant: Catalog = {
   "<b>Morph</b> animates elements that appear on both this slide and the previous one (copy a slide, then move things around).": "<b>變形</b>會為同時出現在此投影片與上一張的元素製作動畫（複製一張投影片，然後移動內容試試）。",
   "A <b>state</b> is hidden from arrow-key flow — viewers reach it by clicking a linked element. Shared element ids morph between states.": "<b>狀態</b>不會出現在方向鍵流程中 — 觀眾透過點按連結元素到達。共享 id 的元素會在狀態間變形。",
   "A deck needs at least one slide": "簡報至少需要一張投影片",
-  "About Bento Slides — version, updates, licenses": "關於 Bento Slides — 版本、更新、授權",
+  "About bento/slides — version, updates, licenses": "關於 bento/slides — 版本、更新、授權",
   "Align": "對齊",
   "Ambient": "氛圍",
   "Angle": "角度",

--- a/slides/src/main.ts
+++ b/slides/src/main.ts
@@ -5,7 +5,7 @@
 
 import './styles.css'
 import { anim } from './anim'
-import { configureApp } from '../../kernel/src/app.ts'
+import { configureApp, appConfig } from '../../kernel/src/app.ts'
 import {
   capturePristine, readEmbeddedDoc, serializeFile, serializeAuto, downloadFile,
   suggestedFileName, parseEnvelope, decryptEnvelope, setEncryptionPassword,
@@ -25,7 +25,7 @@ import { onlineTransport, startSharing, stopSharing } from './sync/online'
 // (window title suffix, save-picker label, update manifest + its `app` check).
 configureApp({
   appId: 'bento-slides',
-  appName: 'Bento Slides',
+  appName: 'bento/slides',
   manifestUrl: 'https://bento.page/releases/slides/manifest.json',
 })
 
@@ -93,7 +93,7 @@ function bootWith(doc: BentoDoc) {
  * never expose the editor. Leaving the presentation lands on a minimal card.
  */
 function playerMode(doc: BentoDoc) {
-  document.title = `${doc.title} — Bento Slides`
+  document.title = `${doc.title} — ${appConfig().appName}`
   if (doc.fonts?.length) injectFonts(doc)
   document.getElementById('bento-splash')?.remove()
   const card = document.createElement('div')
@@ -120,7 +120,7 @@ function playerMode(doc: BentoDoc) {
 
 function editorMode(doc: BentoDoc) {
 
-document.title = `${doc.title} — Bento Slides`
+document.title = `${doc.title} — ${appConfig().appName}`
 
 // Embedded fonts: register @font-face rules from the asset table so text
 // elements can use bundled families in the editor, presenter and thumbnails.

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 The Bento/Suite authors
-// The Bento Slides document model. This JSON is what lives inside the
+// The bento/slides document model. This JSON is what lives inside the
 // <script type="application/bento+json"> block of a .bento.html file.
 
 export const FORMAT = 'bento/slides'

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 The Bento/Suite authors
-// The starter deck — what a freshly built Bento Slides file opens with.
+// The starter deck — what a freshly built bento/slides file opens with.
 //
 // It is the product demo, the launch asset and the feature tour in one: every
 // claim it makes is proven by the feature making it. A cast of four "bento
@@ -311,7 +311,7 @@ const DOTS_PAPER =
 
 export function starterDoc(): BentoDoc {
   const doc = newDoc()
-  doc.title = 'Bento Slides Showcase'
+  doc.title = 'bento/slides showcase'
   doc.theme.fontFamily = BODY
   doc.theme.accent = PEACH
   // new charts (＋ Chart, table→chart) inherit the deck's midnight-&-peach family

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1,4 +1,4 @@
-/* ————— Bento Slides chrome ————— */
+/* ————— bento/slides chrome ————— */
 
 :root {
   --ink: #1e2a3a;

--- a/spaces/index.html
+++ b/spaces/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="only light" />
     <meta name="generator" content="bento-spaces" />
-    <title>Bento Spaces</title>
+    <title>bento/spaces</title>
     <!-- NOTICE
       bento/spaces — MIT licensed. https://bento.page
       This file is the document, the viewer and the editor. The runtime is

--- a/spaces/package.json
+++ b/spaces/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:single": "tsc -b && SINGLEFILE=1 vite build --outDir dist-single && mv dist-single/index.html dist-single/Bento_Spaces.bento.html && node ../scripts/postbuild-compress.mjs dist-single/Bento_Spaces.bento.html --generator bento-spaces --title \"Bento Spaces\"",
+    "build:single": "tsc -b && SINGLEFILE=1 vite build --outDir dist-single && mv dist-single/index.html dist-single/Bento_Spaces.bento.html && node ../scripts/postbuild-compress.mjs dist-single/Bento_Spaces.bento.html --generator bento-spaces --title \"bento/spaces\"",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/spaces/src/main.ts
+++ b/spaces/src/main.ts
@@ -11,7 +11,7 @@
 // rather than assembled from guesses. See docs/PLATFORM.md §10.
 
 import './styles.css'
-import { configureApp } from '../../kernel/src/app.ts'
+import { configureApp, appConfig } from '../../kernel/src/app.ts'
 import {
   capturePristine, readEmbeddedDoc, serializeFile, serializeAuto,
   saveFile, parseEnvelope,
@@ -23,7 +23,7 @@ import { parseDoc, starterDoc, docContentKey, uid, type SpacesDoc } from './mode
 
 configureApp({
   appId: 'bento-spaces',
-  appName: 'Bento Spaces',
+  appName: 'bento/spaces',
   manifestUrl: 'https://bento.page/releases/spaces/manifest.json',
 })
 
@@ -41,7 +41,7 @@ if (embedded && parseEnvelope(embedded)) {
 }
 
 function boot(doc: SpacesDoc) {
-  document.title = `${doc.title} — Bento Spaces`
+  document.title = `${doc.title} — ${appConfig().appName}`
   document.getElementById('bento-splash')?.remove()
 
   const app = document.getElementById('app')!
@@ -114,7 +114,7 @@ function boot(doc: SpacesDoc) {
 
   titleInput.addEventListener('input', () => {
     doc.title = titleInput.value || 'Untitled'
-    document.title = `${doc.title} — Bento Spaces`
+    document.title = `${doc.title} — ${appConfig().appName}`
     touch()
   })
 
@@ -181,7 +181,7 @@ function boot(doc: SpacesDoc) {
       if (!next) return false
       doc = next
       titleInput.value = doc.title
-      document.title = `${doc.title} — Bento Spaces`
+      document.title = `${doc.title} — ${appConfig().appName}`
       render()
       touch()
       return true


### PR DESCRIPTION
Applies the naming decision from `docs/DECISIONS.md`. **Stacked on #39** —
it depends on K2's `configureApp` and K3's `--title` flag, so it sits at the
tip of the kernel stack.

## Changed (user-visible)
- Topbar + About wordmarks → `bento/slides` (peach slash kept)
- Window title suffix, `<title>`, NOTICE block, starter deck title
- The `About …` **i18n key** and its value in all 7 catalogs
- spaces: appName, `<title>`, build `--title` flag
- Docs, help page, THIRD_PARTY_NOTICES, CHANGELOG prose
- `site-src/landing` footer: `Bento/Suite` → **`bento/.`** — "Suite" was never
  the platform name, and this is the mark we actually settled on

**Consolidated while here:** the four hardcoded `— Bento Slides` title suffixes
now read `appConfig().appName`, so the app name has one source and the next
rename is a one-line change.

## NOT changed — deliberately
- **`appId: 'bento-slides'` and the `releases/slides/manifest.json` path.**
  Every shipped v1.0.8 file verifies the manifest's `app` field against that
  exact string. Changing either would make existing installs **reject every
  future update**. This is the one genuinely dangerous edit in a rebrand and
  it stays put.
- **The generator meta, the `Bento_Slides.bento.html` release filename, and the
  `bento-autosave` / `bento-lang` / `bento-offline` storage keys** — machine
  identifiers. Renaming buys nothing and would drop users' recovery snapshots
  and language preferences.
- **The starter deck's kicker labels stay uppercase.** Every kicker in the deck
  (`ONE FILE`, `LIVE DATA`, `STRUCTURED DATA`) is uppercase by design;
  lowercasing only the brand one would read as a bug rather than a decision.
  That's display typography, not the wordmark — happy to change all of them if
  you'd rather, but it's a deck redesign, not a rebrand.

## Verification
- Both apps typecheck and build; **both shells pass the splice conformance
  gate**; `SEEDS=100` rig ALL PASS.
- The inflated slides runtime still contains the **manifest app id, manifest
  URL and signing pubkey verbatim** — the update channel is provably intact.
- Titles render `bento/slides` and `bento/spaces`.
- Browser smoke: lowercase wordmark with the peach slash, unclipped at desktop
  width, correctly collapsing to the mark below 760px.