### PR TITLE
Fix: blob offload never ran for images users actually insert

### DIFF
--- a/server/sync-worker/src/worker.js
+++ b/server/sync-worker/src/worker.js
@@ -110,6 +110,16 @@ async function sha256b64u(bytes) {
   return b64uEnc(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)))
 }
 
+/** CORS for the blob routes. A PUT with a content-type is not a "simple"
+ *  request, so browsers preflight it — OPTIONS must answer before any upload
+ *  can start. max-age keeps the preflight off the hot path for repeat uploads. */
+const CORS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, HEAD, PUT, OPTIONS',
+  'access-control-allow-headers': 'content-type',
+  'access-control-max-age': '86400',
+}
+
 export default {
   async fetch(req, env) {
     const url = new URL(req.url)
@@ -122,7 +132,21 @@ export default {
     // HMAC(roomKey, sha256(plaintext)), so the same image in two rooms yields
     // different keys and nothing correlates.
     const b = url.pathname.match(/^\/b\/([A-Za-z0-9._-]{1,80})\/([A-Za-z0-9_-]{16,64})$/)
-    if (b) return await blob(req, env, b[1], b[2])
+    if (b) {
+      // A .bento.html runs from file:// or from ANY origin someone serves it
+      // on, so blob fetches are always cross-origin and need CORS — without it
+      // the browser rejects them before the request is even sent, and the
+      // offload silently never happens. (WebSockets aren't subject to CORS,
+      // which is why live sync worked while only blobs failed.)
+      // Allowing any origin is safe here: the token is the capability, the
+      // bytes are ciphertext, and there are no cookies or credentials to ride
+      // along on a fetch the relay never treats as authenticated by origin.
+      if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: CORS })
+      const res = await blob(req, env, b[1], b[2])
+      const h = new Headers(res.headers)
+      for (const [k, v] of Object.entries(CORS)) h.set(k, v)
+      return new Response(res.body, { status: res.status, headers: h })
+    }
 
     const m = url.pathname.match(/^\/d\/([A-Za-z0-9._-]{1,80})$/)
     if (!m) {

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -8,7 +8,7 @@ import Moveable from 'moveable'
 import Selecto from 'selecto'
 import type { Store } from '../store'
 import { t } from '../i18n'
-import { defaultShape, readableInk, uid, type ShapeElement, type SlideElement, type TableElement } from '../model'
+import { defaultShape, internAsset, readableInk, uid, type ShapeElement, type SlideElement, type TableElement } from '../model'
 import { renderSlide, sanitizeHtml } from '../render'
 import { autoformatAtCaret, clearAutoformat, markdownToHtml, undoAutoformat } from './markdown'
 import { PathEditor } from './patheditor'
@@ -1340,7 +1340,16 @@ export class SlideCanvas {
     if (preview && slide.hover?.type === 'reveal' && preview !== slide.hover.default) {
       el.showOnHover = preview
     }
-    this.store.commit(() => this.store.slide.elements.push(el))
+    this.store.commit(() => {
+      // Embedded binary belongs in doc.assets, never inline on the element —
+      // that is what makes it reachable by the live-collab blob offload. Done
+      // INSIDE the commit so the asset and the element land as one undo step
+      // and one sync batch.
+      if ((el.type === 'image' || el.type === 'media') && typeof el.src === 'string') {
+        el.src = internAsset(this.store.doc, el.src)
+      }
+      this.store.slide.elements.push(el)
+    })
     this.store.select([el.id])
     if (startEditing && el.type === 'text') {
       const node = this.surface?.querySelector<HTMLElement>(`[data-el-id="${CSS.escape(el.id)}"]`)

--- a/slides/src/editor/clipboard.ts
+++ b/slides/src/editor/clipboard.ts
@@ -24,7 +24,8 @@ export interface ClipPayload {
 function assetKeysOf(els: SlideElement[]): Set<string> {
   const keys = new Set<string>()
   for (const el of els) {
-    if (el.type === 'image' && typeof el.src === 'string' && el.src.startsWith('asset:')) keys.add(el.src.slice(6))
+    // image AND media: both embed through doc.assets, so both can carry a ref
+    if ((el.type === 'image' || el.type === 'media') && typeof el.src === 'string' && el.src.startsWith('asset:')) keys.add(el.src.slice(6))
     const a = (el as { asset?: string }).asset
     if (typeof a === 'string') keys.add(a) // svg elements reference an asset key
   }
@@ -77,7 +78,7 @@ function mergeAssets(payload: ClipPayload, doc: BentoDoc): Map<string, string> {
 function rewriteRefs(els: SlideElement[], remap: Map<string, string>) {
   if (!remap.size) return
   for (const el of els) {
-    if (el.type === 'image' && typeof el.src === 'string' && el.src.startsWith('asset:')) {
+    if ((el.type === 'image' || el.type === 'media') && typeof el.src === 'string' && el.src.startsWith('asset:')) {
       const k = el.src.slice(6); if (remap.has(k)) el.src = 'asset:' + remap.get(k)
     }
     const a = (el as { asset?: string }).asset

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1488,8 +1488,10 @@ export class Editor {
       const place = (w: number, h: number) => {
         const { width, height } = this.store.doc.size
         const el = defaultImage(src, { x: Math.round((width - w) / 2), y: Math.round((height - h) / 2), w, h, fit: 'contain' })
-        this.store.commit(() => this.store.slide.elements.push(el))
-        this.store.select([el.id])
+        // via canvas.insert, so a pasted photo is interned into doc.assets on
+        // the same path as every other embed — otherwise it stays inline and
+        // live collab can never send it.
+        this.canvas.insert(el)
         this.toast(t('Image pasted'))
       }
       const img = new Image()

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -5,7 +5,8 @@
 // into a single undo checkpoint.
 
 import type { Store } from '../store'
-import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, morphKey, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
+import { MEDIA_EMBED_BUDGET, applyChartPalette, defaultChart, internAsset, morphKey, uid, type ChartElement, type LineEnding, type MediaElement, type ShapeElement, type Slide, type SlideElement, type TableElement, type TextElement, type TransitionKind } from '../model'
+import { resolveAsset } from '../render'
 import { isMacOS } from '../screens'
 import { CHART_PRESETS } from '../charts'
 import { FONT_CHOICES, firstFamily, injectFonts } from '../fonts'
@@ -1528,9 +1529,12 @@ export class PropsPanel {
     // source status: embedded (with size) / linked / none
     const status = document.createElement('p')
     status.className = 'ed-hint'
+    // Resolve first: an embed is stored as an `asset:` ref, so testing el.src
+    // directly would report an embedded clip as "linked".
+    const resolved = el.src ? resolveAsset(this.store.doc, el.src) : ''
     if (!el.src) status.textContent = t('No source yet — choose a file or paste a URL.')
-    else if (el.src.startsWith('data:')) {
-      const kb = Math.round((el.src.length * 3) / 4 / 1024)
+    else if (resolved.startsWith('data:')) {
+      const kb = Math.round((resolved.length * 3) / 4 / 1024)
       status.innerHTML = t('Embedded in the file') + ` · <b>${kb >= 1024 ? (kb / 1024).toFixed(1) + ' MB' : kb + ' KB'}</b>`
     } else status.textContent = t('Linked — the deck stays small but needs this URL to play.')
     this.host.appendChild(status)
@@ -1551,7 +1555,11 @@ export class PropsPanel {
           if (!confirm(t('This file is {mb} MB. Embedding makes the .bento.html large and slow to open and save. Embed anyway?', { mb }))) return
         }
         const reader = new FileReader()
-        reader.onload = () => this.mutate(el.id, (e) => { (e as MediaElement).src = String(reader.result) }, true)
+        // interned, not inline — same reason as every other embed site: only
+        // doc.assets entries are reachable by the live-collab blob offload.
+        reader.onload = () => this.mutate(el.id, (e) => {
+          (e as MediaElement).src = internAsset(this.store.doc, String(reader.result))
+        }, true)
         reader.readAsDataURL(file)
       })
       input.click()
@@ -1562,7 +1570,7 @@ export class PropsPanel {
     const url = document.createElement('input')
     url.type = 'text'
     url.placeholder = t('…or paste a media URL')
-    url.value = el.src && !el.src.startsWith('data:') ? el.src : ''
+    url.value = el.src && !el.src.startsWith('data:') && !el.src.startsWith('asset:') ? el.src : ''
     url.addEventListener('change', () =>
       this.mutate(el.id, (e) => { (e as MediaElement).src = url.value.trim() }, true))
     this.row('URL', url)

--- a/slides/src/model.ts
+++ b/slides/src/model.ts
@@ -718,6 +718,28 @@ export function defaultImage(src: string, partial: Partial<ImageElement> = {}): 
   }
 }
 
+/** Park an embedded data URI in `doc.assets` and return an `asset:` ref.
+ *
+ *  Every embed goes through here so there is exactly ONE place binary content
+ *  lives. That matters beyond tidiness: live collab offloads large `assets`
+ *  entries to the relay's blob store, so an image written straight onto
+ *  `el.src` was invisible to the offload and rode inline in an op batch far
+ *  too big for a frame — it reached collaborators as nothing at all.
+ *
+ *  Identical bytes reuse the same key, so duplicating an image (or pasting the
+ *  same photo twice) costs one copy in the file and one upload on the wire.
+ *  A URL or an existing `asset:` ref passes straight through — only `data:`
+ *  is interned. Callers MUST run this inside a `store.commit` so the assets
+ *  write is part of the same undo step and the same sync batch. */
+export function internAsset(doc: BentoDoc, src: string): string {
+  if (!src.startsWith('data:')) return src
+  const assets = (doc.assets ??= {})
+  for (const k in assets) if (assets[k] === src) return `asset:${k}`
+  const key = uid('a')
+  assets[key] = src
+  return `asset:${key}`
+}
+
 /** Soft ceiling for embedding media as a data URI (bytes). Above this the
  *  editor warns — a big embed makes the .bento.html slow to open and save. */
 export const MEDIA_EMBED_BUDGET = 8 * 1024 * 1024 // 8 MB

--- a/slides/src/sync/session.ts
+++ b/slides/src/sync/session.ts
@@ -279,7 +279,7 @@ export class SyncSession {
   private async offloadAssets() {
     const doc = this.store.doc
     const assets = doc.assets ?? {}
-    const creds = this.blobCreds?.() ?? null
+    const creds = this.blobCreds()
     for (const [k, v] of Object.entries(assets)) {
       if (typeof v !== 'string' || v.length <= BLOB_INLINE_MAX) continue
       if (doc.blobs?.[k]) continue // already published
@@ -319,7 +319,7 @@ export class SyncSession {
   private async resolveBlobs() {
     const doc = this.store.doc
     const refs = doc.blobs ?? {}
-    const creds = this.blobCreds?.() ?? null
+    const creds = this.blobCreds()
     for (const [k, ref] of Object.entries(refs)) {
       if (doc.assets?.[k]) continue // already have the bytes
       if (this.fetching.has(ref.key)) continue
@@ -342,7 +342,25 @@ export class SyncSession {
 
   private fetching = new Set<string>()
   /** set by the editor when an online transport exists */
-  blobCreds: (() => { base: string; room: string; tok: string; rawKey: Uint8Array } | null) | null = null
+  /** Credentials the blob layer needs, taken from whichever transport can
+   *  reach a relay.
+   *
+   *  Resolved ON DEMAND, deliberately. The obvious shape — a hook assigned when
+   *  the online transport connects — is what shipped broken: nothing ever
+   *  assigned it, so `creds` was always null, every upload was skipped by the
+   *  `if (!creds) continue` guard, and the whole offload was inert with no
+   *  error anywhere. Transports are also torn down and rebuilt on reconnect and
+   *  on rejoin, so even a correctly-assigned hook goes stale. Asking the live
+   *  transport list each time cannot drift. */
+  private blobCreds(): { base: string; room: string; tok: string; rawKey: Uint8Array } | null {
+    for (const tr of this.transports) {
+      const f = (tr as { blobCreds?: () => { base: string; room: string; tok: string; rawKey: Uint8Array } | null }).blobCreds
+      if (typeof f !== 'function') continue
+      const c = f.call(tr)
+      if (c) return c
+    }
+    return null
+  }
   private notify(code: string, detail?: string) {
     // routed through the existing notice channel so the editor can toast it
     try { (this as unknown as { noticeFn?: (c: string, d?: string) => void }).noticeFn?.(code, detail) } catch { /* none */ }


### PR DESCRIPTION
Follow-up to #57. That PR was verified end to end **at the protocol layer** and was still completely inert in the product. Found by driving two real browser windows instead of scripting the transport.

Three independent defects, each sufficient on its own to stop the feature:

### 1. Embeds bypassed `doc.assets` entirely
Both insert paths — the toolbar file picker (`pickImage`) and paste (`pasteImageFile`) — wrote the data URI **straight onto `el.src`**. `offloadAssets()` walks `doc.assets`, so nothing a user inserted was ever a candidate; the only entries there are the starter deck's textures and fonts.

Every embed now goes through `internAsset()` and the element carries an `asset:` ref. One place binary content lives, and identical bytes dedupe — pasting the same photo twice is one copy in the file and one upload on the wire.

### 2. `blobCreds` was declared and read, but never assigned
Always `null`, so `if (!creds) continue` skipped every upload **with no error anywhere**. It now resolves from the live transport list on demand rather than being a hook someone must remember to wire — transports are rebuilt on reconnect and rejoin, so even a correctly-assigned hook would go stale.

### 3. The relay sent no CORS headers
A `.bento.html` runs from `file://` or any origin someone serves it on, so blob fetches are **always** cross-origin. The browser rejected them before sending (`TypeError: Failed to fetch`). WebSockets aren't subject to CORS — which is exactly why live sync worked while only blobs failed, and why a Node test could never catch it. A PUT with a content-type isn't a simple request either, so OPTIONS must answer first.

**The relay is already deployed** with this change (version `92483c0e`), per the deploy-relay-before-client rule.

## Also
Media interns like images, so the clipboard carries media asset refs across decks, and the media panel resolves `asset:` before reporting embedded vs linked (it would otherwise call an embedded clip "linked").

## Verified
Two browser windows on **different origins** (`localhost` vs `127.0.0.1`, so BroadcastChannel and the shared per-origin IndexedDB cache cannot mask the relay path), against the **production** relay:

- pasted a 6.6 MB photo → element op syncs small, bytes upload out-of-band
- peer fetches, decrypts, materialises — **SHA-256 identical on both peers** for all three assets
- images **render** on the far side (screenshot confirmed, `naturalWidth` 1600×1200)
- the 6.6 MB upload that failed while CORS was broken **retried on the next edit and succeeded**, exercising the retry-on-next-flush path

Rig `SEEDS=300` ALL PASS. Splice gate OK.

## Note for the release
This is why 1.0.10 shouldn't have been cut yet — the changelog claim "photos and video now work in live collaboration" was false until this lands.