### PR TITLE
Fix #54: a manually-set morph id never morphed

### DIFF
--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -5,7 +5,7 @@
 // into a single undo checkpoint.
 
 import type { Store } from '../store'
-import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
+import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, morphKey, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
 import { isMacOS } from '../screens'
 import { CHART_PRESETS } from '../charts'
 import { FONT_CHOICES, firstFamily, injectFonts } from '../fonts'
@@ -459,7 +459,7 @@ export class PropsPanel {
    */
   private buildMorphProps(el: SlideElement) {
     this.section(t('Morph'))
-    const effective = el.morphId || el.id
+    const effective = morphKey(el)
 
     const warn = document.createElement('p')
     warn.className = 'ed-hint ed-morph-warn'
@@ -515,7 +515,7 @@ export class PropsPanel {
     const next = clean === el.id ? undefined : clean
     const effective = next ?? el.id
     const clash = this.store.slide.elements.some(
-      (e) => e.id !== el.id && (e.morphId || e.id) === effective)
+      (e) => e.id !== el.id && morphKey(e) === effective)
     if (clash) return t('Another element on this slide already uses that morph id.')
     this.mutate(el.id, (e) => {
       if (next === undefined) delete e.morphId
@@ -529,12 +529,12 @@ export class PropsPanel {
    *  (they'd collide) and our own default key. */
   private morphTargets(el: SlideElement): Array<{ key: string; label: string }> {
     const here = new Set(
-      this.store.slide.elements.filter((e) => e.id !== el.id).map((e) => e.morphId || e.id))
+      this.store.slide.elements.filter((e) => e.id !== el.id).map(morphKey))
     const seen = new Map<string, string>()
     this.store.doc.slides.forEach((s, i) => {
       if (s.id === this.store.slide.id) return
       for (const e of s.elements) {
-        const key = e.morphId || e.id
+        const key = morphKey(e)
         if (key === el.id || here.has(key) || seen.has(key)) continue
         seen.set(key, `${t('Slide')} ${i + 1} · ${this.morphElDesc(e)}`)
       }

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -479,6 +479,19 @@ export const uid = (prefix = 'el') =>
 export const FONT_STACK =
   "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
 
+/**
+ * An element's effective morph key: the `morphId` override when set, else its
+ * own `id`. THE single definition — render.ts stamps it into `data-flip-id`,
+ * present.ts pairs and looks up model frames by it, and the panel uses it for
+ * collision checks. Computing it inline in more than one place is exactly how
+ * issue #54 happened: present.ts's model map keyed by `id` while every lookup
+ * passed a flip id, so any element carrying a `morphId` silently missed and
+ * never morphed. Route every morph-key read through here.
+ */
+export function morphKey(el: Pick<ElementBase, 'id' | 'morphId'>): string {
+  return el.morphId || el.id
+}
+
 /** True when a background reads as light (so it wants dark text on top). Accepts
  *  a #rrggbb hex; for a gradient/CSS string it samples the first hex it finds and
  *  falls back to "light" (the safe assumption for the model's dark default ink). */

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -9,6 +9,7 @@ import 'reveal.js/dist/reveal.css'
 import { anim, resetXform } from './anim'
 import { chartSnapshotSvg, mountChart } from './charts'
 import type { BentoDoc, GradientFill, ShapeElement, Slide, SlideElement } from './model'
+import { morphKey } from './model'
 import { applyElementFrame, gradientLineCoords, renderSlide } from './render'
 import { paintSpeaker, setSpeakerWindow, speakerIdleBody, speakerWindow } from './screens'
 import { t } from './i18n'
@@ -921,9 +922,17 @@ function elementsById(root: HTMLElement): Map<string, HTMLElement> {
   return map
 }
 
-function modelById(doc: BentoDoc, index: number): Map<string, SlideElement> {
+/**
+ * Model frames keyed by MORPH KEY, not by `id` — every caller looks these up
+ * with a `data-flip-id`, which is `morphId || id`. Keying by `id` meant any
+ * element carrying a `morphId` missed its own model entry, so `runMorph` hit
+ * `if (!a || !b) continue` and skipped the tween: the DOM paired correctly and
+ * then nothing animated (issue #54). Same-slide keys are unique — the panel
+ * rejects a `morphId` that collides on the slide — so this stays 1:1.
+ */
+function modelByMorphKey(doc: BentoDoc, index: number): Map<string, SlideElement> {
   const map = new Map<string, SlideElement>()
-  for (const el of doc.slides[index]?.elements ?? []) map.set(el.id, el)
+  for (const el of doc.slides[index]?.elements ?? []) map.set(morphKey(el), el)
   return map
 }
 
@@ -936,8 +945,8 @@ function runMorph(
 ) {
   const fromEls = elementsById(fromSection)
   const toEls = elementsById(toSection)
-  const fromModel = modelById(doc, fromIdx)
-  const toModel = modelById(doc, toIdx)
+  const fromModel = modelByMorphKey(doc, fromIdx)
+  const toModel = modelByMorphKey(doc, toIdx)
 
   const matchedFrom: HTMLElement[] = []
   const matchedTo: HTMLElement[] = []

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -4,6 +4,7 @@
 // editor canvas, sidebar thumbnails, and Reveal.js sections.
 
 import type { BentoDoc, ShapeElement, Slide, SlideElement, SvgElement, TableElement } from './model'
+import { morphKey } from './model'
 import { chartSnapshotSvg } from './charts'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
@@ -412,7 +413,7 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
   const node = document.createElement('div')
   node.className = `bento-el bento-el-${el.type}`
   node.dataset.elId = el.id
-  node.dataset.flipId = el.morphId || el.id
+  node.dataset.flipId = morphKey(el)
   if (el.link) node.dataset.link = el.link
   if (el.group) node.dataset.group = el.group
   if (el.showOnHover) node.dataset.showOnHover = el.showOnHover


### PR DESCRIPTION
Fixes #54.

## The bug

Setting `morphId` to pair an element with one on another slide did nothing. The morph only ever worked via the duplicate-a-slide idiom (same `id` on both slides) — exactly as the reporter described.

## Cause

`data-flip-id` is `morphId || id`, and present.ts pairs the **DOM** by that key correctly. But `modelById()` keyed the **model** maps by `el.id`, while every lookup into them passes a flip id:

```js
const a = fromModel.get(node.dataset.flipId)
const b = toModel.get(node.dataset.flipId)
if (!a || !b) continue          // <- always taken for a morphId element
```

So an element carrying a `morphId` matched in the DOM, then missed its own model entry and fell straight out of the geometry tween. Nothing animated, no error. Elements using the default key were unaffected — which is precisely why "duplicate the slide" worked and "set a morph id" didn't.

## Fix

Key the model maps by the morph key (renamed `modelByMorphKey`). The panel already rejects a `morphId` colliding with another element's effective key on the same slide, so the map stays 1:1.

The bug *was* key-computation drift — two sites deriving the key independently — so `morphId || id` is now a single exported helper `morphKey()` in model.ts, used by render.ts, present.ts and panels.ts. No inline computation of that expression remains in the codebase.

## Verification

Against the reporter's own deck, loaded into a dev build and driven through anim.ts's manual clock (the preview pane never fires rAF, so wall-clock animation can't be sampled there):

| | shape `a` | shape `b` | shape transform through the transition |
|---|---|---|---|
| **pre-fix** | `true` | **`false`** | stays `(none)` the whole time |
| **post-fix** | `true` | `true` | `translate(-241.2px, 140.9px) scale(0.599)` → `translate(-153.9px, 89.9px) scale(0.744)` → `translate(-12.5px, 7.3px) scale(0.979)` → settles |

In both runs the same-id text element on the same slide morphs normally, isolating the defect to the `morphId` path. The trajectory matches the model geometry (`127.4,260,300x200` → `381.1,111.8,519x346`).

`tsc -b` clean.

## Not fixed here

The reporter also notes the override is hard to **clear**. The documented way (type the element's own id) works in code, but the "Pair with" picker offers no unpair option, so there's no affordance. Left as a separate UX change — it needs a new UI string in all 7 catalogs and doesn't belong in a rendering bug fix.