### PR TITLE
Copyright: The Bento/Suite authors → The Bento authors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "bento",
-  "owner": { "name": "The Bento/Suite authors", "url": "https://bento.page" },
+  "owner": { "name": "The Bento authors", "url": "https://bento.page" },
   "plugins": [
     {
       "name": "bento-slides",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The Bento/Suite authors
+Copyright (c) 2026 The Bento authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ through the signed update channel.
 ## License
 
 Bento is open source under the [MIT License](LICENSE) — all software here is
-MIT, © 2026 The Bento/Suite authors. Bundled runtime components (reveal.js,
+MIT, © 2026 The Bento authors. Bundled runtime components (reveal.js,
 Moveable, Selecto) are MIT; the embedded typefaces (Fraunces, Instrument Sans)
 are OFL; gallery imagery is public-domain (see
 `scripts/gallery-photos/SOURCES.md`). Each component keeps its own license.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-bento/slides is MIT-licensed (© 2026 The Bento/Suite authors; see `LICENSE`).
+bento/slides is MIT-licensed (© 2026 The Bento authors; see `LICENSE`).
 The shippable single-file shell (`Bento_Slides.bento.html`) bundles the
 following third-party open-source components. Their license terms require that
 these notices accompany copies, so the same text is embedded as a `NOTICE`

--- a/kernel/src/anim.ts
+++ b/kernel/src/anim.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Bento's animation engine — the in-house replacement for GSAP, sized to
 // exactly what the presenter and editor use:
 //   anim.to / anim.fromTo(target, vars) with channels:

--- a/kernel/src/app.ts
+++ b/kernel/src/app.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Per-app identity for the kernel. Every Bento app calls configureApp() once,
 // first thing at boot, before any kernel module is used.
 //

--- a/kernel/src/autosave.ts
+++ b/kernel/src/autosave.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Local auto-save + lightweight version history, backed by IndexedDB.
 //
 // Two concerns, one store:

--- a/kernel/src/charts.ts
+++ b/kernel/src/charts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // charts-lite: Bento's own chart engine (replaces ECharts — see git history).
 //
 // A `chart` element stores a plain-JSON option in the ECharts option SHAPE —

--- a/kernel/src/doc.ts
+++ b/kernel/src/doc.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The kernel document envelope — the ONLY doc fields kernel modules may read.
 // Every app's document model (bento/slides, bento/spaces, …) satisfies this
 // structurally; the kernel never sees an app's content shape (slides, blocks,

--- a/kernel/src/i18n.ts
+++ b/kernel/src/i18n.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Internationalization, Bento-sized: a ~1KB t() with English-string-as-key
 // (gettext philosophy — the source stays readable, fallback is free), catalogs
 // compiled into the bundle (self-containment: nothing is fetched), and locale

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Self-saving: a Bento file writes itself back to disk with updated data.
 //
 // At boot (before the app mutates the DOM) we deep-clone the document. On save

--- a/kernel/src/update.ts
+++ b/kernel/src/update.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Self-update: a shipped Bento file asks the release origin whether a newer
 // app shell exists — automatically at launch (per-browser opt-out in the
 // About dialog) or on demand — and rebuilds itself as "same document, newer

--- a/plugins/bento-slides/.claude-plugin/plugin.json
+++ b/plugins/bento-slides/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Author Bento presentations — self-contained .bento.html decks with morph transitions, live charts and speaker notes. Starts from nothing: downloads the latest Bento app automatically.",
   "version": "1.0.6",
   "author": {
-    "name": "The Bento/Suite authors",
+    "name": "The Bento authors",
     "url": "https://bento.page"
   },
   "homepage": "https://bento.page",

--- a/scripts/build-404-deck.mjs
+++ b/scripts/build-404-deck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The 404 page's punchline: a tiny, fully working deck. Spliced from the
 // built shell like the gallery decks; template:true so every open is fresh.
 //

--- a/scripts/build-announcement-deck.mjs
+++ b/scripts/build-announcement-deck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // U1: the launch announcement IS a deck. This file becomes the Show HN link
 // target and the press kit. PRIVATE until launch — built into working/, not
 // wired into release.mjs (wire it at T-0, e.g. to site/hello.bento.html).

--- a/scripts/build-example-decks.mjs
+++ b/scripts/build-example-decks.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The gallery decks — four distinct art directions distilled from
 // Awwwards Site-of-the-Year style FAMILIES (immersive dark tech,
 // editorial typography, premium minimal commerce, playful toy-like).

--- a/scripts/build-guestbook.mjs
+++ b/scripts/build-guestbook.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // U2: the public guestbook deck — one live-collab file anyone can open and
 // sign. Minting fresh credentials IS the reset mechanism ("epochs, not
 // moderation" — see working/guestbook-design.md). The deck definition lives

--- a/scripts/build-landing.mjs
+++ b/scripts/build-landing.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Assemble the bento.page landing page: inject the deck's embedded typefaces
 // (Fraunces Black + Instrument Sans, from slides/src/fontdata.ts) into the
 // template so the page is fully self-contained — no external requests, same

--- a/scripts/build-qr-page.mjs
+++ b/scripts/build-qr-page.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // "This QR code is a presentation" — builds site/q/index.html from
 // site-src/q.html: composes a tiny deck, deflates it into a base64url
 // payload (the QR encodes URL#payload — the deck literally lives in the

--- a/scripts/guestbook-archive-pull.mjs
+++ b/scripts/guestbook-archive-pull.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Pull the daemon's KV archives down to disk so nothing is lost to the 90-cap.
 //
 // The daemon prunes KV `archives/` to the newest 90. At the launch 15-min roll

--- a/scripts/guestbook-archivist.ts
+++ b/scripts/guestbook-archivist.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Headless guestbook archivist: joins the room READ-ONLY (sends nothing),
 // replays the encrypted op log through the real CRDT engine, and writes an
 // archive file containing what people actually signed — not the pristine

--- a/scripts/guestbook-deck.mjs
+++ b/scripts/guestbook-deck.mjs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The guestbook deck definition, shared by the local builder
 // (scripts/build-guestbook.mjs) and the Cloudflare daemon
 // (server/guestbook-daemon/) so epochs look identical wherever they are

--- a/scripts/guestbook-owner-deck.mjs
+++ b/scripts/guestbook-owner-deck.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Build an OWNER deck for the CURRENT live guestbook epoch, on demand — open it
 // to moderate (People panel → Remove). The daemon mints epochs server-side and
 // stashes the owner key in KV; this fetches it (admin-gated) and splices it into

--- a/scripts/guestbook-roll.mjs
+++ b/scripts/guestbook-roll.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The guestbook daemon's one command — a COMPLETE, load-hardened epoch roll.
 //
 //   node scripts/guestbook-roll.mjs --snapshot-only

--- a/scripts/keygen.mjs
+++ b/scripts/keygen.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // One-time: generate the Bento release signing keypair (ECDSA P-256).
 //
 //   node scripts/keygen.mjs [key-file]

--- a/scripts/make-og.mjs
+++ b/scripts/make-og.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Compose the social share card (og:image) as a self-contained SVG, using the
 // SAME embedded typefaces as the deck/landing so it's on-brand. Writes an SVG;
 // it's rasterised to site-src/og.png in the browser (no CLI rasteriser is

--- a/scripts/postbuild-compress.mjs
+++ b/scripts/postbuild-compress.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Self-extracting shell: compress the built runtime so the file on disk is
 // ~half the size, with zero feature loss.
 //

--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The ONE publish step for bento.page.
 //
 // `site/` is the assembled deploy tree: AUTHORED sources (landing, guestbook

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Cut a bento/slides release: build the shell, sign the manifest, and
 // assemble the complete static site for bento.page into ./site/.
 //

--- a/scripts/reseed-guestbook.mjs
+++ b/scripts/reseed-guestbook.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Keep the LIVE guestbook daemon on the current shell.
 //
 // bento.page/guestbook.bento.html is served by the Cloudflare daemon from its

--- a/scripts/shell-gate.mjs
+++ b/scripts/shell-gate.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // CONFORMANCE GATE — old updaters are frozen code; every shell must satisfy
 // the splice contract they rely on (see postbuild-compress.mjs): plaintext
 // #bento-doc, regex-extractable, balanced script tags, and a v0.1.0-style

--- a/scripts/sign-release.mjs
+++ b/scripts/sign-release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Sign a bento/slides release: produce the manifest.json that shipped files
 // poll (on user request only) to learn about updates.
 //

--- a/scripts/test-sync.ts
+++ b/scripts/test-sync.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-sync M0 convergence rig.
 //
 //   node scripts/test-sync.ts        (Node ≥ 23.6 strips types natively)

--- a/server/guestbook-daemon/src/worker.js
+++ b/server/guestbook-daemon/src/worker.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-guestbook-daemon — the sustainable home of the public guestbook.
 // Storage: Workers KV (R2 is not enabled on this account; KV fits — values
 // are ~500 KB against a 25 MB limit, archives pruned to the newest 90).

--- a/server/sync-worker/src/worker.js
+++ b/server/sync-worker/src/worker.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-sync relay — the first (and only) Bento server code. One Durable
 // Object per docId room. The relay is BLIND by design:
 //

--- a/site-src/landing.html
+++ b/site-src/landing.html
@@ -907,7 +907,7 @@ window.bento.loadDoc(json) <span class="c">// write, undoable</span></div>
   <div class="wrap">
     <div><b>Privacy, precisely:</b> this page loads nothing from anyone. The optional collaboration relay sees ciphertext, connection timing, and a hash of your room key. Never your content, never your name.</div>
     <div>Set in <b>Fraunces</b> &amp; <b>Instrument Sans</b> (OFL), the same faces that travel inside every deck. Built on reveal.js, Moveable, Selecto (MIT) and engines of our own.</div>
-    <div><b>Open source, MIT.</b> All of Bento's software is MIT-licensed, © 2026 The Bento/Suite authors. Auditable and forkable. · <a href="https://github.com/nyblnet/bento" style="color:var(--peach,#FF9E8A);font-weight:600;text-decoration:none" target="_blank" rel="noopener">GitHub &#8599;</a></div>
+    <div><b>Open source, MIT.</b> All of Bento's software is MIT-licensed, © 2026 The Bento authors. Auditable and forkable. · <a href="https://github.com/nyblnet/bento" style="color:var(--peach,#FF9E8A);font-weight:600;text-decoration:none" target="_blank" rel="noopener">GitHub &#8599;</a></div>
     <div><a href="/agents.md" style="color:var(--mist);text-decoration:none">agents.md</a> · <a href="/guestbook/" style="color:var(--mist);text-decoration:none">the Guestbook</a></div>
     <div>© 2026 bento.page · <b>Bento/Slides</b> is the first app of Bento/Suite. <b>Bento/Docs</b> and <b>Bento/Sheets</b> are coming soon.</div>
   </div>

--- a/slides/index.html
+++ b/slides/index.html
@@ -13,7 +13,7 @@
     <title>bento/slides</title>
     <!--
       NOTICE — bento/slides
-      MIT License — © 2026 The Bento/Suite authors
+      MIT License — © 2026 The Bento authors
       Full license text: the LICENSE file in the source tree, or https://bento.page
       Source & third-party notices: https://bento.page
 

--- a/slides/src/anim.ts
+++ b/slides/src/anim.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: the animation engine lives in the shared kernel now (kernel/src/
 // anim.ts). This path stays alive so slides code (and in-flight branches)
 // keeps importing './anim' unchanged — see docs/PLATFORM.md §9.

--- a/slides/src/autosave.ts
+++ b/slides/src/autosave.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: the IndexedDB auto-save/version store lives in the shared kernel now
 // (kernel/src/autosave.ts). This path stays alive so slides code keeps
 // importing './autosave' unchanged — see docs/PLATFORM.md §9.

--- a/slides/src/charts.ts
+++ b/slides/src/charts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: the charts-lite engine lives in the shared kernel now
 // (kernel/src/charts.ts). It reads only {w, h, option}; slides' ChartElement
 // satisfies that structurally, so call sites are unchanged.

--- a/slides/src/editor/bezier.ts
+++ b/slides/src/editor/bezier.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Exact cubic-bezier path model for true pen-tool editing. Unlike the old
 // Catmull-Rom approach (which SAMPLED the rendered curve back into approximate
 // anchors and re-smoothed on every edit — lossy, drifting, no real handles),

--- a/slides/src/editor/beziereditor.ts
+++ b/slides/src/editor/beziereditor.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // True pen-tool editing for curve (path) shapes. Each on-curve anchor shows its
 // in/out control handles; dragging a handle bends the curve exactly (the path
 // IS the handles — no sampling, no re-smoothing, no drift). Smooth anchors

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The editing canvas: renders the current slide at fit-to-window scale and
 // wires Moveable (drag/resize/rotate/snap) + Selecto (click & rubber-band
 // selection) + contenteditable text editing on top of it.

--- a/slides/src/editor/clipboard.ts
+++ b/slides/src/editor/clipboard.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // System-clipboard copy/paste: external objects (images, text) onto the canvas,
 // and Bento elements or whole slides between decks (across tabs/windows).
 //

--- a/slides/src/editor/comments.ts
+++ b/slides/src/editor/comments.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Review comments. Threads live in Slide.comments (saved with the file,
 // never rendered in present/print). The editor shows them as small numbered
 // markers on the canvas — at the anchored element's top-right corner, or

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Editor shell: topbar, slide sidebar, canvas, properties panel, keyboard
 // shortcuts, save & present wiring.
 

--- a/slides/src/editor/lineedit.ts
+++ b/slides/src/editor/lineedit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Direct on-canvas editing for line / curved-line / connector SHAPES — the
 // intuitive alternative to resizing a box and rotating it. A selected line
 // shows two draggable endpoint handles; a curve (path) shows its anchor points

--- a/slides/src/editor/markdown.ts
+++ b/slides/src/editor/markdown.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Lightweight markdown affordances for text editing. Two entry points:
 // - autoformatAtCaret: called on every input; when the text just before the
 //   caret completes an inline pattern (**bold**, *italic*, `code`, ~~strike~~)

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Right-hand properties panel. Shows slide properties when nothing is
 // selected, element properties otherwise. Bursts of 'input' events collapse
 // into a single undo checkpoint.

--- a/slides/src/editor/patheditor.ts
+++ b/slides/src/editor/patheditor.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Visual motion-path editing — HYBRID bezier. The path of an fx.loop
 // 'motion-path' is a set of draggable waypoints. By default a waypoint stays
 // AUTO: its in/out tangents are auto-computed (Catmull-Rom) so the trajectory

--- a/slides/src/fontdata.ts
+++ b/slides/src/fontdata.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Embedded display face for the starter deck: Fraunces Black (latin subset,
 // 34.6KB woff2). SIL Open Font License 1.1 — free to embed and redistribute;
 // the face travels inside every saved document via doc.fonts + doc.assets.

--- a/slides/src/fonts.ts
+++ b/slides/src/fonts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Font utilities: the curated system-stack choices offered in the editor,
 // and @font-face injection for fonts embedded in the document's asset table.
 

--- a/slides/src/i18n.ts
+++ b/slides/src/i18n.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: the i18n ENGINE lives in the shared kernel (kernel/src/i18n.ts);
 // the CATALOGS are this app's string data and stay here in ./i18n/*.ts.
 //

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // German — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Spanish — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // French — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Italian — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Japanese — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Simplified Chinese — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Traditional Chinese (Taiwan conventions) — machine-drafted, native review welcome
 import type { Catalog } from '../i18n'
 

--- a/slides/src/icons.ts
+++ b/slides/src/icons.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Minimal inline icon set (lucide-style, stroke = currentColor). No deps.
 
 const svg = (body: string, viewBox = '0 0 24 24') =>

--- a/slides/src/main.ts
+++ b/slides/src/main.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Boot sequence. Order matters: capture the pristine document BEFORE any DOM
 // mutation — the captured copy is what gets re-serialized on save.
 

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The bento/slides document model. This JSON is what lives inside the
 // <script type="application/bento+json"> block of a .bento.html file.
 

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Present mode: a fullscreen Reveal.js overlay generated from the model.
 // Slides marked transition:'morph' use GSAP Flip to animate elements whose
 // ids match across the two slides (PowerPoint "Morph" behaviour).

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Shared model → DOM renderer. One code path draws slides everywhere:
 // editor canvas, sidebar thumbnails, and Reveal.js sections.
 

--- a/slides/src/save.ts
+++ b/slides/src/save.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: self-save + bento/enc encryption live in the shared kernel now
 // (kernel/src/save.ts). This path stays alive so slides code keeps importing
 // './save' unchanged — see docs/PLATFORM.md §9.

--- a/slides/src/screens.ts
+++ b/slides/src/screens.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The speaker-notes window. It outlives any single present session: the editor
 // opens it (its own user gesture) BEFORE presenting, and present mode adopts it.
 // Opening the notes and going fullscreen are then two separate gestures, so

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The starter deck — what a freshly built bento/slides file opens with.
 //
 // It is the product demo, the launch asset and the feature tour in one: every

--- a/slides/src/store.ts
+++ b/slides/src/store.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 import type { BentoDoc, Slide, SlideElement } from './model'
 
 export type StoreEvent =

--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-sync M0 — the CRDT engine. Pure data, no DOM, no imports beyond the
 // model types: the same file runs in the browser session layer and in the
 // node convergence rig (scripts/test-sync.ts, node --experimental-strip-types).

--- a/slides/src/sync/online.ts
+++ b/slides/src/sync/online.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-sync online transport — E2EE WebSocket to the blind relay
 // (server/sync-worker). Every session frame is AES-GCM encrypted with the
 // room key from doc.collab.key; the relay sees ciphertext, fan-out routing,

--- a/slides/src/sync/session.ts
+++ b/slides/src/sync/session.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // bento-sync session — the bridge between the CRDT engine (crdt.ts) and the
 // running editor. Owns: the differ hook on the store, transports (same-machine
 // BroadcastChannel always; an online relay transport can be added), presence,

--- a/slides/src/update.ts
+++ b/slides/src/update.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: signed self-update lives in the shared kernel now
 // (kernel/src/update.ts). App identity (manifest url, manifest `app` id) is
 // supplied by configureApp() in main.ts — see docs/PLATFORM.md §6, §9.

--- a/spaces/src/i18n.ts
+++ b/spaces/src/i18n.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Facade: the i18n ENGINE lives in the shared kernel; CATALOGS are per-app
 // string data and live here. This module registers them at import time and
 // re-exports the engine, so registration is guaranteed to precede the first

--- a/spaces/src/main.ts
+++ b/spaces/src/main.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // Boot sequence for bento/spaces. Order matters: configure the app, then
 // capture the pristine document BEFORE any DOM mutation — the captured copy
 // is what gets re-serialized on save.

--- a/spaces/src/model.ts
+++ b/spaces/src/model.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Bento/Suite authors
+// Copyright (c) 2026 The Bento authors
 // The bento/spaces document model. This JSON is what lives inside the
 // #bento-doc block — the format IS the product (docs/PLATFORM.md §3).
 //


### PR DESCRIPTION
The last place the retired **`Bento/Suite`** name survived. Split out from the
website rebrand (#44) as requested — the two touch `landing.html` at lines ~350
apart, so they merge in either order.

## What
`Copyright (c) 2026 The Bento/Suite authors` → `The Bento authors`, in
**LICENSE and 75 source files**. Pure mechanical string replacement: the diff is
exactly **76 files, 76 insertions, 76 deletions** — one line each, nothing else.

## Why atomic
An attribution that disagrees with `LICENSE` is worse than one that's merely
dated, so every occurrence moves together or none does. That's the whole reason
this wasn't bundled into a website tweak.

## On the capitalisation
**"Bento", not "bento"** — this is a legal attribution naming the authors, not a
wordmark usage. The lowercase forms (`bento/.`, `bento/slides`) are the marks; a
copyright line is prose, and punctuation in a holder string invites trouble.
One `sed` away from lowercase if you'd rather.

## Verified
- Zero occurrences of the old string remain; LICENSE updated.
- Both touched `.json` files still parse.
- slides and spaces typecheck and build.
- Both shells pass the splice conformance gate; `SEEDS=100` CRDT rig ALL PASS.