### PR TITLE
Fix: large text edits crashed live collab (stack overflow in the text RGA)

### DIFF
--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -1364,7 +1364,15 @@ function applyTxtToState(st: TxtState, op: TxtOp): boolean {
     // carry higher lamports than their anchors)
     while (idx < st.toks.length && tokCmp(st.toks[idx].id, newId) > 0) idx++
     const toks: TxtTok[] = grp.toks.map((t, i) => ({ id: `${op.l}.${op.a}.${i}`, t }))
-    st.toks.splice(idx, 0, ...toks)
+    // NOT splice(idx, 0, ...toks): tokenize is per-character, so a large text
+    // element is hundreds of thousands of tokens, and spreading them as call
+    // ARGUMENTS overflows the stack (~200KB of text was enough). That threw
+    // inside diff(), so session.flush() failed and NOTHING synced for the rest
+    // of the session — not just the oversized element. Splice in place without
+    // a spread instead; cost is one array copy.
+    st.toks = idx === st.toks.length
+      ? st.toks.concat(toks)
+      : st.toks.slice(0, idx).concat(toks, st.toks.slice(idx))
     if (st.pd?.length) {
       const pend = new Set(st.pd)
       for (const t of toks)


### PR DESCRIPTION
A text element of roughly **200 KB or more broke live collaboration entirely**
— and not just for that element. Surfaced by a background agent while it was
doing unrelated work; I reproduced and bisected it against the real engine
before fixing.

## Cause
`tokenize()` is per-character, so ~200 KB of text is ~200,000 tokens.
`applyTxtToState` inserted them with:

```js
st.toks.splice(idx, 0, ...toks)
```

Spreading 200k+ values as **call arguments** overflows V8's stack. Measured
against the real engine: 100 KB fine, 200 KB and above throw `RangeError`.

## Why it was so damaging
The throw happens inside `diff()`, which `session.flush()` calls on every
debounced edit. So once a document contained one large text element,
**`flush()` threw and nothing synced for the rest of the session** — every
later edit, on any slide, silently lost to collaborators.

And it's invisible: no error surfaces, peers simply stop receiving. A user
would experience it as "collaboration randomly stopped working."

## Fix
Splice without a spread — `slice`/`concat` instead. One extra array copy on an
operation that already allocates the token array.

## Verified
- Repro passes at 200 / 300 / 500 KB.
- **Convergence rig `SEEDS=300` ALL PASS** (46,402 checks) — the mandatory gate
  for any `crdt.ts` change.
- Plus a targeted large-text convergence test the rig doesn't cover (it uses
  short strings): two replicas concurrently editing a 300 KB element converge
  to identical html with **both contributions preserved**.
- `tsc -b` clean.

## Scope
One line of behaviour change in `crdt.ts`, deliberately kept minimal given
it's the highest-risk file in the repo. Independent of the relay work in #43
and the client work in #45 — this would still break collab with both of those
merged.

Worth noting the rig didn't catch this because it only generates short
strings. A follow-up worth considering: add a large-text case to
`scripts/test-sync.ts` so the gate covers this class.