### PR TITLE
Relay: encrypted blob endpoints (step 1 of asset offload)

### DIFF
--- a/server/sync-worker/src/worker.js
+++ b/server/sync-worker/src/worker.js
@@ -49,6 +49,11 @@ const RATE_BYTES = 8 * 1024 * 1024
 // of any one room regardless of frame size — the actual protection against an
 // unbounded bill, since room creation is unauthenticated by design.
 const ROOM_BYTE_CAP = 96 * 1024 * 1024
+// Ceiling for one uploaded blob. Clients chunk above this: WebCrypto has NO
+// streaming AES-GCM (one-shot only) and a round trip costs ~5x the payload in
+// memory, so a browser encrypting a 64MB asset in one call would need ~320MB.
+// Chunking is a MEMORY requirement, not just resumability.
+const MAX_BLOB = 8 * 1024 * 1024
 const OP_KEY = (seq) => `op:${String(seq).padStart(10, '0')}`
 
 /** Tell the sender why a frame was refused, ECHOING its client-supplied id
@@ -102,6 +107,17 @@ async function sha256b64u(bytes) {
 export default {
   async fetch(req, env) {
     const url = new URL(req.url)
+    // --- encrypted asset blobs (docs/blob-offload.md) ----------------------
+    // Assets are too big for the op log: a DO storage value caps near 2MB, so
+    // an 8MB video can never travel as an op. They go here instead, and the op
+    // carries only a reference. The relay pipes ciphertext straight through —
+    // it never buffers a blob (verified: 32MB streams with no memory growth)
+    // and cannot read one. Keys are opaque to us: the client derives them as
+    // HMAC(roomKey, sha256(plaintext)), so the same image in two rooms yields
+    // different keys and nothing correlates.
+    const b = url.pathname.match(/^\/b\/([A-Za-z0-9._-]{1,80})\/([A-Za-z0-9_-]{16,64})$/)
+    if (b) return await blob(req, env, b[1], b[2])
+
     const m = url.pathname.match(/^\/d\/([A-Za-z0-9._-]{1,80})$/)
     if (!m) {
       return new Response('bento-sync relay — see https://bento.page', {
@@ -122,6 +138,63 @@ export default {
       })
     }
   },
+}
+
+/** Blob store: PUT to upload, GET to fetch, HEAD to test existence (which is
+ *  how a client skips re-uploading an asset a peer already sent — content
+ *  addressing means an identical asset has an identical key).
+ *
+ *  Auth is the room token, same possession proof as the socket. That is
+ *  deliberately no stronger than the room itself: anyone who can read the
+ *  room's frames can already read its assets, and the bytes are ciphertext
+ *  either way.
+ *
+ *  R2 is OPTIONAL. Without the binding these routes answer 501 and clients
+ *  keep inlining small assets, so a self-hoster who hasn't set up a bucket
+ *  still has a working relay. */
+async function blob(req, env, room, key) {
+  if (!env.BLOBS) {
+    return new Response('blob storage not configured on this relay', { status: 501 })
+  }
+  const tok = new URL(req.url).searchParams.get('tok') || ''
+  if (!/^[A-Za-z0-9_-]{10,64}$/.test(tok)) return new Response('bad token', { status: 400 })
+  // The DO owns the room's token; ask it rather than duplicating the check.
+  const idc = env.ROOM.idFromName(room)
+  const okRes = await env.ROOM.get(idc).fetch(
+    new Request(`https://do/authz?tok=${encodeURIComponent(tok)}`),
+  )
+  if (okRes.status !== 200) return new Response('forbidden', { status: 403 })
+
+  const path = `${room}/${key}`
+  if (req.method === 'HEAD') {
+    const head = await env.BLOBS.head(path)
+    return new Response(null, { status: head ? 200 : 404, headers: head ? { 'content-length': String(head.size) } : {} })
+  }
+  if (req.method === 'GET') {
+    const obj = await env.BLOBS.get(path)
+    if (!obj) return new Response('not found', { status: 404 })
+    // streamed, never materialised in the worker
+    return new Response(obj.body, {
+      headers: { 'content-type': 'application/octet-stream', 'cache-control': 'private, max-age=31536000, immutable' },
+    })
+  }
+  if (req.method === 'PUT') {
+    const len = parseInt(req.headers.get('content-length') || '0', 10)
+    if (!len || len > MAX_BLOB) {
+      return new Response(JSON.stringify({ error: 'too-large', max: MAX_BLOB, got: len }), {
+        status: 413, headers: { 'content-type': 'application/json' },
+      })
+    }
+    // Content-addressed, so an existing key is the same bytes — skip the write
+    // and let the client move on. This is the dedupe path.
+    const existing = await env.BLOBS.head(path)
+    if (existing) return new Response(JSON.stringify({ deduped: true, size: existing.size }), { headers: { 'content-type': 'application/json' } })
+    await env.BLOBS.put(path, req.body, {
+      httpMetadata: { cacheControl: 'private, max-age=31536000, immutable' },
+    })
+    return new Response(JSON.stringify({ stored: len }), { headers: { 'content-type': 'application/json' } })
+  }
+  return new Response('method not allowed', { status: 405 })
 }
 
 export class Room {
@@ -168,6 +241,16 @@ export class Room {
   }
 
   async fetch(req) {
+    // Token check for the blob routes — the DO is the only holder of the
+    // room's token, so blob auth asks it rather than duplicating the rule.
+    // Never CREATES a room: an unknown room 403s instead of claiming a token,
+    // otherwise blob PUTs would become a way to squat room names.
+    const u0 = new URL(req.url)
+    if (u0.pathname === '/authz') {
+      const saved = await this.state.storage.get('tok')
+      const given = u0.searchParams.get('tok') || ''
+      return new Response(null, { status: saved !== undefined && saved === given ? 200 : 403 })
+    }
     if (req.headers.get('Upgrade') !== 'websocket') {
       return new Response('expected websocket', { status: 426 })
     }

--- a/server/sync-worker/wrangler.toml
+++ b/server/sync-worker/wrangler.toml
@@ -11,6 +11,14 @@ routes = [
   { pattern = "sync.bento.page", custom_domain = true }
 ]
 
+# Encrypted asset blobs (docs/blob-offload.md). The relay pipes ciphertext
+# straight through — it never buffers a blob and cannot read one. OPTIONAL: if
+# the binding is absent the /b/ routes answer 501 and clients fall back to
+# inlining small assets, so a self-hoster without R2 still works.
+[[r2_buckets]]
+binding = "BLOBS"
+bucket_name = "bento-blobs"
+
 [[durable_objects.bindings]]
 name = "ROOM"
 class_name = "Room"


### PR DESCRIPTION
First half of `docs/blob-offload.md`. Assets can't travel as ops — a Durable
Object storage value caps near 2 MB, so an 8 MB video never fits and **no
frame-size constant fixes it**. This gives them somewhere to go. Client side
and the differ change come next.

## Probed before building — and it changed the design
The doc said not to trust these assumptions. Both mattered:

**WebCrypto has no streaming AES-GCM.** `encrypt`/`decrypt` are one-shot, and a
round trip costs **~5× the payload in memory** (8 MB → 40 MB, 64 MB → 320 MB).
So **chunking is a memory requirement, not just resumability** — and the
constraint lives in the *browser*, not the worker. `MAX_BLOB` is 8 MB; clients
chunk above it.

**A worker can pipe a multi-MB body straight to R2 with no buffering.**
Verified at 8 MB and 32 MB against a real R2 binding — byte-identical
round-trip, no memory growth. So `request.body` goes directly to
`BLOBS.put()`; the relay never materialises a blob and can't read one.

## The endpoints
`PUT` / `GET` / `HEAD` on `/b/<room>/<key>`.

`HEAD` is the **dedupe probe** — content addressing means an identical asset
has an identical key, so a client can skip an upload a peer already did. `PUT`
short-circuits on an existing key for the same reason.

**Auth** is the room token, asked of the DO rather than duplicated — the DO
owns it. The `/authz` branch deliberately **never creates a room**: an unknown
room 403s, otherwise blob PUTs would be a way to squat room names.

**R2 is optional.** Without the binding these routes answer 501 and clients
keep inlining small assets, so a self-hoster who hasn't configured a bucket
still has a working relay.

## Verified
Under `wrangler dev` with a real R2 binding:

| case | result |
|---|---|
| PUT before the room exists | `403` (no squatting) |
| wrong token | `403` |
| 3 MB PUT → HEAD → GET | round-trips **byte-intact** |
| repeat PUT of same key | `deduped` |
| 9 MB PUT | `413` with a structured error |
| missing key | `404` |

Note my first test run passed a *false* result because `wrangler dev --local`
persists DO and R2 state between runs — it reused a room from an earlier
attempt and reported an auth bypass that wasn't real. Fixed by randomising
room and key per run; worth knowing for anyone testing this locally.

## Deploy
Needs an R2 bucket (`bento-blobs`) created before deploying, or the routes
answer 501 — which is a safe default, not a failure.