### PR TITLE
Fix #30: deleting a slide could empty the deck entirely

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1219,11 +1219,19 @@ export class Editor {
   }
 
   private deleteSlide(i: number) {
-    if (this.store.doc.slides.length <= 1) return this.toast(t('A deck needs at least one slide'))
     const target = this.store.doc.slides[i]
+    if (!target) return
     // dependents: states of this slide, and element links pointing at it
     const states = this.store.doc.slides.filter((s) => s.stateOf === target.id)
     const doomedIds = new Set([target.id, ...states.map((s) => s.id)])
+    // "A deck needs at least one slide" has to be checked against what will
+    // SURVIVE, not against the current count: deleting a parent takes its
+    // interactive states with it, so one slide + one state (length 2) sailed
+    // past a `length <= 1` test and then deleted BOTH — leaving a deck with
+    // zero slides and an editor with nothing to render (issue #30). States
+    // don't count as survivors: they're unreachable except through a parent.
+    const survivesLinear = this.store.doc.slides.some((s) => !s.stateOf && !doomedIds.has(s.id))
+    if (!survivesLinear) return this.toast(t('A deck needs at least one slide'))
     let linkCount = 0
     for (const s of this.store.doc.slides) {
       if (doomedIds.has(s.id)) continue


### PR DESCRIPTION
Fixes #30.

## The bug

The "a deck needs at least one slide" guard tested the **current** slide count, but a delete can remove more than one slide — deleting a parent cascades to its interactive states.

So a deck of one linear slide + one state of it (`slides.length === 2`) sailed past `length <= 1`, and the cascade then took **both**, leaving zero slides and an editor with nothing to render.

Deterministic repro: load a two-slide deck where slide 2 is `stateOf` slide 1, click delete on the parent → `slides.length` goes 2 → 0, guard never fires.

## Fix

Check what will **survive** rather than what currently exists: compute the doomed set (target + its states) first, then require at least one *linear* slide outside it. States don't count as survivors — they're unreachable except through a parent, so a deck of nothing but states is as broken as an empty one.

## Verification

In the browser, five cases:

| case | expected | result |
|---|---|---|
| parent + its state, delete parent | refused | ✅ (was: 0 slides) |
| that state itself | still deletable | ✅ 1 linear left |
| two plain linear slides | normal delete | ✅ |
| last remaining slide | refused | ✅ |
| parent + state + another linear | parent and state both go | ✅ 3 → 1 |

The full starter deck (12 linear + 4 states) drains cleanly to exactly 1 slide and then refuses, with the toast. No console errors. `tsc -b` clean.

## Note on the report

The literal steps (delete down to one, add a slide, delete) do **not** reproduce — with two plain linear slides, deletion works correctly. The reporter's deck almost certainly contained an interactive state; the starter deck ships four, and any sweep down to "one slide" passes through the broken case above. Landing on a zero-slide deck is what makes deletion appear stuck.