### PR TITLE
README: fix the roadmap — real app names, retired suite name gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ security issue? See [SECURITY.md](SECURITY.md).
 
 ## Roadmap
 
-**Bento/Slides** is the first app of Bento/Suite — a PowerPoint alternative,
-shipping now. **Docs** (`bento/docs`) and **Sheets** (`bento/sheets`) follow,
-each as its own self-contained `.bento.html` distributable. The current release
-lives on [bento.page](https://bento.page) and reaches every existing file
-through the signed update channel.
+**bento/slides** is the first app — a PowerPoint alternative, shipping now.
+**bento/spaces** (notes), **bento/dash** (sheets & tables) and **bento/vault**
+follow, each as its own self-contained `.bento.html` distributable. The
+current release lives on [bento.page](https://bento.page) and reaches every
+existing file through the signed update channel.
 
 ## License
 


### PR DESCRIPTION
The last stale corner of the rebrand, and it's the one a visitor from HN
reads first.

The Roadmap paragraph announced **"Docs (`bento/docs`)"** and **"Sheets
(`bento/sheets`)"** — names we never adopted — and described slides as *"the
first app of Bento/Suite"*, a platform name we retired.

Now reads:

> **bento/slides** is the first app — a PowerPoint alternative, shipping now.
> **bento/spaces** (notes), **bento/dash** (sheets & tables) and
> **bento/vault** follow…

Matching the landing page (already live) and `docs/DECISIONS.md`.

My earlier sweep missed it because it matched `Bento Slides` with a space;
these were the slash forms (`Bento/Slides`, `Bento/Suite`). README is now clean
of both retired app names and the retired platform name.

Docs only — one paragraph, no code.