### PR TITLE
CI: don't cancel main runs; rig: cover large text and diff-failure recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches — only the tip matters there. NOT on
+  # main: every merge commit is a distinct state, and the post-merge run is the
+  # safety net for interaction bugs between PRs merged close together. Four
+  # merges in a few minutes once left two merge commits only partly verified.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   validate:

--- a/scripts/test-sync.ts
+++ b/scripts/test-sync.ts
@@ -664,6 +664,50 @@ const castCount = (d: Doc) =>
     A.doc.slides.find((s: any) => s.id === sid).elements.find((e: any) => e.id === 'cast').y
   ok(y('s1') === 41 && y('s2') === 42, 'fork edits landed on their own copies')
 }
+
+{
+  // LARGE TEXT. The rig only ever generated short strings, which is how a
+  // stack overflow in applyTxtToState survived 46k checks: tokenize() is
+  // per-character, so ~200KB of text is ~200k tokens, and inserting them with
+  // splice(idx, 0, ...toks) spread them as CALL ARGUMENTS and blew the stack.
+  // The throw happened inside diff(), so session.flush() failed and NOTHING
+  // synced for the rest of the session. Guard the whole class here.
+  console.log('large text: 300KB element diffs, merges and converges…')
+  const A = new Replica('A')
+  const B = new Replica('B')
+  const big = 'word '.repeat(60_000) // ~300KB
+  const ea = A.mutate((d) => { d.slides[0].elements[0].html = big + ' AAA' })
+  const eb = B.mutate((d) => { d.slides[0].elements[0].html = d.slides[0].elements[0].html + ' BBB' })
+  A.receive(eb)
+  B.receive(ea)
+  ok(A.fingerprint() === B.fingerprint(), 'large-text merge converged')
+  const html = A.doc.slides[0].elements[0].html
+  ok(html.includes('AAA') && html.includes('BBB'), 'large-text merge kept both edits')
+  ok(html.length > 200_000, `large text survived the merge (${html.length} chars)`)
+}
+{
+  // DIFF FAILURE RECOVERY. A differ bug must not wedge the session: the shadow
+  // only advances after a successful diff, so an uncaught throw re-diffs the
+  // same delta forever. session.ts recovers by advancing the shadow and
+  // shipping a snapshot — but those discarded ops CONSUMED sequence numbers,
+  // leaving a permanent hole that stalls peers on the gap buffer. This asserts
+  // the snapshot actually clears that stall.
+  console.log('diff failure: seq gap from discarded ops recovers via snapshot…')
+  const A = new Replica('A')
+  const B = new Replica('B')
+  B.receive(A.mutate((d) => { d.title = 't1' }))
+  // ops A mints then DISCARDS, exactly as a mid-diff throw would: seqs spent,
+  // ops never broadcast
+  A.mutate((d) => { d.title = 't2' })
+  A.mutate((d) => { d.title = 't3' })
+  const later = A.mutate((d) => { d.title = 't4' })
+  B.receive(later)
+  ok(B.doc.title === 't1', 'peer stalls on the sequence gap (as designed)')
+  // the recovery session.ts performs
+  B.state.mergeSnapshot(B.doc, JSON.parse(JSON.stringify(A.doc)), JSON.parse(JSON.stringify(A.state.toJSON())))
+  ok(B.doc.title === 't4', 'snapshot cleared the gap and caught the peer up')
+  ok(A.fingerprint() === B.fingerprint(), 'diff-failure recovery converged')
+}
 {
   console.log('pre-v2 saved state and snapshots are discarded…')
   const A = new Replica('A')


### PR DESCRIPTION
Two gaps that today's bugs walked straight through.

## `cancel-in-progress` was cancelling `main`
Four merges within a few minutes left two merge commits **only partly
verified** — 11/16 and 4/16 steps before cancellation. On a PR branch
cancelling is correct (only the tip matters). On `main` it isn't: every merge
commit is a distinct state, and the post-merge run is precisely the safety net
for interaction bugs between PRs merged close together — which is the exact
situation that triggered it. Now scoped to non-main refs.

## The rig only generated short strings
Which is how a stack overflow survived **46,402 checks**. `tokenize()` is
per-character, so ~200 KB of text is ~200k tokens, and
`splice(idx, 0, ...toks)` spread them as call arguments and blew the stack.
Because it threw inside `diff()`, `flush()` failed and *nothing* synced for
the rest of the session.

New case: two replicas concurrently edit a 300 KB element and must converge
with both edits intact.

**I verified it fails against the unfixed code** (`RangeError`), not merely
that it passes against the fixed code. A test that can't catch its own bug is
theatre — and this one had to be proven, given the original slipped through a
green rig.

## Diff-failure recovery had no coverage
`session.ts` (#50) now catches a diff throw, advances the shadow and ships a
snapshot. But the discarded ops **consumed sequence numbers**, leaving a
permanent hole that stalls peers on the gap buffer. The new case asserts both
halves: the peer *does* stall as designed, and the snapshot *does* clear it.

Otherwise that path stays untested until something triggers it in production —
which is when you least want to discover a flaw in it.

Rig: ALL PASS (45,368 checks).