### PR TITLE
Docs: bento/vault design — personal server, dumb relay as a separate product

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -53,7 +53,34 @@ practical cost is discoverability, not legal exposure. Mitigation is the
 descriptor. Get real clearance before commercialising; a bare wordmark would
 be hard to register, a composite (mark + logo) much less so.
 
-## 2026-07-24 — bento/vault holds the map, not the keys
+## 2026-07-25 — bento/vault is a personal server; the relay is a separate product
+**Supersedes the "map, not the keys" entry below.** Vault is not an index and
+not a sync service — it is "cloud services without a cloud": your documents
+live on hardware you own (desktop / NAS / homelab) and it provides
+reachability, search, cross-document references and version history without
+any of it running on someone else's computer. The closer reference is
+Tailscale, not Dropbox.
+
+Vault and the **relay** are separate products with separate release trains.
+The relay is dumb infrastructure — rendezvous, an optional encrypted
+dead-drop, presence, nothing else — hosted on Cloudflare for the masses and
+self-hosted by serious users. Every actual service runs on the personal
+server; if the hosted relay ever accretes features, self-hosting becomes
+second-class and we lose the audience this is for.
+
+Consequences captured in `docs/vault-design.md`: the relay needs a portable
+(Docker) implementation because the current Worker+DO+hibernation stack is not
+realistically self-hostable; independent release trains require a versioned
+capability handshake (we can no longer control deploy order); background
+execution is unreliable on every platform so the protocol must be correct
+after unbounded offline periods; mobile uses iOS File Provider /
+Android DocumentsProvider rather than a background daemon; and the agent syncs
+a FOLDER, so no Bento app needs any changes. Retained from the superseded
+entry: the relay only ever sees ciphertext, and **export-to-standalone-file
+always works** — that invariant is what keeps "your data is a file you own"
+true while vault holds it.
+
+## 2026-07-24 — [SUPERSEDED] bento/vault holds the map, not the keys
 The document library must not become a custody service. It stores an encrypted
 index of what documents exist and how they reference each other; each document
 keeps its own encryption password and collab credentials. Compromising the

--- a/docs/blob-offload.md
+++ b/docs/blob-offload.md
@@ -1,0 +1,139 @@
+# Asset blob offload — design
+
+*Design document, July 2026. Status: **proposed** — nothing built. Companion
+to `relay-design.md` ("Wire efficiency") and `collab-design.md`. The immediate
+motivation is a live bug: media cannot be added during a collaboration session
+at all.*
+
+## The problem
+
+`crdt.ts` syncs an asset as a **whole-value LWW register** — one `set` op whose
+value is the entire base64 data URI. That runs into a hard ceiling:
+
+- An asset costs **~1.78× its binary size** on the wire (base64 twice — once
+  into the data URI, once over the ciphertext).
+- A Durable Object storage value caps near **2 MB** (measured, not documented:
+  2 MB stores, 2.5 MB throws inside `storage.put()`).
+- So the practical ceiling is **~1.05 MB of binary**, against a
+  `MEDIA_EMBED_BUDGET` of 8 MB.
+
+Raising the frame limit does not help — the Cloudflare WebSocket limit is now
+32 MiB, but *storage* is the binding constraint. No constant fixes this.
+
+Two further consequences, both fixed by this design:
+
+- **Snapshots carry every asset** (`session.snapshot()` serialises the whole
+  document), so a media-heavy deck can never snapshot — and since the relay
+  only prunes covered ops when a snapshot lands, its op log grows unbounded
+  for the room's whole 30-day life.
+- **No dedupe.** The same image referenced twice is stored twice; re-adding it
+  writes it again.
+
+## The constraint that shapes everything
+
+**The file must stay self-contained.** A `.bento.html` carries its assets as
+data URIs in `doc.assets` — that is the product. So this is a **transport
+change, not a format change**. `doc.assets` keeps holding data URIs; only the
+way an asset *travels between peers* changes. A receiving peer fetches the
+blob, decrypts, and materialises it back into `doc.assets` exactly as if it
+had arrived inline.
+
+Get this wrong and the single-file invariant breaks (`PLATFORM.md` §1).
+
+## Model
+
+**The op stops carrying bytes.** Above a threshold (~64 KB — below that,
+inlining is cheaper than the round trip) the differ emits a reference instead
+of the value:
+
+```
+set assets.<k> = { __blob: "<storage key>", hash, size, mime }
+```
+
+A couple of hundred bytes instead of megabytes.
+
+**Content-addressed, with a privacy wrinkle.** The natural id is
+`sha256(plaintext)`, which gives dedupe for free — but if the relay sees that
+id, it can tell two different rooms hold the same image. Use
+**`HMAC(roomKey, sha256(plaintext))`** as the storage key instead:
+deterministic *within* a room so dedupe works, opaque *across* rooms so
+nothing correlates. Cheap now, awkward to retrofit.
+
+**Blobs move over HTTP, not the WebSocket.** `PUT /b/<room>/<key>` and
+`GET /b/<room>/<key>`, backed by R2. This sidesteps the 2 MB storage-value
+limit entirely, gives resumable multipart upload for free, and R2 charges no
+egress. It is also exactly the vault dead-drop primitive — build it once
+(`vault-design.md`).
+
+**Upload before you emit.** An op must never reference a blob that is not yet
+fetchable. Belt and braces: a peer that receives a reference to an unknown
+blob fetches on demand and renders a placeholder meanwhile, which also covers
+replay and late joiners.
+
+**Encryption** uses the existing room key, same as frames. The relay stores
+ciphertext and can no more read a blob than a frame.
+
+## The risky seam
+
+This makes an op's meaning depend on an **external fetch**: applying an op
+becomes async and failable, which breaks the CRDT's "ops are pure data"
+property.
+
+Mitigations:
+
+- There is precedent in the engine — the `pending` buffer already defers ops
+  whose target node is unknown, so *deferred until resolvable* is an existing
+  shape rather than a new concept.
+- Keep `crdt.ts` changes minimal: the differ and apply path should treat
+  `{ __blob }` as an **opaque value**, with a separate resolution layer above
+  them doing the fetching and substitution. The CRDT should not know what a
+  blob is.
+- Extend `scripts/test-sync.ts` to cover blob-reference ops before merging
+  anything. (Note it currently only generates short strings — which is why it
+  missed the large-text stack overflow fixed in #47. Assume it will miss this
+  class too unless extended.)
+
+## Failure modes, stated plainly
+
+- **Blob upload fails, op already sent** — prevented by upload-before-emit,
+  but a crash between the two is possible. The receiver renders a placeholder
+  and the asset stays missing until the sender re-uploads on next connect.
+- **Blob expired, peer never fetched it** — a peer holds an element
+  referencing an asset nobody can produce. This is permanent divergence and it
+  needs a deliberate answer: render a placeholder with an honest "asset
+  unavailable" state, never a silent broken image. TTL should match the room's
+  30-day expiry, which is long enough that any peer who opened the document
+  and saved has the bytes in their own file.
+- **Storage quota reached** — refuse loudly with a code, exactly as frames now
+  do. Never drop silently; that class of bug cost us a permanent resend loop.
+
+## Sequence
+
+1. **Relay blob endpoints + R2.** `PUT`/`GET`, per-room namespace, TTL matched
+   to room expiry, size and quota caps from the start. Independently testable
+   with no client changes.
+2. **Client blob layer.** Content hashing, HMAC key derivation, an
+   IndexedDB-backed cache, fetch-on-demand with placeholder rendering.
+3. **Wire it into the differ** above the threshold; extend the convergence rig
+   in the same PR.
+4. **Chunked/resumable upload** for genuinely large single blobs.
+
+Steps 1 and 2 touch neither `crdt.ts` nor the document format, so they can
+proceed while other sync work lands.
+
+## Verify before building — do not trust these assumptions
+
+Today's session produced three confident conclusions that measurement
+overturned (the 1 MB frame limit, "chunking is unnecessary", and the RGA
+stack overflow). Treat the following the same way:
+
+- **Can a Worker stream a multi-MB blob to/from R2 without buffering it in
+  memory?** The 128 MB Worker memory limit is exactly the kind of constraint
+  that is not in the docs you would reason from.
+- **What is R2's actual behaviour under the free/paid plan** for many small
+  objects, and what do per-operation costs look like at realistic churn?
+- **Does `crypto.subtle` streaming decryption work** for a blob larger than
+  memory, or must it be chunked for that reason alone (independent of upload
+  resumability)?
+
+Answer these with a probe against a real deployment before the design hardens.

--- a/docs/relay-design.md
+++ b/docs/relay-design.md
@@ -171,17 +171,39 @@ change re-sends the whole asset — and **every snapshot re-sends every asset**,
 because `session.snapshot()` serialises the whole document. Content-addressing
 is what fixes this; chunking would not.
 
-### Not chunking
+### Chunking IS required — the binding constraint is storage, not the socket
 
-Cloudflare raised the WebSocket message limit from 1 MiB to **32 MiB**
-(2025-10-31), so a single frame comfortably carries the current 8 MB embed
-budget (14.2 MB on the wire). Chunking would solve a problem that no longer
-exists at these sizes.
+An earlier draft of this section argued chunking was unnecessary because
+Cloudflare raised the WebSocket message limit from 1 MiB to 32 MiB
+(2025-10-31). **That was wrong**, and testing against the real worker under
+standalone `workerd` is what caught it.
 
-If a single asset ever exceeds ~18 MB binary, the answer is a **resumable
-multipart upload to the blob store** — an ordinary, well-understood problem —
-not splitting CRDT ops across frames, which would require reassembly state and
-orphan collection inside a relay that cannot read its own payloads.
+The WebSocket limit is not the binding constraint. **A Durable Object storage
+value caps near 2 MB** — measured: 2 MB stores, 2.5 MB throws inside
+`storage.put()`. Worse, `webSocketMessage`'s blanket `.catch(() => {})`
+swallowed the throw, so frames between the old 1 MB cap and 32 MiB passed every
+check and then silently disappeared. Raising `MAX_FRAME` alone doesn't widen
+the pipe; it just moves where the payload is lost.
+
+`MAX_FRAME` is therefore pinned at **1.9 MB**, chosen so that *accepted* and
+*storable* mean the same thing. At the ~1.78× wire cost that carries roughly
+**1.05 MB of binary** — photographs, not video.
+
+So an 8 MB `MEDIA_EMBED_BUDGET` cannot travel as one op, and no constant will
+change that. Two ways out, and they are not exclusive:
+
+- **Content-addressed blobs (preferred).** The asset never enters the op log;
+  the op carries a hash and the encrypted blob goes to a store with no 2 MB
+  row limit (R2, or the dead-drop). Also fixes dedupe, replay and pruning.
+- **Chunked ops.** Split an asset across ≤ 1.9 MB frames and reassemble.
+  Needed if a payload must live in the op log at all, and needed *anyway* as
+  resumable multipart upload once a single blob is large. The costs are real:
+  reassembly state, and orphan collection for partial sets inside a relay that
+  cannot read its own payloads — mitigated because the chunk count is
+  plaintext envelope metadata, so the relay can GC incomplete sets on a TTL.
+
+Sequence blobs first (it removes the need for chunking in the common case),
+then chunk uploads for genuinely large single assets.
 
 ### Migration path
 
@@ -203,10 +225,11 @@ their own relays we cannot control deploy order at all. So:
 Recorded here because the recommendation is to grow `server/sync-worker/` into
 this relay rather than start beside it.
 
-- **`MAX_FRAME` is 1 MB, an outdated self-imposed limit** (the platform now
-  allows 32 MiB). Consequence: any asset over **~549 KB of binary** produces an
-  op the relay silently drops with `return` — no NACK, nothing the client can
-  see. Peers receive the element but not the asset, and render a broken image.
+- **`MAX_FRAME` was 1 MB and silent on overflow** — any asset over ~549 KB of
+  binary produced an op dropped with a bare `return`. FIXED: frames are now
+  refused with `{ ctl:'refused', code }`, and `MAX_FRAME` is 1.9 MB, pinned to
+  the ~2 MB Durable Object storage ceiling rather than the 32 MiB socket
+  limit (see *Chunking IS required*).
 - **Silent drops become a retry loop.** The peer's version vector stays behind,
   the `need`/`vv` catch-up asks for the missing op, the sender re-sends the
   same oversized frame from its log, and the relay drops it again — forever.

--- a/docs/relay-design.md
+++ b/docs/relay-design.md
@@ -289,6 +289,49 @@ one: per-vault and per-IP rate limits, a dead-drop size and TTL cap, relayed
 bandwidth metering, and a documented policy for what happens when a limit is
 hit (degrade, don't silently drop).
 
+### Making room creation cost something
+
+Room creation is unauthenticated by design — the token is trust-on-first-use,
+and there are no accounts because "no signup" is a product property we are not
+giving up. That means anyone can use the hosted relay as a free persistent
+pub/sub backend. The caps above bound what *one room* costs; they do nothing
+about *many rooms*.
+
+Layers, cheapest first:
+
+1. **Edge rate limiting** (Cloudflare WAF rule on the route, keyed by IP). No
+   code, blocks volumetric abuse before it reaches a Durable Object. Blunt —
+   NAT and IPv6 rotation defeat it — but it is free and stops the lazy case.
+2. **Signed rooms only for new rooms.** Legacy `r`-rooms stay permissive;
+   refuse to create new ones. An abuser must then generate a keypair, which is
+   cheap — but the *point* is that it yields a stable pubkey to meter, ban and
+   revoke against. Identity is more useful here than the crypto cost.
+3. **Proof of work at room CREATION.** A Hashcash-style stamp: find a nonce
+   such that `sha256(roomName || nonce)` has N leading zero bits. Bound to the
+   room name so work is not reusable. Verification is a single hash — the
+   asymmetry is the whole point.
+
+**Why proof of work fits here specifically.** It buys a cost curve without
+accounts, which is the one thing a CAPTCHA or a login would take away. And it
+is aimed correctly: creating *a* room should be free-ish, creating a hundred
+thousand should not. A normal user creates a room rarely — the cost is
+invisible. Attach it to every connection instead and you have merely taxed
+legitimate users and drained phone batteries.
+
+**Adaptive difficulty is the real lever.** Advertise the current difficulty in
+the capability handshake (`pow: { bits: 16 }`) and raise it under load. Normal
+operation ~16 bits is imperceptible; under attack 24+ bits costs an abuser
+seconds per room while a genuine user notices once.
+
+**Honest limits.** PoW does not stop a determined, funded abuser — it prices
+out bulk, not intent. It is also regressive on mobile (a phone burns battery
+where a botnet does not care), which is another argument for creation-only.
+And it must be a **capability, not a requirement**: a self-hosted relay serving
+one household should advertise `pow: null` and skip it entirely. Rejected for
+this role: Turnstile (Cloudflare-only, so it breaks the self-hosted story, and
+needs a browser origin that `file://` documents do not have) and accounts (the
+product does not have them and should not need them).
+
 **Metadata leakage, stated plainly** — the hosted relay operator can see
 public keys, IP addresses, connection times, blob sizes and traffic timing. It
 cannot see documents, titles, or the index. This should be written in the

--- a/docs/relay-design.md
+++ b/docs/relay-design.md
@@ -104,6 +104,122 @@ relay's entire job is routing envelopes and checking signatures.
 For v1 it is acceptable for web clients to always take the relayed path;
 documents are small and the dead-drop absorbs bulk transfer.
 
+## Wire efficiency
+
+The shipped collab relay carries roughly **1.78× the bytes it needs to**, and
+compresses nothing. Both are fixable, and the fixes belong in this design
+rather than being retrofitted after a second product depends on the format.
+
+### Where the overhead goes
+
+Tracing an 8 MB binary asset through today's path:
+
+| step | size | why |
+|---|---|---|
+| binary asset | 8.0 MB | |
+| → data URI in `doc.assets` | 10.7 MB | **base64 #1** — the document is JSON inside a `<script>` block, so binary *must* be text |
+| → JSON op batch | ~10.7 MB | negligible |
+| → AES-GCM ciphertext | ~10.7 MB | +16-byte tag |
+| → base64 for the `d` field | 14.2 MB | **base64 #2** |
+| → `JSON.stringify({p:1,i,d})` | 14.2 MB | |
+
+Two rounds of base64, each ×1.333, compounding to ×1.78.
+
+**Base64 #1 is inherent to the document and correct** — a `.bento.html` is JSON
+in a script tag. It is *not* inherent to the wire.
+
+**Base64 #2 is pure waste.** It exists only because frames are JSON text
+messages, and WebSocket has native binary frames.
+
+### Three fixes, in priority order
+
+**1. Compress before encrypting.** Nothing is compressed today: encrypting
+first makes the payload incompressible, and `permessage-deflate` cannot help
+either. Media is already compressed and won't benefit — but *ordinary editing
+traffic* (typing, moving elements, style changes) is JSON that compresses
+5–10×, and it is the overwhelming majority of frames in a live session. Both
+primitives already exist in the codebase: `deflateRawSync` in the build
+pipeline and `CompressionStream` in the browser (the shell loader already uses
+`DecompressionStream`). No new dependency.
+
+> **Documented caveat:** compress-then-encrypt leaks information through
+> ciphertext length — the CRIME/BREACH class. Here the attacker must already be
+> an authorised collaborator injecting chosen content and measuring frame
+> sizes, which is a weak position, but this must be a recorded decision rather
+> than an accident. Revisit if untrusted parties ever share a room.
+
+**2. Binary frames.** Sending the ciphertext as an `ArrayBuffer` removes
+base64 #2 — a flat **25% off every frame**, not just media. Requires: the IV
+carried as a length-prefixed header (or the leading 12 bytes) instead of a
+JSON field; the relay accepting non-string messages (it currently drops them
+outright — `typeof data !== 'string'` → `return`) and storing `Uint8Array`
+values; and signatures computed over bytes rather than `${i}.${d}`.
+
+**3. Content-addressed blobs.** Assets leave the op log entirely: the op
+carries a hash and a pointer, the encrypted blob is stored raw. This removes
+base64 #1 *from the wire* and fixes three other things at once — dedupe (the
+same image referenced twice is stored once), replay (a late joiner no longer
+downloads every historical asset), and pruning (see below). Same primitive as
+the dead-drop.
+
+Net effect: **×1.78 → ×1.33 → ×1.00.**
+
+### Assets are whole-value registers today
+
+`crdt.ts` emits a single `set` op whose value is the entire data URI, so any
+change re-sends the whole asset — and **every snapshot re-sends every asset**,
+because `session.snapshot()` serialises the whole document. Content-addressing
+is what fixes this; chunking would not.
+
+### Not chunking
+
+Cloudflare raised the WebSocket message limit from 1 MiB to **32 MiB**
+(2025-10-31), so a single frame comfortably carries the current 8 MB embed
+budget (14.2 MB on the wire). Chunking would solve a problem that no longer
+exists at these sizes.
+
+If a single asset ever exceeds ~18 MB binary, the answer is a **resumable
+multipart upload to the blob store** — an ordinary, well-understood problem —
+not splitting CRDT ops across frames, which would require reassembly state and
+orphan collection inside a relay that cannot read its own payloads.
+
+### Migration path
+
+The wire format cannot change under shipped clients, and once self-hosters run
+their own relays we cannot control deploy order at all. So:
+
+1. Wire revisions are advertised through the **capability handshake**
+   (`wire:1` text+base64, `wire:2` binary, `wire:3` binary+compressed).
+   Clients negotiate down; a new client on an old relay simply sends `wire:1`.
+2. **The relay accepts every past revision indefinitely.** Old frames are not
+   deprecated, they are just not produced any more.
+3. Compression is per-frame and self-describing, so a mixed room works: a
+   `wire:3` client and a `wire:1` client can share a room, each sending what
+   the other understands.
+4. Ship the relay side of a revision **before** any client produces it.
+
+## Current relay: known issues this design must fix
+
+Recorded here because the recommendation is to grow `server/sync-worker/` into
+this relay rather than start beside it.
+
+- **`MAX_FRAME` is 1 MB, an outdated self-imposed limit** (the platform now
+  allows 32 MiB). Consequence: any asset over **~549 KB of binary** produces an
+  op the relay silently drops with `return` — no NACK, nothing the client can
+  see. Peers receive the element but not the asset, and render a broken image.
+- **Silent drops become a retry loop.** The peer's version vector stays behind,
+  the `need`/`vv` catch-up asks for the missing op, the sender re-sends the
+  same oversized frame from its log, and the relay drops it again — forever.
+  Bandwidth burned on an op that can never land.
+- **Snapshots die the same way, and take pruning with them.** A snapshot
+  carries the whole document, so a deck over ~750 KB exceeds the cap. Since the
+  relay only prunes covered ops when a snapshot lands, **the op log then grows
+  unbounded for the room's 30-day life** — the decks that cost the most storage
+  are exactly the ones where pruning has silently stopped.
+- **Raising `MAX_FRAME` alone would be a mistake**: it multiplies the
+  worst-case abuse write by 32×. It must land together with a per-room storage
+  cap and byte-based rate limiting.
+
 ## The dead-drop (optional capability)
 
 A vault on a laptop is asleep most of the day. The dead-drop is an encrypted
@@ -170,6 +286,11 @@ relay rather than starting a second service beside it.
 
 ## Sequencing
 
+0. **Fix the shipped relay first** (see *Current relay: known issues*): raise
+   `MAX_FRAME` together with a per-room storage cap and byte-based rate
+   limits, and make oversize rejection loud instead of silent. This is a live
+   correctness bug plus an unbounded cost exposure, and it is independent of
+   everything below.
 1. **Capability handshake + identity verification.** Nothing else works
    without it, and retrofitting negotiation is the expensive mistake.
 2. **Announce / resolve / relayed frames.** Correct but slow: everything

--- a/docs/relay-design.md
+++ b/docs/relay-design.md
@@ -1,0 +1,181 @@
+# bento relay — design
+
+*Design document, July 2026. Status: **proposed** — nothing built. The relay
+is a product in its own right, separate from `bento/vault` (see
+`vault-design.md`) and with its own release train. Today's collab relay
+(`server/sync-worker/`) is a narrower ancestor of this; the two converge —
+see* Relationship to the collab relay *below.*
+
+## What it is
+
+Rendezvous plumbing. It lets a **client** (desktop UI, phone, web app) reach a
+**vault** (the personal server holding a user's documents) without either side
+needing a public address, a static IP, or a forwarded port.
+
+It is deliberately the dumbest component in the system. It never sees
+plaintext, never indexes, never searches, never renders, never runs a model.
+Every actual service runs on the vault.
+
+## The relay is always in the path
+
+Even when a homelabber runs the relay and the vault on the same box, clients
+still speak to the vault *through* the relay. This is a design decision, not
+an accident, and it buys four things:
+
+1. **The vault never accepts inbound connections.** It dials out to the relay
+   and keeps that channel open. No port forwarding, no DDNS, no inbound
+   firewall rule, nothing exposed to the internet. This is the single biggest
+   security and setup win available, and it is why the model works for
+   non-experts.
+2. **One client code path.** No "am I local or remote?" branching, no
+   discovery fallback matrix, no separate LAN protocol. A client is configured
+   with a relay URL and a vault identity; everything else is the same.
+3. **One auth model**, applied in one place.
+4. **Uniform testing** — the localhost deployment exercises the same protocol
+   as the hosted one.
+
+**Control plane always, data plane when necessary.** The relay always brokers
+identity, discovery and session setup. Bulk data should travel *directly*
+between client and vault whenever the two can reach each other (same LAN, or
+after successful hole-punching), falling back to relayed ciphertext when they
+cannot. Same split as Tailscale: coordination is centralised, traffic is not.
+
+## Identity and addressing
+
+Reuse the shipped owner→invite→member chain from `collab-design.md` rather
+than inventing a second one.
+
+- A vault has an **owner keypair** (ECDSA P-256). Its address commits to the
+  public key: `v` + base64url(sha256(ownerPubRaw)). The relay can therefore
+  verify trustlessly who may announce as that vault — exactly the trick the
+  `w`-rooms already use.
+- **Devices are members.** Each device mints its own keypair, never leaving
+  the device, and is admitted by an owner-signed delegation. Pairing a new
+  phone is the same operation as inviting a collaborator.
+- **Revocation** is the existing owner-signed `rev.${pub}` path.
+
+The relay verifies signatures to decide *who may connect to what*. It learns
+public keys and connection metadata; it learns nothing about content.
+
+## Wire protocol
+
+### Capability handshake — first message, always
+
+Vault and relay ship on **independent release trains**, and a self-hoster's
+relay may be a year older than the client talking to it. There is no way to
+enforce deploy order, so negotiation is mandatory from the first commit:
+
+```
+→ hello   { pv: 1, role: "vault"|"client", vault: "v<hash>", pub, sig }
+← welcome { pv: 1, caps: ["rendezvous", "presence", "deaddrop"], limits: {...} }
+```
+
+- Clients **degrade, never fail**, on a missing capability. No `deaddrop`
+  means "your phone reaches the vault when the vault is awake" — not an error.
+- **Never remove or repurpose a field**; only add. Unknown fields are ignored,
+  as everywhere else in Bento.
+- The client surfaces the relay's version and capabilities in its UI, so a
+  self-hoster can see *why* something is unavailable rather than filing a bug.
+
+### Operations
+
+| Message | From | Purpose |
+|---|---|---|
+| `announce` | vault | "I am online and reachable", with connection candidates |
+| `resolve` | client | "Is vault V online? How do I reach it?" |
+| `offer` / `answer` / `candidate` | both | Session negotiation, relayed verbatim |
+| `presence` | both | Which of my devices are currently connected |
+| `frame` | both | Opaque ciphertext, when a direct path could not be established |
+| `drop.put` / `drop.get` | both | Encrypted dead-drop, if the capability is offered |
+
+Everything carrying user content is ciphertext the relay cannot read. The
+relay's entire job is routing envelopes and checking signatures.
+
+### Data path
+
+- **Direct** — preferred. Native clients (desktop agent, mobile) can hole-punch
+  and speak directly to the vault. On a LAN this is trivially fast.
+- **WebRTC data channels** — the only P2P option available to *browser*
+  clients, since a web page cannot open arbitrary sockets. The relay acts as
+  the signalling channel.
+- **Relayed** — the fallback, and the only path when a symmetric NAT defeats
+  hole-punching. Ciphertext only, and metered (see *Abuse*).
+
+For v1 it is acceptable for web clients to always take the relayed path;
+documents are small and the dead-drop absorbs bulk transfer.
+
+## The dead-drop (optional capability)
+
+A vault on a laptop is asleep most of the day. The dead-drop is an encrypted
+blob store with a TTL that lets a phone fetch recent documents while the vault
+is unreachable. It is a **cache, not a service**: the vault remains the
+authority, and the relay still cannot read anything.
+
+Self-hosters on always-on hardware do not need it, which is exactly why it is
+a *capability* and not part of the core protocol.
+
+## What the relay must never do
+
+Search. Index. Store plaintext. Parse documents. Render. Run a model. Hold
+authoritative state. Know a document's title.
+
+The reason is structural, not ideological: if the hosted relay accretes
+features, the self-hosted relay cannot match it, self-hosting silently becomes
+second-class, and we lose the users this exists for. Keeping the relay tiny is
+also the only thing that makes maintaining two implementations affordable.
+
+## Two implementations
+
+- **Hosted** — Cloudflare Worker + Durable Object (+ R2 for the dead-drop).
+  Reference deployment; what `bento.page` runs, for people who will never run
+  a server.
+- **Portable** — a single Node or Go binary in a Docker image. One process,
+  one config file, no cloud account. This is what a homelabber runs, very
+  often on the same box as their vault.
+
+Both implement this document. Any behaviour that cannot be expressed in both
+does not belong in the relay.
+
+> **Prerequisite, worth doing before writing either:** verify whether the
+> existing `server/sync-worker/` actually runs under standalone `workerd`. It
+> depends on Durable Object bindings, the WebSocket Hibernation API and
+> SQLite-backed DO classes, and the r/selfhosted copy already claims it is
+> self-hostable. That test tells us whether the portable twin is a nice-to-have
+> or the only real self-host path.
+
+## Abuse, quotas, and honesty
+
+The hosted relay is a public service and will be abused. It needs, from day
+one: per-vault and per-IP rate limits, a dead-drop size and TTL cap, relayed
+bandwidth metering, and a documented policy for what happens when a limit is
+hit (degrade, don't silently drop).
+
+**Metadata leakage, stated plainly** — the hosted relay operator can see
+public keys, IP addresses, connection times, blob sizes and traffic timing. It
+cannot see documents, titles, or the index. This should be written in the
+user-facing docs, not buried here; "we can't read your files" is true and
+"we see nothing" is not.
+
+## Relationship to the collab relay
+
+`server/sync-worker/` already does a narrow version of this: blind ciphertext
+routing between peers, with key-committed room ids and signature-verified
+writes. Vault rendezvous is the same shape with a bigger job.
+
+**Recommendation: one relay, two capabilities** — collab rooms and vault
+rendezvous served by the same process, advertised through the same capability
+handshake. A self-hoster then runs one box, not two, and the identity chain is
+shared rather than duplicated. This argues for growing `sync-worker` into the
+relay rather than starting a second service beside it.
+
+## Sequencing
+
+1. **Capability handshake + identity verification.** Nothing else works
+   without it, and retrofitting negotiation is the expensive mistake.
+2. **Announce / resolve / relayed frames.** Correct but slow: everything
+   proxied. Enough to make a desktop agent reachable from a phone.
+3. **Direct path** (hole-punching, then WebRTC for browsers) as an
+   optimisation over a protocol that already works.
+4. **Dead-drop**, for the laptop-only profile.
+5. **Portable implementation** — no later than step 3, because the second
+   implementation is what keeps the first honest.

--- a/docs/vault-design.md
+++ b/docs/vault-design.md
@@ -1,0 +1,225 @@
+# bento/vault — design
+
+*Design document, July 2026. Status: **proposed** — nothing built. Companion
+to `collab-design.md` (which solves a different problem: live multiplayer on
+one document) and to `PLATFORM.md` (the invariants every Bento app honours).*
+
+## What it is, in one sentence
+
+**Cloud services without a cloud**: your documents live on hardware you own,
+and vault gives you the things people go to clouds for — reachability from
+every device, search across everything, cross-document references, shareable
+links, version history — without any of it running on someone else's computer.
+
+This is explicitly **not** a sync service. Dropbox and iCloud are the wrong
+comparison; the closer references are Tailscale (coordination server plus
+direct connections) and a homelab Nextcloud that someone else made painless.
+
+## Two products, not one
+
+The single most important boundary in this document.
+
+| | **bento/vault** | **bento relay** |
+|---|---|---|
+| What | The personal server: storage, index, search, services, clients | Rendezvous plumbing |
+| Runs on | Your desktop / NAS / homelab box | Cloudflare (hosted, for the masses) **or** self-hosted |
+| Knows | Everything — it holds your documents in the clear | Nothing — ciphertext and routing only |
+| Released | Its own train | Its own train |
+
+The relay is *infrastructure*, deliberately dumb. Vault is the *product*.
+Serious self-hosters run their own relay; everyone else uses the hosted one at
+`bento.page`. Either way they run the same vault.
+
+### The relay stays dumb — non-negotiable
+
+The relay does exactly three things:
+
+1. **Rendezvous** — help two devices that trust each other find each other
+   through NAT (signalling for a direct connection; fall back to relaying
+   ciphertext when hole-punching fails).
+2. **Optional encrypted dead-drop** — hold ciphertext blobs with a TTL so a
+   phone can fetch a document while the home machine is asleep (see
+   *Availability*).
+3. **Presence** — which of my devices are reachable right now.
+
+It never sees plaintext, never indexes, never searches, never renders, never
+runs a model. **Every actual service runs on the personal server.**
+
+The reason is not purity. If the hosted relay accretes features, the
+self-hosted relay can't match it, self-hosting silently becomes second-class,
+and we lose the audience this product is for. Keeping the relay tiny is also
+what makes maintaining two implementations affordable.
+
+### Two implementations, because one runtime isn't self-hostable
+
+The existing `server/sync-worker/` is Cloudflare-specific: Durable Object
+bindings, the WebSocket Hibernation API, and SQLite-backed DO classes. A
+homelabber cannot `docker run` that. `workerd` is the nominal answer but it is
+an unusual deployment and its parity on hibernation / SQLite-backed classes
+needs *testing*, not assuming.
+
+So the relay ships twice:
+
+- **Hosted**: Cloudflare Worker + DO (+ R2 for the dead-drop). The reference
+  deployment, what `bento.page` runs.
+- **Portable**: a plain Node or Go binary in a Docker image. One process, one
+  config file, no cloud account.
+
+Both implement the same wire protocol. This is affordable *only* because the
+relay is dumb — protect that.
+
+> **Action item, independent of vault:** the r/selfhosted copy already claims
+> the collab relay is self-hostable. Test that under standalone `workerd`
+> before anyone takes us up on it, and soften the claim or build the portable
+> twin.
+
+### Independent release trains force a negotiated protocol
+
+Today the app and the relay are deployed by the same person, so "deploy the
+relay before shipping the client" is a workable rule (and is written down in
+`CLAUDE.md`). **That rule dies here.** A self-hoster's relay might be a year
+old when a new vault client ships, and we have no way to make them upgrade.
+
+Therefore, from the first commit:
+
+- Every relay connection begins with a **capability handshake**: protocol
+  version plus a set of named capabilities (`rendezvous`, `deaddrop`,
+  `presence`). Clients degrade rather than fail — no dead-drop means "your
+  phone syncs when your desktop is awake", not an error dialog.
+- **Never remove or repurpose a wire field**; add. Unknown fields are ignored,
+  as everywhere else in Bento.
+- The client surfaces the relay's version and capabilities in the UI, so a
+  self-hoster can see *why* something is unavailable.
+
+## Availability: the hard problem
+
+A cloud is reachable because the server never sleeps. Your desktop closes its
+lid. This — not background execution — is the real constraint.
+
+Two deployment profiles, one protocol:
+
+- **Always-on box** (NAS, homelab, VPS): no dead-drop needed. Devices reach
+  the vault directly via rendezvous. This is what serious self-hosters get,
+  and it is the ideologically clean path.
+- **Laptop-only** (most people): the hosted relay offers an **encrypted
+  dead-drop** — the vault pushes ciphertext blobs of recently-changed
+  documents, and phones fetch from there when the laptop is asleep. The relay
+  still cannot read anything; it is a cache, not a service.
+
+The dead-drop is an *optional relay capability*, so the protocol does not
+depend on it and the self-hosted profile is not a degraded one.
+
+### Background execution: don't fight the platform
+
+Chrome freezes and discards background tabs; iOS suspends within seconds and
+grants only opportunistic `BGAppRefreshTask` windows; Android batches
+`WorkManager` jobs under Doze. Nothing reliable exists on any of them.
+
+The design consequence: **the protocol must be correct after an arbitrary,
+unbounded offline period.** No leases, no heartbeats, no "last seen"
+assumptions. Sync is triggered by foreground, by explicit action, and by
+pre-suspension flush (`freeze` / `pagehide` / `applicationDidEnterBackground`);
+anything the OS grants beyond that is a bonus that may never arrive.
+
+The desktop agent is the exception and the reason it exists: a real background
+process on a machine that is already awake.
+
+## Clients
+
+- **Desktop agent** — the heart of "set and forget". A tray app that watches a
+  folder, encrypts client-side, maintains the index, and serves the vault.
+  Leaning **Tauri** (small binary, tray, filesystem watching, settings UI in
+  one codebase), with the same core compiled **headless** for NAS/server use.
+- **Mobile** — *not* a background daemon; that fight is unwinnable. Use the
+  platform-sanctioned providers instead: **iOS File Provider extension** and
+  **Android DocumentsProvider (SAF)**. Documents appear in the system file
+  browser, the OS materialises them on demand and wakes the extension when the
+  user touches them. Plus sync-on-foreground in the app itself.
+- **Web** — the existing single-file apps, unchanged (see below).
+
+## The apps need no changes
+
+If the agent syncs a **folder**, then slides, spaces and dash require zero
+integration work. You save a `.bento.html` into `~/Bento` exactly as you do
+today and it is in the vault. The file remains the interface.
+
+This is deliberate: vault can be built entirely in parallel with the app
+fan-out, blocking nothing and coupling to no app's format.
+
+## Data model (sketch)
+
+- **Blobs**: content-addressed, client-side encrypted, chunked so a change
+  moves a delta rather than a whole document. R2 or any S3-compatible store
+  for the dead-drop; plain filesystem on the vault itself.
+- **Index**: the authority on what documents exist, their `docId`, titles,
+  timestamps, tags and references. Small enough to sync eagerly. Concurrent
+  device edits reconcile with LWW registers plus tombstones — **do not** reach
+  for the slides CRDT here; a file list is not a rich-text document.
+- **Identity**: reuse the shipped owner→invite→member key chain from
+  `collab-design.md`. A new device is paired the same way a collaborator is
+  invited; per-device keys never leave the device.
+
+## Search and local models
+
+The differentiator, and the reason to design the index for it from day one
+rather than retrofitting: a vault that indexes every document can answer
+questions across all of them **locally** — including via a local model
+(Ollama is already referenced in the README). "Find the deck where I showed Q3
+churn", "summarise these six notes."
+
+No cloud can offer this without taking your data. It also reframes mobile:
+the phone is not syncing a library, it is *querying your box* — far less data
+movement, and a query is a foreground action by definition, so the background
+problem evaporates.
+
+Implication for the index: store extracted plain text per document alongside
+the metadata, and leave room for an embedding vector per document (or per
+block) even if v1 only does keyword search.
+
+## Invariants
+
+1. **Export always works.** Any document is exportable as a standalone
+   `.bento.html` from any client at any time. This is what keeps "your data is
+   a file you own" true while vault holds it. Without this we have built
+   Notion with extra steps.
+2. **The relay only ever sees ciphertext.** Both deployments, no exceptions.
+3. **Vault is optional.** Every Bento app works fully with no vault, forever.
+   Vault is a convenience over something that already functions alone.
+4. **Losing the vault loses convenience, not work** — the files are still
+   files.
+
+## Threat model (first pass)
+
+- **Hosted relay operator (us)** — sees ciphertext, blob sizes, timing, device
+  presence, and IPs. Cannot read documents, titles, or the index. Metadata
+  leakage is real and should be documented honestly, not hand-waved.
+- **Network attacker** — sees TLS. Rendezvous must not leak the index.
+- **Stolen device** — per-device keys are revocable via the existing
+  owner-signed revocation path; a revoked device loses access to future
+  content but obviously retains what it already had.
+- **Compromised vault host** — total loss for that user; the vault holds
+  plaintext by design. Document this plainly. Full-disk encryption is the
+  user's responsibility, as with any personal server.
+
+## Out of scope for v1
+
+Real-time collaboration through the vault (that is `collab-design.md`'s job
+and it already works), team/multi-user vaults, public web publishing, mobile
+editing beyond what the apps already do in a browser, and Windows/Linux
+desktop builds before macOS is proven.
+
+## Sequencing
+
+1. **Desktop agent, one folder, macOS, always-on-box profile.** No dead-drop,
+   no mobile. This alone delivers the promise for daily personal use and
+   proves the data model.
+2. **Relay: capability handshake + rendezvous**, hosted implementation first,
+   portable twin immediately after (not "later" — the second implementation is
+   what keeps the first honest).
+3. **iOS File Provider** against a data model the agent has already proven.
+4. **Dead-drop** for the laptop-only profile.
+5. Search, then local-model queries.
+6. Everything else.
+
+Step 1 needs no changes to any Bento app, so it can proceed alongside the
+spaces/dash fan-out without contention.

--- a/docs/vault-design.md
+++ b/docs/vault-design.md
@@ -30,6 +30,10 @@ The relay is *infrastructure*, deliberately dumb. Vault is the *product*.
 Serious self-hosters run their own relay; everyone else uses the hosted one at
 `bento.page`. Either way they run the same vault.
 
+The relay's own spec is `relay-design.md`. Note that **the relay is always in
+the path** — clients never speak to a vault directly, even when both run on
+the same box — so the vault never accepts an inbound connection.
+
 ### The relay stays dumb — non-negotiable
 
 The relay does exactly three things:


### PR DESCRIPTION
Captures the vault model we worked through, and **supersedes** the earlier
"map, not the keys" decision, which said the opposite.

Docs only — nothing built.

## The model
**"Cloud services without a cloud."** Documents live on hardware you own;
vault provides reachability, search, cross-document references and history
without any of it running on someone else's computer. Tailscale is the
reference, not Dropbox.

## The boundary that matters
**Vault and the relay are separate products with separate release trains.**
The relay is deliberately dumb — rendezvous, an optional encrypted dead-drop,
presence, nothing else. Hosted on Cloudflare for the masses, self-hosted by
serious users. Every actual service runs on the personal server. If the hosted
relay ever accretes features, self-hosting silently becomes second-class and
we lose the audience this product is for.

## Consequences the doc works through
- **The relay needs a portable Docker implementation.** The current
  Worker + DO + hibernation stack isn't realistically self-hostable, and the
  r/selfhosted copy *already claims it is*. Flagged as an action item: test it
  under standalone `workerd` before someone takes us up on it, then either
  soften the claim or build the twin.
- **Separate release trains kill the "deploy the relay first" rule** — a
  self-hoster's relay might be a year old. Requires a versioned capability
  handshake from the first commit, with clients degrading rather than failing.
- **Background execution is unreliable everywhere** (Chrome tab freezing, iOS
  suspension, Android Doze), so the protocol must be correct after unbounded
  offline periods. Mobile uses **iOS File Provider / Android
  DocumentsProvider** — OS-driven materialisation — rather than a doomed
  background daemon.
- **The agent syncs a folder**, so slides/spaces/dash need zero changes and
  vault can be built in parallel with the fan-out, blocking nothing.
- **Availability, not sync, is the hard problem**: always-on boxes need no
  dead-drop; laptop-only users get one, holding ciphertext only.

## Invariants
Relay sees ciphertext only · vault is always optional · and
**export-to-standalone-`.bento.html` always works** — that last one is what
keeps "your data is a file you own" true while vault is holding it.

Includes a first-pass threat model (honest about metadata leakage and about a
compromised vault host being total loss), an explicit out-of-scope list, and a
sequencing plan starting with a macOS desktop agent that needs no app changes.