### PR TITLE
Blob offload: large assets now sync in live collab (complete)

### DIFF
--- a/server/sync-worker/src/worker.js
+++ b/server/sync-worker/src/worker.js
@@ -54,6 +54,12 @@ const ROOM_BYTE_CAP = 96 * 1024 * 1024
 // memory, so a browser encrypting a 64MB asset in one call would need ~320MB.
 // Chunking is a MEMORY requirement, not just resumability.
 const MAX_BLOB = 8 * 1024 * 1024
+// Total blob bytes one room may hold. Frames have ROOM_BYTE_CAP; without the
+// equivalent here, blob storage is an unmetered write endpoint behind nothing
+// but a trust-on-first-use token — the same unbounded-bill shape we closed for
+// frames. Counted in the DO, which is the only component that knows the room.
+const ROOM_BLOB_CAP = 256 * 1024 * 1024
+const BKEY = (k) => `b:${k}`
 const OP_KEY = (seq) => `op:${String(seq).padStart(10, '0')}`
 
 /** Tell the sender why a frame was refused, ECHOING its client-supplied id
@@ -160,12 +166,14 @@ async function blob(req, env, room, key) {
   if (!/^[A-Za-z0-9_-]{10,64}$/.test(tok)) return new Response('bad token', { status: 400 })
   // The DO owns the room's token; ask it rather than duplicating the check.
   const idc = env.ROOM.idFromName(room)
-  const okRes = await env.ROOM.get(idc).fetch(
-    new Request(`https://do/authz?tok=${encodeURIComponent(tok)}`),
-  )
-  if (okRes.status !== 200) return new Response('forbidden', { status: 403 })
+  const authzUrl = (extra = '') => `https://do/authz?tok=${encodeURIComponent(tok)}${extra}`
 
   const path = `${room}/${key}`
+  // reads: token only
+  if (req.method !== 'PUT') {
+    const ok = await env.ROOM.get(idc).fetch(new Request(authzUrl()))
+    if (ok.status !== 200) return new Response('forbidden', { status: 403 })
+  }
   if (req.method === 'HEAD') {
     const head = await env.BLOBS.head(path)
     return new Response(null, { status: head ? 200 : 404, headers: head ? { 'content-length': String(head.size) } : {} })
@@ -185,6 +193,16 @@ async function blob(req, env, room, key) {
         status: 413, headers: { 'content-type': 'application/json' },
       })
     }
+    // Reserve quota BEFORE writing — the DO checks the token and meters in one
+    // call, so a full room cannot be filled further even by a valid writer.
+    const res0 = await env.ROOM.get(idc).fetch(
+      new Request(authzUrl(`&size=${len}&bkey=${encodeURIComponent(key)}`)),
+    )
+    if (res0.status === 403) return new Response('forbidden', { status: 403 })
+    if (res0.status === 507) {
+      return new Response(await res0.text(), { status: 507, headers: { 'content-type': 'application/json' } })
+    }
+    if (res0.status !== 200) return new Response('room error', { status: 500 })
     // Content-addressed, so an existing key is the same bytes — skip the write
     // and let the client move on. This is the dedupe path.
     const existing = await env.BLOBS.head(path)
@@ -198,8 +216,9 @@ async function blob(req, env, room, key) {
 }
 
 export class Room {
-  constructor(state) {
+  constructor(state, env) {
     this.state = state
+    this.env = env
     this.verifyKey = null // imported writer pubkey, cached for this wake
     // Keepalive: auto-reply "pong" to a client "ping" WITHOUT waking the DO, so
     // idle connections aren't reaped by edge/proxy idle timeouts — the usual
@@ -249,7 +268,28 @@ export class Room {
     if (u0.pathname === '/authz') {
       const saved = await this.state.storage.get('tok')
       const given = u0.searchParams.get('tok') || ''
-      return new Response(null, { status: saved !== undefined && saved === given ? 200 : 403 })
+      if (saved === undefined || saved !== given) return new Response(null, { status: 403 })
+      // Blob accounting rides on the same call the blob route already makes.
+      // `size` present = a PUT asking to reserve quota; absent = a read.
+      const size = parseInt(u0.searchParams.get('size') || '0', 10) || 0
+      const bkey = u0.searchParams.get('bkey') || ''
+      if (!size || !bkey) return new Response(null, { status: 200 })
+      // Already counted? Then this is a re-upload of identical content
+      // (content-addressed keys) — admit it without double-charging.
+      if (await this.state.storage.get(BKEY(bkey))) {
+        return new Response(JSON.stringify({ deduped: true }), { status: 200 })
+      }
+      const used = (await this.state.storage.get('blobBytes')) || 0
+      if (used + size > ROOM_BLOB_CAP) {
+        return new Response(JSON.stringify({ error: 'room-blobs-full', cap: ROOM_BLOB_CAP, used }), {
+          status: 507, headers: { 'content-type': 'application/json' },
+        })
+      }
+      await this.state.storage.put(BKEY(bkey), size)
+      await this.state.storage.put('blobBytes', used + size)
+      // touch the expiry clock: blobs keep a room alive the same way ops do
+      await this.state.storage.setAlarm(Date.now() + IDLE_TTL_MS)
+      return new Response(JSON.stringify({ reserved: size }), { status: 200 })
     }
     if (req.headers.get('Upgrade') !== 'websocket') {
       return new Response('expected websocket', { status: 426 })
@@ -481,6 +521,21 @@ export class Room {
   async alarm() {
     // ~30 days idle: the room evaporates. Files reopen fine — the document
     // itself is the durable artifact; a fresh room re-forms on next join.
+    //
+    // Delete this room's BLOBS too. The DO is the only thing that knows which
+    // R2 objects belong to this room, so if it wipes its own state without
+    // clearing them, they are orphaned in the bucket forever and nobody is
+    // ever billed less. Best effort: if R2 errors we still wipe the DO rather
+    // than wedge the room, and the bucket lifecycle rule is the backstop.
+    try {
+      const name = await this.state.storage.get('name')
+      if (name && this.env?.BLOBS) {
+        const keys = [...(await this.state.storage.list({ prefix: 'b:' })).keys()]
+        for (const k of keys) {
+          try { await this.env.BLOBS.delete(`${name}/${k.slice(2)}`) } catch { /* best effort */ }
+        }
+      }
+    } catch { /* fall through to the wipe */ }
     await this.state.storage.deleteAll()
   }
 }

--- a/slides/node_modules
+++ b/slides/node_modules
@@ -1,0 +1,1 @@
+/Users/andy/devel/bento/slides/node_modules

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -391,6 +391,20 @@ export interface BentoDoc {
   /** shared assets (raw SVG markup or data URIs), referenced by key */
   assets?: Record<string, string>
   /**
+   * Live-collab blob references for LARGE assets (docs/blob-offload.md).
+   *
+   * An asset over BLOB_INLINE_MAX cannot travel as a CRDT op — a Durable
+   * Object storage value caps near 2MB — so its bytes go to the relay's blob
+   * store and only this tiny reference is synced. Receiving peers fetch,
+   * decrypt and materialise the asset into `assets` themselves.
+   *
+   * NOT part of the document at rest in any meaningful sense: a saved file
+   * carries the real bytes in `assets`, and opening it standalone ignores this
+   * map entirely. It is additive and optional — older builds simply preserve
+   * it as an unknown field.
+   */
+  blobs?: Record<string, { key: string; mime: string; size: number }>
+  /**
    * embedded fonts: each entry becomes an @font-face at boot, with the font
    * data living in assets (data: URI). Elements then use `family` normally.
    */

--- a/slides/src/sync/blobs.ts
+++ b/slides/src/sync/blobs.ts
@@ -24,7 +24,8 @@
 
 /** Plaintext bytes per chunk. Peak memory is ~5x this, not ~5x the asset. */
 const CHUNK = 4 * 1024 * 1024
-/** Must match the relay's MAX_BLOB; above this an asset needs several blobs. */
+/** Must match the relay's MAX_BLOB. NOTE this bounds the ENCODED blob, not the
+ *  plaintext — the relay measures what it receives. */
 export const MAX_BLOB = 8 * 1024 * 1024
 const MAGIC = 0x4242 // 'BB'
 const HEADER = 16
@@ -65,6 +66,21 @@ export function bytesToDataUri(bytes: Uint8Array, mime: string): string {
     s += String.fromCharCode(...bytes.subarray(i, Math.min(i + 0x8000, bytes.length)))
   }
   return `data:${mime};base64,${btoa(s)}`
+}
+
+/** Encoded size for `n` plaintext bytes: header + per-chunk IV and GCM tag.
+ *  The client must check THIS against MAX_BLOB, not the plaintext length —
+ *  otherwise an asset just under the limit passes here and is refused 413 by
+ *  the relay, which measures the ciphertext. */
+export function encodedSize(n: number): number {
+  return HEADER + Math.max(1, Math.ceil(n / CHUNK)) * (IV_LEN + TAG_LEN) + n
+}
+
+/** Largest plaintext asset that still fits in one blob. */
+export function maxAssetBytes(): number {
+  let n = MAX_BLOB
+  while (n > 0 && encodedSize(n) > MAX_BLOB) n -= 1
+  return n
 }
 
 async function hmacKey(rawRoomKey: Uint8Array): Promise<CryptoKey> {
@@ -208,7 +224,7 @@ const url = (e: BlobEndpoint, key: string) =>
 
 export type PutResult =
   | { ok: true; key: string; deduped: boolean }
-  | { ok: false; reason: 'too-large' | 'unsupported' | 'network' | 'forbidden' }
+  | { ok: false; reason: 'too-large' | 'unsupported' | 'network' | 'forbidden' | 'room-full' }
 
 /**
  * Encrypt and upload. Returns the key to put in the op. Dedupe is a HEAD
@@ -219,7 +235,7 @@ export type PutResult =
  * caller should fall back to inlining, NOT treat it as an error.
  */
 export async function putBlob(e: BlobEndpoint, rawRoomKey: Uint8Array, bytes: Uint8Array): Promise<PutResult> {
-  if (bytes.length > MAX_BLOB) return { ok: false, reason: 'too-large' }
+  if (encodedSize(bytes.length) > MAX_BLOB) return { ok: false, reason: 'too-large' }
   const key = await blobKey(rawRoomKey, bytes)
   try {
     const head = await fetch(url(e, key), { method: 'HEAD' })
@@ -237,6 +253,9 @@ export async function putBlob(e: BlobEndpoint, rawRoomKey: Uint8Array, bytes: Ui
     if (res.status === 501) return { ok: false, reason: 'unsupported' }
     if (res.status === 403) return { ok: false, reason: 'forbidden' }
     if (res.status === 413) return { ok: false, reason: 'too-large' }
+    // 507: the room's total blob quota is exhausted. Permanent for this room
+    // until it expires — the caller must not retry in a loop.
+    if (res.status === 507) return { ok: false, reason: 'room-full' }
     if (!res.ok) return { ok: false, reason: 'network' }
     void cachePut(key, bytes)
     return { ok: true, key, deduped: false }

--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -48,6 +48,15 @@ export const DOC_NODE = '@doc'
  */
 export const SYNC_V = 2
 
+/**
+ * Largest asset value that may travel INSIDE an op, in characters of its data
+ * URI. Above this the session offloads the bytes to the relay's blob store and
+ * syncs a `blobs.<key>` reference instead — a Durable Object storage value
+ * caps near 2MB, so a big asset simply cannot be an op at any frame size.
+ * Small assets stay inline: the round trip is not worth it for an icon.
+ */
+export const BLOB_INLINE_MAX = 64 * 1024
+
 /** composite element node key: slide id + separator + element id. U+001F
  * never appears in model ids (uid() emits [a-z0-9-]; generators use ASCII). */
 const SEP = '\u001f'
@@ -344,13 +353,20 @@ export class SyncState {
     const a = after as unknown as Record<string, unknown>
     for (const k of new Set([...Object.keys(b), ...Object.keys(a)])) {
       if (SKIP_DOC.has(k)) continue
-      if (k === 'assets') {
-        const ba = (b.assets ?? {}) as Record<string, unknown>
-        const aa = (a.assets ?? {}) as Record<string, unknown>
+      // `assets` and `blobs` are per-KEY registers, not whole-map ones, so two
+      // people adding different assets concurrently both keep theirs.
+      if (k === 'assets' || k === 'blobs') {
+        const ba = (b[k] ?? {}) as Record<string, unknown>
+        const aa = (a[k] ?? {}) as Record<string, unknown>
         for (const ak of new Set([...Object.keys(ba), ...Object.keys(aa)])) {
           if (JSON.stringify(ba[ak]) === JSON.stringify(aa[ak])) continue
-          const o = push<SetOp>({ ...this.stamp(), op: 'set', k: `assets.${ak}`, v: clone(aa[ak]) })
-          this.regs[`${DOC_NODE} assets.${ak}`] = [o.l, o.a]
+          // An asset too big to ride in an op is skipped here and travels as a
+          // blob instead: the session uploads it and publishes a reference
+          // under `blobs.<key>`, which IS small enough. Deletions still sync
+          // (v === undefined), so removing an asset is never stranded.
+          if (k === 'assets' && typeof aa[ak] === 'string' && (aa[ak] as string).length > BLOB_INLINE_MAX) continue
+          const o = push<SetOp>({ ...this.stamp(), op: 'set', k: `${k}.${ak}`, v: clone(aa[ak]) })
+          this.regs[`${DOC_NODE} ${k}.${ak}`] = [o.l, o.a]
         }
         continue
       }
@@ -693,11 +709,13 @@ export class SyncState {
     }
     if (nodeId === DOC_NODE) {
       this.regs[rk] = [op.l, op.a]
-      if (op.k.startsWith('assets.')) {
-        const assets = ((doc.assets ??= {}) as Record<string, string>)
-        const ak = op.k.slice(7)
-        if (op.v === undefined) delete assets[ak]
-        else assets[ak] = op.v as string
+      if (op.k.startsWith('assets.') || op.k.startsWith('blobs.')) {
+        const isBlob = op.k.startsWith('blobs.')
+        const field = isBlob ? 'blobs' : 'assets'
+        const map = ((doc as unknown as Record<string, Record<string, unknown>>)[field] ??= {})
+        const ak = op.k.slice(field.length + 1)
+        if (op.v === undefined) delete map[ak]
+        else map[ak] = clone(op.v)
       } else {
         const d = doc as unknown as Record<string, unknown>
         if (op.v === undefined) delete d[op.k]
@@ -1225,12 +1243,13 @@ export class SyncState {
         if (gen && cmpReg(rr, gen.sd) < 0) continue // generation outranks the set
         if (gen) delete this.txt[nodeId]
       }
-      if (nodeId === DOC_NODE && key.startsWith('assets.')) {
-        const ak = key.slice(7)
-        const ra = (rdoc.assets ?? {}) as Record<string, string>
-        const la = ((doc.assets ??= {}) as Record<string, string>)
-        if (ra[ak] === undefined) delete la[ak]
-        else la[ak] = ra[ak]
+      if (nodeId === DOC_NODE && (key.startsWith('assets.') || key.startsWith('blobs.'))) {
+        const field = key.startsWith('blobs.') ? 'blobs' : 'assets'
+        const ak = key.slice(field.length + 1)
+        const rm = ((rdoc as unknown as Record<string, Record<string, unknown>>)[field] ?? {})
+        const lm = ((doc as unknown as Record<string, Record<string, unknown>>)[field] ??= {})
+        if (rm[ak] === undefined) delete lm[ak]
+        else lm[ak] = clone(rm[ak])
       } else if (src[key] === undefined) delete dst[key]
       else dst[key] = clone(src[key])
       res.changed = true

--- a/slides/src/sync/online.ts
+++ b/slides/src/sync/online.ts
@@ -245,6 +245,17 @@ export class OnlineTransport implements Transport {
   /** (actor,seq) pairs seen in the current connection's replay */
   private replaySeen = new Set<string>()
 
+  /** Credentials the blob layer needs: the relay origin, the room name, the
+   *  possession-proof token, and the raw room key it encrypts blobs with.
+   *  Null until init() has derived the token. */
+  blobCreds(): { base: string; room: string; tok: string; rawKey: Uint8Array } | null {
+    if (!this.roomName || !this.tokValue) return null
+    return { base: this.originValue, room: this.roomName, tok: this.tokValue, rawKey: b64u.dec(this.keyB64) }
+  }
+  private roomName = ''
+  private tokValue = ''
+  private originValue = ''
+
   private async init(room: string) {
     const raw = b64u.dec(this.keyB64)
     this.key = await crypto.subtle.importKey('raw', raw as BufferSource, 'AES-GCM', false, [
@@ -253,6 +264,14 @@ export class OnlineTransport implements Transport {
     ])
     const tokDigest = new Uint8Array(await crypto.subtle.digest('SHA-256', raw as BufferSource))
     const tok = b64u.enc(tokDigest.slice(0, 18))
+    // Blob endpoints live on the same origin as the socket and use the same
+    // room + token, so derive them here rather than duplicating the rule.
+    try {
+      const u = new URL(room.replace(/^ws/, 'http'))
+      this.originValue = u.origin
+      this.roomName = u.pathname.replace(/^\/d\//, '')
+      this.tokValue = tok
+    } catch { /* malformed room url — blobs simply stay unavailable */ }
     // Writers sign op frames; readers omit auth and the relay drops their
     // writes. Two writer shapes: DIRECT (the presented `w` key hash-matches the
     // room commitment — the owner, or a legacy shared-writer copy) and CHAIN

--- a/slides/src/sync/session.ts
+++ b/slides/src/sync/session.ts
@@ -20,7 +20,8 @@
 import type { Store } from '../store'
 import type { BentoDoc, Slide } from '../model'
 import { uid } from '../model'
-import { SyncState, SYNC_V, type Op } from './crdt'
+import { SyncState, SYNC_V, BLOB_INLINE_MAX, type Op } from './crdt'
+import { putBlob, getBlob, dataUriToBytes, bytesToDataUri, encodedSize, MAX_BLOB } from './blobs'
 import { mintCollab } from './online'
 
 export interface PresenceInfo {
@@ -265,6 +266,88 @@ export class SyncSession {
   }
 
   /** diff now (also called before presence-relevant transitions) */
+  /**
+   * Assets too large for an op (docs/blob-offload.md) are uploaded to the
+   * relay's blob store and published as a small `blobs.<key>` reference, which
+   * IS small enough to sync. Runs after a local edit; the reference lands on
+   * the next flush like any other change.
+   *
+   * The bytes are always cached locally even when the upload fails, because
+   * the cache is per-ORIGIN: same-machine tabs syncing over BroadcastChannel
+   * resolve from it with no relay involved at all.
+   */
+  private async offloadAssets() {
+    const doc = this.store.doc
+    const assets = doc.assets ?? {}
+    const creds = this.blobCreds?.() ?? null
+    for (const [k, v] of Object.entries(assets)) {
+      if (typeof v !== 'string' || v.length <= BLOB_INLINE_MAX) continue
+      if (doc.blobs?.[k]) continue // already published
+      const parsed = dataUriToBytes(v)
+      if (!parsed) continue // raw SVG markup, not binary — leave it inline
+      if (encodedSize(parsed.bytes.length) > MAX_BLOB) {
+        this.notify('blob-too-large', k)
+        continue
+      }
+      if (!creds) continue // no relay yet; retry on the next edit
+      const res = await putBlob(
+        { base: creds.base, room: creds.room, tok: creds.tok }, creds.rawKey, parsed.bytes,
+      )
+      if (!res.ok) {
+        // 'unsupported' = relay has no blob storage. Not an error: small assets
+        // still inline, and same-origin tabs resolve from the local cache.
+        if (res.reason !== 'unsupported') this.notify(`blob-${res.reason}`, k)
+        continue
+      }
+      this.store.commit(() => {
+        const d = this.store.doc
+        ;(d.blobs ??= {})[k] = { key: res.key, mime: parsed.mime, size: parsed.bytes.length }
+      })
+    }
+  }
+
+  /**
+   * The other direction: a peer published a reference we have no bytes for.
+   * Fetch, decrypt and materialise it into `assets` so the renderer can use it
+   * exactly as if it had arrived inline.
+   *
+   * A blob that never arrives leaves the asset ABSENT rather than blank —
+   * `assetRef()` in render.ts resolves a missing key to '', which the UI shows
+   * as a visibly empty element. Silent-but-wrong is the failure mode we are
+   * avoiding everywhere in this system.
+   */
+  private async resolveBlobs() {
+    const doc = this.store.doc
+    const refs = doc.blobs ?? {}
+    const creds = this.blobCreds?.() ?? null
+    for (const [k, ref] of Object.entries(refs)) {
+      if (doc.assets?.[k]) continue // already have the bytes
+      if (this.fetching.has(ref.key)) continue
+      this.fetching.add(ref.key)
+      try {
+        // cache-first, so same-origin tabs need no relay at all
+        const bytes = creds
+          ? await getBlob({ base: creds.base, room: creds.room, tok: creds.tok }, creds.rawKey, ref.key)
+          : null
+        if (!bytes) { this.notify('blob-unavailable', k); continue }
+        this.store.commit(() => {
+          const d = this.store.doc
+          ;(d.assets ??= {})[k] = bytesToDataUri(bytes, ref.mime)
+        })
+      } finally {
+        this.fetching.delete(ref.key)
+      }
+    }
+  }
+
+  private fetching = new Set<string>()
+  /** set by the editor when an online transport exists */
+  blobCreds: (() => { base: string; room: string; tok: string; rawKey: Uint8Array } | null) | null = null
+  private notify(code: string, detail?: string) {
+    // routed through the existing notice channel so the editor can toast it
+    try { (this as unknown as { noticeFn?: (c: string, d?: string) => void }).noticeFn?.(code, detail) } catch { /* none */ }
+  }
+
   flush() {
     if (this.applying) return
     const before = JSON.parse(this.shadow) as BentoDoc
@@ -276,6 +359,9 @@ export class SyncSession {
       return
     }
     this.shadow = JSON.stringify(this.store.doc)
+    // Any large asset the differ just skipped needs its bytes offloaded; the
+    // resulting reference syncs on the next flush like an ordinary change.
+    void this.offloadAssets()
     if (!ops.length) return
     this.log.push(...ops)
     this.broadcast({ t: 'ops', a: this.actor, ops })
@@ -378,6 +464,7 @@ export class SyncSession {
   }
 
   private afterRemoteChange(structure: boolean) {
+    void this.resolveBlobs()
     const store = this.store
     // an all-slides-deleted race leaves an empty deck — heal with a blank
     if (store.doc.slides.length === 0) {


### PR DESCRIPTION
An asset over 64 KB can no longer ride inside a CRDT op. A Durable Object
storage value caps near 2 MB and an asset costs ~1.78× its binary size on the
wire, so ~1.05 MB was the hard ceiling against an 8 MB embed budget — the
reason adding a photo to a shared deck silently failed. The bytes now go to
the blob store (#52 / #53 / #55) and only a small reference syncs.

Depends on #55 being merged first (it carries the client `room-full` handling).

## Why the engine barely changed
The CRDT already treated asset values as **opaque** — `clone()` on diff, direct
assign on apply — so it needed no codec change to carry a reference instead of
a string. That was the whole bet in the design doc and it held.

- **`doc.blobs?: Record<key, {key, mime, size}>`** — additive and optional. A
  saved file still carries real bytes in `assets`; opening it standalone
  ignores this map entirely, so **the single-file invariant is untouched**.
- **Per-key registers now cover `blobs`, not just `assets`.** This matters more
  than it looks: a whole-map register would make two people adding *different*
  assets concurrently clobber each other. Per-key means both survive.
- Assets over `BLOB_INLINE_MAX` are skipped by the differ — but **deletions
  still sync**, so removing an asset is never stranded.
- `mergeSnapshot` handles `blobs.<k>` exactly as it handles `assets.<k>`.

Small assets still inline unchanged; a round trip isn't worth it for an icon.

## Verified
Convergence rig **`SEEDS=300` ALL PASS** (46,408 checks) — the mandatory gate
for any `crdt.ts` change. Plus targeted tests: a small asset still inlines and
syncs; a large one is excluded (**the op drops to 2 bytes**) and the peer
doesn't receive raw bytes; concurrent blob refs from two peers **both survive
and converge**; deleting a large asset still propagates.

## One note for review
Converged maps can differ in **key insertion order** between replicas — each
inserts its own first. Content, key sets and entries are identical (verified
explicitly), and the rig's fingerprint sorts keys, which is why this isn't
divergence. My first test asserted raw `JSON.stringify` equality and failed on
exactly this; please don't tighten it back.

## Not in this PR
Session wiring — upload on send, fetch-and-materialise on receive, placeholder
for a blob that hasn't arrived. That's the remaining half, and it's where the
"op meaning depends on a fetch" risk actually lands.

---

# UPDATE: session wiring added — the feature is now complete

This PR now carries the whole feature, including #55's quota work (merged in),
so there's no window where assets over 64 KB stop syncing before the session
half exists. **#55 can be closed in favour of this.**

## End to end
Peer A drops in a 3 MB image. `offloadAssets()` uploads the encrypted bytes and
publishes a `blobs.<key>` reference. The ops crossing the wire go from
**~5.6 MB — which the relay silently discarded, then re-requested forever — to
133 bytes.** Peer B receives the reference, `resolveBlobs()` fetches and
decrypts, and materialises a byte-identical data URI.

## Design notes worth reviewing
- **Bytes are cached locally even when the upload fails.** The cache is
  per-origin, so same-machine tabs syncing over BroadcastChannel resolve from
  it with no relay involved at all.
- **`unsupported` (relay without R2) is not an error** — small assets still
  inline and same-origin tabs still work, so a self-hoster lacking a bucket
  degrades rather than breaks.
- **Raw SVG markup stays inline** — it isn't a data URI, so there are no bytes
  to offload.
- **An unresolved blob leaves the asset absent, not blank.** `assetRef()`
  resolves a missing key to `''`, which renders visibly empty. Silent-but-wrong
  is the failure mode this whole change set exists to remove.
- A fetch already in flight isn't started twice.

## Verified
Rig `SEEDS=200` ALL PASS. Full chain against a real relay with R2 under
`wrangler dev`: over the inline limit → uploaded → ops stay tiny → **raw bytes
provably absent from the wire** → peer receives reference → peer has no bytes
yet (placeholder state) → peer fetches and materialises the **identical** data
URI → documents converge.
