### PR TITLE
Starter deck: restore the "Bento Slides Showcase" title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ pre-1.0.
   follows the same name. Where the save dialog opens is set by the browser and
   can't be pointed at a folder by the page, but it now remembers the last place
   you saved, so the second update onwards starts in the right directory.
+- **The starter deck is called “Bento Slides Showcase” again.** The lowercase
+  rebrand swept the deck's own title along with the app's, but a deck title is
+  a document name — it shows in the window title and becomes the suggested
+  filename — so it reads better in title case. The `bento/slides` wordmark is
+  unchanged.
 
 ## [1.0.10] — 2026-07-25
 

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -311,7 +311,10 @@ const DOTS_PAPER =
 
 export function starterDoc(): BentoDoc {
   const doc = newDoc()
-  doc.title = 'bento/slides showcase'
+  // The DECK's title, not the app's — it reads as a document name (window title,
+  // suggested filename), so it stays in title case. The lowercase `bento/slides`
+  // wordmark is app chrome and is unaffected.
+  doc.title = 'Bento Slides Showcase'
   doc.theme.fontFamily = BODY
   doc.theme.accent = PEACH
   // new charts (＋ Chart, table→chart) inherit the deck's midnight-&-peach family


### PR DESCRIPTION
The lowercase rebrand (`2b3214f`) swept the **deck's** title along with the app's. Those are different things: a deck title is a *document* name — it shows in the window title and is what `suggestedFileName()` turns into a filename — so it belongs in title case.

`bento/slides` stays the wordmark. The About tooltip, the on-slide `BENTO/SLIDES` kicker, and every other piece of app chrome are untouched.

I checked the rest of that rebrand commit: this was the **only** document title it lowercased. Everything else it changed reads through `appConfig().appName` (app chrome, correctly lowercase), and `newDoc()` still defaults to `'Untitled'`.

## Verified in the browser
| | |
|---|---|
| deck title | Bento Slides Showcase |
| window title | Bento Slides Showcase — bento/slides |
| suggested filename | `Bento_Slides_Showcase.bento.html` |
| wordmark | `bento/slides` (unchanged) |

Split out of #70 so each PR carries one concern.