### PR TITLE
Docs: make the ownership zones match reality

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,38 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-07-25 — Every PR gets human review before merging to main (for now)
+
+At this stage of development the maintainer reviews **every** PR before it
+lands on `main`, including agent-authored ones. No auto-merge. The point is
+visibility into what the agents are actually producing while the multi-agent
+workflow is still being shaken out — the cost is throughput, and that is
+currently the right trade.
+
+Supporting config, already in place: `main` is branch-protected with one
+required approval, and CI (`validate`) is a **required status check**, so a red
+build cannot merge. Admin bypass stays enabled for the maintainer.
+
+### FUTURE ACTION — revisit when review becomes the bottleneck
+
+When PR volume outgrows one reviewer, consider auto-merging **app-zone** PRs on
+green CI. If that happens, these paths must **always** require human review
+regardless, because a bad merge is either silent or catastrophic:
+
+- **`kernel/src/`** — every app depends on it.
+- **`slides/src/sync/`, above all `crdt.ts`** — convergence bugs are silent and
+  corrupt documents. The rig is necessary but not sufficient: it only generates
+  short strings, which is why it missed the large-text stack overflow (#47).
+- **`server/`** — one bad deploy breaks live collaboration for everyone at
+  once, and there is no per-user rollback.
+- **`scripts/release.mjs` / `sign-release.mjs` / `keygen.mjs`** — the signing
+  and release path.
+- **Anything touching the `#bento-doc` splice contract or the update-manifest
+  shape** (`PLATFORM.md` §2, §6) — these brick files already on users' disks.
+
+Do not enable auto-merge without that exclusion list encoded somewhere
+enforceable, not just written down here.
+
 ## 2026-07-24 — Naming: the platform is `bento`, the mark is `bento/.`, all lowercase
 Settled after working through the whole namespace. **Do not reopen these** —
 each rejected candidate was rejected for a specific reason, recorded below.

--- a/docs/PARALLEL-WORK.md
+++ b/docs/PARALLEL-WORK.md
@@ -9,11 +9,16 @@ rules exist to keep N parallel workstreams from dissolving into merge hell.
 
 ## 1. Ownership zones
 
-- **App zones** — `slides/`, and (as they land) `spaces/`, `dash/`: parallel
-  work is safe *within different apps*. Agents working on different apps must
-  not touch each other's app directories.
-- **Kernel zone** — shared machinery (save/splice, sync engine + relay,
-  update, i18n runtime, build tooling; see `docs/PLATFORM.md` §9):
+- **App zones** — `slides/` (shipped) and `spaces/` (scaffold); `dash/` when
+  it lands. Parallel work is safe *within different apps*. Agents working on
+  different apps must not touch each other's app directories. Each app owns
+  its own `package.json`, `vite.config.ts`, `index.html`, `src/model.ts` and
+  `src/i18n.ts` facade.
+- **Kernel zone — `kernel/src/`** — `save.ts` (splice + bento/enc),
+  `autosave.ts`, `update.ts`, `anim.ts`, `charts.ts`, the `i18n.ts` engine,
+  `app.ts`, `doc.ts`; plus `slides/src/sync/` and `server/`, which are shared
+  in effect even though they still live app-side. See `docs/PLATFORM.md` §9.
+  This zone is:
   **serialize, don't parallelize.** One coordinated change at a time, reviewed
   against the platform invariants. If your app task needs a kernel change,
   stop, make (or request) the kernel change as its own small PR, land it,
@@ -66,7 +71,25 @@ of every tool can see it.
 - i18n: new strings present in all catalogs (`x-pseudo` audit catches strays)
 - no edits under generated dirs (`site/`, `dist-single/`)
 
-## 6. Coordination artifacts (the shared brain)
+## 6. Picking up work without colliding
+
+Zones stop *cross-app* collisions. Two agents inside one app will still
+collide, and no tooling fixes that — it is a work-assignment question.
+Practical rules for a small team running many agents:
+
+- **One agent per app zone at a time**, unless the maintainer has explicitly
+  split the work by file.
+- **Push the branch early**, before the work is finished, so another agent can
+  see it exists.
+- **Check `gh pr list` before starting.** An open PR touching your files is
+  the cheapest collision warning available.
+- **Branches whose commits look unmerged may already be shipped.** `main` was
+  rewritten once (to scrub a bot's commits), which orphaned older branch
+  hashes. Compare *content*, not commit ids, before "rescuing" anything.
+- Agents from other harnesses (Codex, Antigravity) read `AGENTS.md`, not this
+  file — keep the hard rules mirrored there.
+
+## 7. Coordination artifacts (the shared brain)
 
 - `docs/DECISIONS.md` — append-only decision log. Before starting non-trivial
   work: read it. After settling anything another agent could contradict:
@@ -78,7 +101,7 @@ of every tool can see it.
   finds adjacent-but-out-of-scope work files it as a note or issue instead of
   expanding its own PR.
 
-## 7. What agents never do
+## 8. What agents never do
 
 - Release, publish, deploy, or touch signing keys (maintainer-only, local).
 - Rewrite history or force-push shared branches.

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -118,11 +118,18 @@ display labels only — model values stay English words. Audit with
 
 ## 9. What is kernel vs what is app
 
-Shared (extract once, evolve carefully, serialize changes — see
-`docs/PARALLEL-WORK.md`):
-save/splice, autosave, encryption, collab engine + relay protocol, signed
-update, i18n runtime, compressed-shell build + conformance gate, and (for
-Slides+Dash) the charts engine and table rendering.
+Shared — **`kernel/src/`**, extracted and in use (evolve carefully, serialize
+changes — see `docs/PARALLEL-WORK.md`): `save.ts` (splice + bento/enc
+encryption), `autosave.ts`, `update.ts`, `anim.ts`, `charts.ts`, the `i18n.ts`
+engine, `app.ts` (per-app identity via `configureApp`), `doc.ts` (the
+`KernelDoc` envelope). Apps import these through facades at their own paths.
+
+Also shared but NOT yet in `kernel/`: the collab engine (`slides/src/sync/`)
+and the relay (`server/`). Both are slides-shaped today and genericizing the
+CRDT is its own project — treat them as kernel-zone for serialization.
+
+Shared build tooling: `scripts/postbuild-compress.mjs` (parameterised per app
+via `--generator` / `--title`) and `scripts/shell-gate.mjs`.
 
 Per-app (own it, don't prematurely abstract):
 the document model, the renderer, the editor UX, starter documents, panels.


### PR DESCRIPTION
Right-sized follow-up to the multi-agent groundwork — just the parts that stop
agents colliding, skipping the governance scaffolding a solo team doesn't need
(no CODEOWNERS, no workspaces conversion, no wire-version enforcement yet).

## What changed
The zone definitions were written *before* the kernel existed and still
described it abstractly. Agents read these files to know what they may touch,
so vagueness costs more than it looks.

- **Kernel zone is now named**: `kernel/src/` with the actual module list, plus
  `slides/src/sync/` and `server/` flagged as kernel-zone-in-effect — shared in
  practice, still app-side until the CRDT is genericized.
- **App zones updated**: `slides/` is shipped and `spaces/` exists, so they're
  no longer "as they land". Spells out what each app owns.
- Records the shared build tooling (`postbuild-compress` with its per-app
  flags, `shell-gate`).

## New section: picking up work without colliding
Zones only prevent *cross-app* collisions. Two agents inside one app still
collide, and no tooling fixes that — it's a work-assignment problem. So:
one agent per app zone, push branches early so they're visible, check
`gh pr list` first, and mirror hard rules into `AGENTS.md` since other
harnesses read that instead of this.

It also warns that **branches whose commits look unmerged may already be
shipped** — `main` was rewritten once to scrub a bot's commits, orphaning
older branch hashes. Compare content, not commit ids, before "rescuing"
anything. That one would have cost someone real time.

## Done alongside this PR (config, not code)
- **CI is now a required status check** (`validate`) on `main`. Previously
  protection required a review but *not* a passing build, so a red PR could
  merge — which inverted the point of the gates.
- **Pruned merged branches**: 17 remote branches down to 11.

Docs only.

---

## Also records the review posture (added)

`docs/DECISIONS.md` now states the current policy explicitly: **the maintainer
reviews every PR before it merges to main**, agents included, no auto-merge —
visibility matters more than throughput while the multi-agent workflow is
still being shaken out.

And it records the **future action** we discussed but deliberately did *not*
take: when review becomes the bottleneck, consider auto-merging app-zone PRs
on green CI — with a permanent human-review list for paths where a bad merge
is silent or catastrophic (`kernel/src/`, `slides/src/sync/` especially
`crdt.ts`, `server/`, the release/signing scripts, and anything touching the
splice contract or update-manifest shape). With the caveat that the exclusion
list must be *enforceable*, not just documented, before auto-merge is enabled.
