### PR TITLE
Update save picker: suggest the open file's own name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Updating a file now suggests that file's own name.** When an update asks
+  where to save, the dialog is pre-filled with the name of the deck you have
+  open rather than one derived from its title — so a file called
+  `Q3-board.bento.html` no longer offers to save itself as
+  `Q3_Board_Review.bento.html`. The backup written alongside an in-place update
+  follows the same name. Where the save dialog opens is set by the browser and
+  can't be pointed at a folder by the page, but it now remembers the last place
+  you saved, so the second update onwards starts in the right directory.
+
 ## [1.0.10] — 2026-07-25
 
 - **Table defaults can follow the deck theme.** A deck may now define table

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -195,10 +195,19 @@ let fileHandle: FsFileHandle | null = null
 
 const hasFsAccess = () => typeof (window as any).showSaveFilePicker === 'function'
 
-async function pickHandle(doc: KernelDoc, suffix = ''): Promise<FsFileHandle | null> {
+async function pickHandle(
+  doc: KernelDoc, suffix = '', suggestedName?: string,
+): Promise<FsFileHandle | null> {
   try {
     return await (window as any).showSaveFilePicker({
-      suggestedName: suggestedFileName(doc, suffix),
+      suggestedName: suggestedName ?? suggestedFileName(doc, suffix),
+      // startIn takes a HANDLE, never a path — the API gives no way to point a
+      // picker at an arbitrary directory, by design. With a handle we land in
+      // the open file's own folder; without one, `id` is the fallback: the
+      // browser remembers the last directory used under this id, so the second
+      // update onwards opens where the first one saved.
+      ...(fileHandle ? { startIn: fileHandle } : {}),
+      id: 'bento-doc',
       types: [{ description: appConfig().appName, accept: { 'text/html': ['.html'] } }],
     })
   } catch (err: any) {
@@ -245,6 +254,31 @@ export async function saveFile(doc: KernelDoc, forcePicker = false): Promise<Sav
 
 export const currentFileName = () => fileHandle?.name ?? null
 
+/**
+ * The name of the file this document is actually open AS, when knowable.
+ *
+ * Two sources, best first: a held FS Access handle, else this document's own
+ * URL. The URL case is the one that matters — a `.bento.html` double-clicked
+ * from disk grants no handle, which is exactly when a save picker appears with
+ * nothing useful in it.
+ *
+ * Only a name ending in `.bento.html` counts. That deliberately excludes the
+ * hosted demo (`/slides/`, `index.html`), so the anonymous try-it deck still
+ * falls back to naming itself after its title instead of "index".
+ */
+export function openedFileName(): string | null {
+  if (fileHandle?.name) return fileHandle.name
+  try {
+    const base = decodeURIComponent(new URL(location.href).pathname.split('/').pop() ?? '')
+    return /\.bento\.html$/i.test(base) ? base : null
+  } catch {
+    return null
+  }
+}
+
+/** Strip the document extension: "Q3-board.bento.html" -> "Q3-board". */
+export const fileBase = (name: string) => name.replace(/\.bento\.html$/i, '').replace(/\.html$/i, '')
+
 // --- self-update writing ----------------------------------------------------
 
 /** Whether we hold a writable handle to the file (in-place update possible). */
@@ -264,13 +298,13 @@ export async function writeUpdatedFile(html: string): Promise<void> {
 export async function writeUpdatedFileAs(
   html: string,
   doc: KernelDoc,
-  opts: { suffix?: string; keepHandle?: boolean } = {},
+  opts: { suffix?: string; keepHandle?: boolean; suggestedName?: string } = {},
 ): Promise<boolean> {
   if (!hasFsAccess()) {
-    downloadFile(html, suggestedFileName(doc, opts.suffix))
+    downloadFile(html, opts.suggestedName ?? suggestedFileName(doc, opts.suffix))
     return true
   }
-  const handle = await pickHandle(doc, opts.suffix)
+  const handle = await pickHandle(doc, opts.suffix, opts.suggestedName)
   if (!handle) return false
   // Share/export artifacts must NOT become the ⌘S target — otherwise the next
   // save would overwrite e.g. a view-only copy with the FULL document (owner

--- a/kernel/src/update.ts
+++ b/kernel/src/update.ts
@@ -22,7 +22,7 @@
 import type { KernelDoc } from './doc.ts'
 import { appConfig } from './app.ts'
 import {
-  serializeDocInto, serializeAuto, suggestedFileName, downloadFile,
+  serializeDocInto, serializeAuto, suggestedFileName, downloadFile, openedFileName, fileBase,
   hasFileHandle, writeUpdatedFile, writeUpdatedFileAs,
 } from './save.ts'
 
@@ -174,9 +174,12 @@ export async function buildUpdatedFile(release: ReleaseInfo, doc: KernelDoc): Pr
   return serializeDocInto(shell, doc)
 }
 
-/** Build the updated file and hand it to the user as a fresh download. */
+/** Build the updated file and hand it to the user as a fresh download.
+ *  Named after the file they have open, not the deck title — an update
+ *  REPLACES that file, so "Q3-board.bento.html" is the answer even when the
+ *  deck is titled "Q3 Board Review". */
 export async function applyUpdate(release: ReleaseInfo, doc: KernelDoc): Promise<void> {
-  downloadFile(await buildUpdatedFile(release, doc), suggestedFileName(doc))
+  downloadFile(await buildUpdatedFile(release, doc), openedFileName() ?? suggestedFileName(doc))
 }
 
 /** Can we rewrite the open file directly (a FS Access handle is held)? */
@@ -190,18 +193,23 @@ export const canUpdateInPlace = hasFileHandle
  *
  * Without a handle (e.g. the file was double-clicked open — the browser grants
  * no handle on open): use a save picker AND KEEP the resulting handle, so this
- * update and every later one can rewrite the file in place. The picker can't
- * default to the open file's location without a handle, so the caller must tell
- * the user to overwrite the file they have open; once they do, it is a one-time
- * grant. Returns false if the picker was cancelled.
+ * update and every later one can rewrite the file in place. The picker is
+ * pre-filled with the open file's own NAME (taken from the document URL); its
+ * DIRECTORY still cannot be set — the API accepts a handle, never a path — so
+ * the caller must still tell the user to overwrite the file they have open.
+ * Once they do, it is a one-time grant. Returns false if cancelled.
  */
 export async function applyUpdateInPlace(release: ReleaseInfo, doc: KernelDoc): Promise<boolean> {
   const html = await buildUpdatedFile(release, doc)
+  // Both names below follow the OPEN FILE, not the deck title: the backup sits
+  // beside the original, and the picker opens pre-filled with the very file the
+  // user is being asked to overwrite.
+  const current = openedFileName()
   if (hasFileHandle()) {
-    const base = suggestedFileName(doc).replace(/\.bento\.html$/, '')
+    const base = fileBase(current ?? suggestedFileName(doc))
     downloadFile(await serializeAuto(doc), `${base}.v${APP_VERSION}-backup.bento.html`)
     await writeUpdatedFile(html)
     return true
   }
-  return writeUpdatedFileAs(html, doc, { keepHandle: true })
+  return writeUpdatedFileAs(html, doc, { keepHandle: true, suggestedName: current ?? undefined })
 }


### PR DESCRIPTION
Reported after the 1.0.10 update: the save dialog offered a name derived from the **deck title**, so a file called `Q3-board.bento.html` proposed saving itself as `Q3_Board_Review.bento.html`. An update *replaces* the open file, so the file's own name is the right answer.

## What changed
- **`openedFileName()`** in the kernel — the name this document is open as: a held FS Access handle, else the document URL's basename. The URL case is the one that matters, because a `.bento.html` double-clicked from disk grants **no** handle, which is exactly when a picker appears with nothing useful in it.
- Only names ending in `.bento.html` count. That deliberately excludes the hosted demo (`/slides/`, `index.html`) so the anonymous try-it deck still names itself after its title, not "index".
- Used by all three update outputs: the downloaded copy, the "Update this file…" picker, and the backup written beside an in-place update.
- **Ordinary saves are unchanged** and still follow the title — a freshly downloaded `Bento_Slides.bento.html` that has never been saved must not propose overwriting the app itself when you first save a deck you just wrote.

## About the directory
A page **cannot** point a save dialog at a path — `showSaveFilePicker` takes a *handle*, never a path, by design. So:
- `startIn` is passed when a handle is held → lands in the open file's own folder.
- A stable `id` is set → the browser remembers the last directory used under it, so the second update onwards opens where the first one saved.

The stale comment claiming the picker "can't default to the open file's location" is corrected: the **name** now can, the **folder** still can't.

## Verified
In the browser against a **locally signed 1.0.11 test manifest** — the real update path, not a stub. A deck served as `Q3-board.bento.html` and titled "Q3 Board Review":

| | before | after |
|---|---|---|
| downloaded copy | `Q3_Board_Review.bento.html` | `Q3-board.bento.html` |
| picker `suggestedName` | `Q3_Board_Review.bento.html` | `Q3-board.bento.html` |
| picker `id` | — | `bento-doc` |

With a handle held, the update still writes in place with no picker at all.

Rig `SEEDS=200` ALL PASS. Splice gate OK. Kernel-zone change, so it ships to every app.