### PR TITLE
Relay: per-room blob quota, expiry cleanup, and a size-limit boundary fix

### DIFF
--- a/server/sync-worker/src/worker.js
+++ b/server/sync-worker/src/worker.js
@@ -54,6 +54,12 @@ const ROOM_BYTE_CAP = 96 * 1024 * 1024
 // memory, so a browser encrypting a 64MB asset in one call would need ~320MB.
 // Chunking is a MEMORY requirement, not just resumability.
 const MAX_BLOB = 8 * 1024 * 1024
+// Total blob bytes one room may hold. Frames have ROOM_BYTE_CAP; without the
+// equivalent here, blob storage is an unmetered write endpoint behind nothing
+// but a trust-on-first-use token — the same unbounded-bill shape we closed for
+// frames. Counted in the DO, which is the only component that knows the room.
+const ROOM_BLOB_CAP = 256 * 1024 * 1024
+const BKEY = (k) => `b:${k}`
 const OP_KEY = (seq) => `op:${String(seq).padStart(10, '0')}`
 
 /** Tell the sender why a frame was refused, ECHOING its client-supplied id
@@ -160,12 +166,14 @@ async function blob(req, env, room, key) {
   if (!/^[A-Za-z0-9_-]{10,64}$/.test(tok)) return new Response('bad token', { status: 400 })
   // The DO owns the room's token; ask it rather than duplicating the check.
   const idc = env.ROOM.idFromName(room)
-  const okRes = await env.ROOM.get(idc).fetch(
-    new Request(`https://do/authz?tok=${encodeURIComponent(tok)}`),
-  )
-  if (okRes.status !== 200) return new Response('forbidden', { status: 403 })
+  const authzUrl = (extra = '') => `https://do/authz?tok=${encodeURIComponent(tok)}${extra}`
 
   const path = `${room}/${key}`
+  // reads: token only
+  if (req.method !== 'PUT') {
+    const ok = await env.ROOM.get(idc).fetch(new Request(authzUrl()))
+    if (ok.status !== 200) return new Response('forbidden', { status: 403 })
+  }
   if (req.method === 'HEAD') {
     const head = await env.BLOBS.head(path)
     return new Response(null, { status: head ? 200 : 404, headers: head ? { 'content-length': String(head.size) } : {} })
@@ -185,6 +193,16 @@ async function blob(req, env, room, key) {
         status: 413, headers: { 'content-type': 'application/json' },
       })
     }
+    // Reserve quota BEFORE writing — the DO checks the token and meters in one
+    // call, so a full room cannot be filled further even by a valid writer.
+    const res0 = await env.ROOM.get(idc).fetch(
+      new Request(authzUrl(`&size=${len}&bkey=${encodeURIComponent(key)}`)),
+    )
+    if (res0.status === 403) return new Response('forbidden', { status: 403 })
+    if (res0.status === 507) {
+      return new Response(await res0.text(), { status: 507, headers: { 'content-type': 'application/json' } })
+    }
+    if (res0.status !== 200) return new Response('room error', { status: 500 })
     // Content-addressed, so an existing key is the same bytes — skip the write
     // and let the client move on. This is the dedupe path.
     const existing = await env.BLOBS.head(path)
@@ -198,8 +216,9 @@ async function blob(req, env, room, key) {
 }
 
 export class Room {
-  constructor(state) {
+  constructor(state, env) {
     this.state = state
+    this.env = env
     this.verifyKey = null // imported writer pubkey, cached for this wake
     // Keepalive: auto-reply "pong" to a client "ping" WITHOUT waking the DO, so
     // idle connections aren't reaped by edge/proxy idle timeouts — the usual
@@ -249,7 +268,28 @@ export class Room {
     if (u0.pathname === '/authz') {
       const saved = await this.state.storage.get('tok')
       const given = u0.searchParams.get('tok') || ''
-      return new Response(null, { status: saved !== undefined && saved === given ? 200 : 403 })
+      if (saved === undefined || saved !== given) return new Response(null, { status: 403 })
+      // Blob accounting rides on the same call the blob route already makes.
+      // `size` present = a PUT asking to reserve quota; absent = a read.
+      const size = parseInt(u0.searchParams.get('size') || '0', 10) || 0
+      const bkey = u0.searchParams.get('bkey') || ''
+      if (!size || !bkey) return new Response(null, { status: 200 })
+      // Already counted? Then this is a re-upload of identical content
+      // (content-addressed keys) — admit it without double-charging.
+      if (await this.state.storage.get(BKEY(bkey))) {
+        return new Response(JSON.stringify({ deduped: true }), { status: 200 })
+      }
+      const used = (await this.state.storage.get('blobBytes')) || 0
+      if (used + size > ROOM_BLOB_CAP) {
+        return new Response(JSON.stringify({ error: 'room-blobs-full', cap: ROOM_BLOB_CAP, used }), {
+          status: 507, headers: { 'content-type': 'application/json' },
+        })
+      }
+      await this.state.storage.put(BKEY(bkey), size)
+      await this.state.storage.put('blobBytes', used + size)
+      // touch the expiry clock: blobs keep a room alive the same way ops do
+      await this.state.storage.setAlarm(Date.now() + IDLE_TTL_MS)
+      return new Response(JSON.stringify({ reserved: size }), { status: 200 })
     }
     if (req.headers.get('Upgrade') !== 'websocket') {
       return new Response('expected websocket', { status: 426 })
@@ -481,6 +521,21 @@ export class Room {
   async alarm() {
     // ~30 days idle: the room evaporates. Files reopen fine — the document
     // itself is the durable artifact; a fresh room re-forms on next join.
+    //
+    // Delete this room's BLOBS too. The DO is the only thing that knows which
+    // R2 objects belong to this room, so if it wipes its own state without
+    // clearing them, they are orphaned in the bucket forever and nobody is
+    // ever billed less. Best effort: if R2 errors we still wipe the DO rather
+    // than wedge the room, and the bucket lifecycle rule is the backstop.
+    try {
+      const name = await this.state.storage.get('name')
+      if (name && this.env?.BLOBS) {
+        const keys = [...(await this.state.storage.list({ prefix: 'b:' })).keys()]
+        for (const k of keys) {
+          try { await this.env.BLOBS.delete(`${name}/${k.slice(2)}`) } catch { /* best effort */ }
+        }
+      }
+    } catch { /* fall through to the wipe */ }
     await this.state.storage.deleteAll()
   }
 }

--- a/slides/src/sync/blobs.ts
+++ b/slides/src/sync/blobs.ts
@@ -24,7 +24,8 @@
 
 /** Plaintext bytes per chunk. Peak memory is ~5x this, not ~5x the asset. */
 const CHUNK = 4 * 1024 * 1024
-/** Must match the relay's MAX_BLOB; above this an asset needs several blobs. */
+/** Must match the relay's MAX_BLOB. NOTE this bounds the ENCODED blob, not the
+ *  plaintext — the relay measures what it receives. */
 export const MAX_BLOB = 8 * 1024 * 1024
 const MAGIC = 0x4242 // 'BB'
 const HEADER = 16
@@ -65,6 +66,21 @@ export function bytesToDataUri(bytes: Uint8Array, mime: string): string {
     s += String.fromCharCode(...bytes.subarray(i, Math.min(i + 0x8000, bytes.length)))
   }
   return `data:${mime};base64,${btoa(s)}`
+}
+
+/** Encoded size for `n` plaintext bytes: header + per-chunk IV and GCM tag.
+ *  The client must check THIS against MAX_BLOB, not the plaintext length —
+ *  otherwise an asset just under the limit passes here and is refused 413 by
+ *  the relay, which measures the ciphertext. */
+export function encodedSize(n: number): number {
+  return HEADER + Math.max(1, Math.ceil(n / CHUNK)) * (IV_LEN + TAG_LEN) + n
+}
+
+/** Largest plaintext asset that still fits in one blob. */
+export function maxAssetBytes(): number {
+  let n = MAX_BLOB
+  while (n > 0 && encodedSize(n) > MAX_BLOB) n -= 1
+  return n
 }
 
 async function hmacKey(rawRoomKey: Uint8Array): Promise<CryptoKey> {
@@ -208,7 +224,7 @@ const url = (e: BlobEndpoint, key: string) =>
 
 export type PutResult =
   | { ok: true; key: string; deduped: boolean }
-  | { ok: false; reason: 'too-large' | 'unsupported' | 'network' | 'forbidden' }
+  | { ok: false; reason: 'too-large' | 'unsupported' | 'network' | 'forbidden' | 'room-full' }
 
 /**
  * Encrypt and upload. Returns the key to put in the op. Dedupe is a HEAD
@@ -219,7 +235,7 @@ export type PutResult =
  * caller should fall back to inlining, NOT treat it as an error.
  */
 export async function putBlob(e: BlobEndpoint, rawRoomKey: Uint8Array, bytes: Uint8Array): Promise<PutResult> {
-  if (bytes.length > MAX_BLOB) return { ok: false, reason: 'too-large' }
+  if (encodedSize(bytes.length) > MAX_BLOB) return { ok: false, reason: 'too-large' }
   const key = await blobKey(rawRoomKey, bytes)
   try {
     const head = await fetch(url(e, key), { method: 'HEAD' })
@@ -237,6 +253,9 @@ export async function putBlob(e: BlobEndpoint, rawRoomKey: Uint8Array, bytes: Ui
     if (res.status === 501) return { ok: false, reason: 'unsupported' }
     if (res.status === 403) return { ok: false, reason: 'forbidden' }
     if (res.status === 413) return { ok: false, reason: 'too-large' }
+    // 507: the room's total blob quota is exhausted. Permanent for this room
+    // until it expires — the caller must not retry in a loop.
+    if (res.status === 507) return { ok: false, reason: 'room-full' }
     if (!res.ok) return { ok: false, reason: 'network' }
     void cachePut(key, bytes)
     return { ok: true, key, deduped: false }


### PR DESCRIPTION
Blob storage shipped without quotas: `MAX_BLOB` capped a *single* upload, but
nothing capped a room's total and nothing ever deleted anything. That's an
unmetered write endpoint behind a trust-on-first-use token — the same
unbounded-bill shape we closed for frames, reopened on a different door.

## Quota
`ROOM_BLOB_CAP` (256 MB) metered in the Durable Object, which is the only
component that knows the room. The blob route already called the DO for auth,
so accounting rides on that same call rather than adding a round trip: `PUT`
passes size + key, the DO reserves or refuses `507`, and the client surfaces
`room-full` as **permanent** so it can't retry into a full room forever.

Dedupe doesn't double-charge — a key already counted is admitted without
re-reserving, matching the content-addressed semantics.

## Expiry
The idle alarm now deletes the room's R2 objects **before** wiping DO state.
The DO is the only thing that knows which objects belong to the room, so
wiping its state first would orphan them in the bucket permanently — and
nobody is ever billed less for storage they can't find. Best-effort: an R2
error still lets the wipe proceed rather than wedging the room.

## A boundary bug the quota test found
The client checked **plaintext** length against `MAX_BLOB` while the relay
checks the **ciphertext** it receives, which is larger by the header and
per-chunk IV + GCM tag. An asset just under the limit passed the client and
was refused `413` by the relay.

Added `encodedSize()` and `maxAssetBytes()`. The true ceiling is **8,388,536
plaintext bytes**, which encodes to exactly `MAX_BLOB` — and one byte more is
correctly rejected on both sides. This is the kind of thing that only shows up
when you push a real payload at a real limit.

## Verified
Under `wrangler dev` with R2: upload within quota works and is readable, a
repeat upload dedupes, and the cap engages after **31 max-size uploads
(~254 MB)** with reason `room-full`.