### PR TITLE
Release prep 1.0.10 — version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.10] — 2026-07-25
+
+- **Fix: deleting a slide could empty the deck entirely.** The "a deck needs at
+  least one slide" guard counted the slides you had rather than the ones that
+  would be left — and deleting a slide also deletes its interactive states. So
+  a deck holding one slide plus one state of it passed the check, lost both,
+  and left the editor with nothing to show. Deletion then appeared stuck. The
+  guard now checks what survives.
+
+- **Fix: setting a morph id by hand did nothing.** Pairing two elements across
+  slides via the Morph panel silently failed — the element matched up but never
+  animated, so morphing only worked through the duplicate-a-slide route. Both
+  ways work now.
+
 - **Photos and video now work in live collaboration.** This finishes what
   1.0.9 could only warn you about: previously anything past about half a
   megabyte was simply too big to send to your collaborators. Now a large image

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cut prep. No code changes — version bump plus the changelog entries that were missing.

- Dates `[Unreleased]` as **1.0.10**
- Adds entries for two fixes that landed without them: the slide-deletion data-loss bug (#30, via #61) and the morph-id pairing bug (#54, via #59)
- The media entry closes the loop on 1.0.9's note that larger media "needs a deeper change, and it's next" — it landed

## Verified
Built shell from `file://`: `APP_VERSION` 1.0.10, starter deck loads, no console errors. Splice gate OK, rig `SEEDS=300` ALL PASS.

## Not in this release
[#63](https://github.com/nyblnet/bento/pull/63) (theme-aware table defaults, external contributor). The code reads well and provenance checks out, but **no CI has run on it** — fork PRs don't trigger the workflow — so it isn't going into a release unverified. Worth landing right after, with checks run.

## Release state
Relay is already deployed with the blob + CORS changes (`92483c0e`), so the deploy-before-client ordering is satisfied. Remaining steps are the local signed ones in docs/RELEASING.md: tag, `scripts/release.mjs`, publish `./site/`.