### PR TITLE
Untrack slides/node_modules and harden the ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-# dependencies & build output
-node_modules/
+# dependencies & build output.
+# No trailing slash on node_modules: `node_modules/` matches DIRECTORIES only,
+# so a node_modules SYMLINK (what you get pointing a worktree at another
+# checkout's deps) slipped past it and was committed once. Match both forms.
+node_modules
 dist/
 dist-single/
 

--- a/slides/node_modules
+++ b/slides/node_modules
@@ -1,1 +1,0 @@
-/Users/andy/devel/bento/slides/node_modules


### PR DESCRIPTION
## The problem

`slides/node_modules` is committed to `main` as a **symlink** (mode 120000) whose content is an absolute path on one machine:

```
/Users/andy/devel/bento/slides/node_modules
```

Any fresh clone materialises a dangling symlink where the dependency tree belongs, so `npm install` has to fight it before anything builds. Worth fixing promptly now that the repo is public and taking outside contributions.

It entered in a13c4ce.

## Why .gitignore missed it

The rule was `node_modules/`. **A trailing slash matches directories only**, and a symlink is a file to git — so the rule that covers every normal install didn't cover the symlink form (what you get when a git worktree is pointed at another checkout's deps to avoid a second install). Dropping the slash matches both.

## Verification

With the new rule, both forms are ignored — checked with `--untracked-files=all`:

- `node_modules` as a **symlink** → ignored ✓
- `node_modules` as a real **directory** → ignored ✓

No dependency change. This only stops tracking a path that should never have been tracked.

## Disclosure

The symlink originated from my own tooling in an earlier session — I pointed a git worktree at this checkout's `node_modules` to typecheck without a second install, and it was picked up by an unrelated commit. Flagging that plainly rather than leaving it to look like a mystery.