### PR TITLE
Add theme-aware defaults for inserted tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Table defaults can follow the deck theme.** A deck may now define table
+  colours, typography, spacing, borders, and corner radius in `theme.table`.
+  Tables inserted from the toolbar inherit those defaults, and switching back
+  from the Minimal preset restores the themed header treatment. Existing decks
+  without table defaults keep the same built-in appearance.
+
 ## [1.0.10] — 2026-07-25
 
 - **Fix: deleting a slide could empty the deck entirely.** The "a deck needs at

--- a/docs/format.md
+++ b/docs/format.md
@@ -78,6 +78,7 @@ the string `</script>` can never appear and terminate the block.
 | `accent` | `string` | Single accent color; also seeds derived chart palettes. |
 | `fontFamily` | `string` | Default font stack. |
 | `chartPalette?` | `string[]` | Ordered series colors for new charts. Absent = derived from `accent`. |
+| `table?` | `Partial<TableStyle>` | Defaults for newly inserted tables. Omitted properties use the standard table style; existing tables retain their own `style`. |
 
 ---
 

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1393,11 +1393,10 @@ export class Editor {
     probe.src = src
   }
 
-  /** A fresh table styled to read on the CURRENT slide — on a dark background the
-   *  default dark body text / hairline borders would be invisible, so flip them
-   *  light (the header keeps its own dark-bg + white text, which reads on both). */
+  /** A themed table adapted to the current slide. Dark backgrounds need light
+   *  body text and separators; the theme still owns the header treatment. */
   private newTable(): TableElement {
-    const tbl = defaultTable()
+    const tbl = defaultTable({}, this.store.doc.theme)
     if (!isLightBg(this.store.slide.background)) {
       tbl.style.color = readableInk(this.store.slide.background)
       tbl.style.zebra = 'rgba(255,255,255,0.06)'

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -5,7 +5,7 @@
 // into a single undo checkpoint.
 
 import type { Store } from '../store'
-import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, internAsset, morphKey, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
+import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, internAsset, morphKey, tableStyleFor, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
 import { resolveAsset } from '../render'
 import { isMacOS } from '../screens'
 import { CHART_PRESETS } from '../charts'
@@ -1400,14 +1400,18 @@ export class PropsPanel {
       : st.borderWidth ? 'Lined'
       : st.zebra ? 'Zebra'
       : 'Minimal'
+    const themed = tableStyleFor(this.store.doc.theme)
     this.section(t('Style'))
     this.row('Preset', this.select(['Lined', 'Zebra', 'Boxed', 'Minimal'], preset, (v) =>
       this.mutate(el.id, (e) => {
         const s = (e as TableElement).style
-        s.borderWidth = v === 'Lined' || v === 'Boxed' ? 1 : 0
-        s.zebra = v === 'Zebra' || v === 'Boxed' ? 'rgba(30,42,58,0.05)' : undefined
+        s.borderWidth = v === 'Lined' || v === 'Boxed' ? Math.max(themed.borderWidth, 1) : 0
+        s.zebra = v === 'Zebra' || v === 'Boxed' ? themed.zebra ?? 'rgba(30,42,58,0.05)' : undefined
         if (v === 'Minimal') { s.headerBg = 'transparent'; s.headerColor = s.color }
-        else if (s.headerBg === 'transparent') { s.headerBg = '#1E2A3A'; s.headerColor = '#FFFFFF' }
+        else if (s.headerBg === 'transparent') {
+          s.headerBg = themed.headerBg
+          s.headerColor = themed.headerColor
+        }
       }, true)))
 
     this.row('Header fill', this.colorAlpha(st.headerBg, (v, fin) =>

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -381,6 +381,8 @@ export interface BentoDoc {
     fontFamily: string
     /** ordered series colours for new charts; derived from accent when absent */
     chartPalette?: string[]
+    /** defaults for newly inserted tables; omitted decks keep the standard look */
+    table?: Partial<TableStyle>
   }
   /** present-mode chrome; decks with built-in chrome can turn Reveal's off */
   present?: {
@@ -660,7 +662,28 @@ export function defaultChart(option: Record<string, unknown>, partial: Partial<C
   }
 }
 
-export function defaultTable(partial: Partial<TableElement> = {}): TableElement {
+const DEFAULT_TABLE_STYLE: TableStyle = {
+  headerBg: '#1E2A3A',
+  headerColor: '#FFFFFF',
+  zebra: 'rgba(30,42,58,0.05)',
+  borderColor: 'rgba(30,42,58,0.14)',
+  borderWidth: 1,
+  cellPadX: 16,
+  cellPadY: 11,
+  fontSize: 18,
+  color: '#1E2A3A',
+  radius: 10,
+}
+
+/** Resolve a new table's style from built-in defaults and optional deck overrides. */
+export function tableStyleFor(theme?: BentoDoc['theme']): TableStyle {
+  return { ...DEFAULT_TABLE_STYLE, ...(theme?.table ?? {}) }
+}
+
+export function defaultTable(
+  partial: Partial<TableElement> = {},
+  theme?: BentoDoc['theme'],
+): TableElement {
   const cell = (html: string): TableCell => ({ html })
   return {
     id: uid('tbl'),
@@ -674,18 +697,7 @@ export function defaultTable(partial: Partial<TableElement> = {}): TableElement 
       { cells: [cell('Row 1'), cell('—'), cell('—')] },
       { cells: [cell('Row 2'), cell('—'), cell('—')] },
     ],
-    style: {
-      headerBg: '#1E2A3A',
-      headerColor: '#FFFFFF',
-      zebra: 'rgba(30,42,58,0.05)',
-      borderColor: 'rgba(30,42,58,0.14)',
-      borderWidth: 1,
-      cellPadX: 16,
-      cellPadY: 11,
-      fontSize: 18,
-      color: '#1E2A3A',
-      radius: 10,
-    },
+    style: tableStyleFor(theme),
     ...partial,
   }
 }


### PR DESCRIPTION
## Summary

- add optional `theme.table` defaults for table colours, typography, spacing, borders, and corner radius
- apply those defaults when a table is inserted from the toolbar
- preserve the existing dark-slide readability adaptation for body text, zebra rows, and borders
- restore themed header and zebra treatments when switching table presets
- document the additive format field and add an Unreleased changelog entry

## Why

Charts already support deck-level defaults through `theme.chartPalette`, while tables must currently be restyled after every insertion. This change gives template authors the same kind of reusable default for tables without changing the per-element `TableStyle` model.

The field is optional and additive. Existing decks without `theme.table` keep the current built-in table appearance, and existing table elements retain their own saved `style`.

## Validation

- `cd slides && node_modules/.bin/tsc -b`
- `cd slides && npm run build:single`
- browser QA with a themed deck: verified header colour, border colour and width, font size, padding, radius, and the Boxed preset
- browser QA across `Minimal` → `Boxed`: verified the themed header and zebra treatment are restored
- browser QA with a deck that omits `theme.table`: verified the existing built-in defaults are unchanged
