### PR TITLE
Add "Start from scratch…" — reset a deck to one blank slide (#31)

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -512,12 +512,40 @@ export class Editor {
       item(ICONS.code, t('Replace from JSON…'),
         t('Paste edited document JSON to replace this deck’s content — ⌘Z undoes.'),
         () => this.openReplaceJson())
+      item(ICONS.template, t('Start from scratch…'),
+        t('Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.'),
+        () => this.startFromScratch())
     }
     wrap.append(trigger, menu)
     document.addEventListener('pointerdown', (ev) => {
       if (!wrap.contains(ev.target as Node)) wrap.classList.remove('open')
     })
     return wrap
+  }
+
+  /**
+   * Clear the deck back to a single blank slide (issue #31). Starting a fresh
+   * presentation meant deleting every slide by hand, then stripping the one
+   * the deck refuses to delete.
+   *
+   * CONTENT ONLY: docId, theme, size, layouts and the live session all stay.
+   * "Duplicate as new deck…" (above) is the action that changes IDENTITY, and
+   * conflating the two here would be the surprising choice — under collab this
+   * lands as an ordinary edit everyone sees, which is what "let's start over
+   * on this deck" means. One commit, so ⌘Z brings the whole deck back.
+   */
+  private startFromScratch() {
+    const n = this.store.doc.slides.length
+    if (!window.confirm(t('Replace all {n} slides with one blank slide? ⌘Z undoes this.', { n: String(n) }))) return
+    const blank = builtinLayouts().find((l) => l.id === 'layout-blank')
+    if (!blank) return
+    this.canvas.commitTextEdit() // a live text edit would commit ONTO the new slide
+    this.store.select([])
+    this.store.commit(() => {
+      this.store.doc.slides = [instantiateLayout(blank)]
+    }, 'slides')
+    this.store.goTo(0)
+    this.store.emit('current')
   }
 
   /** A sealed hand-out: present-only player file, no editor, no live session. */

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -659,4 +659,7 @@ export const de: Catalog = {
   "Add a point on the path; double-click a point to remove it": "Punkt auf dem Pfad hinzufügen; Punkt doppelklicken zum Entfernen",
   "Set how fast the element moves through that point": "Legt fest, wie schnell das Element diesen Punkt durchläuft",
   "Scroll a point": "Punkt scrollen",
+  "Start from scratch…": "Von vorne beginnen…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Ersetzt alle Folien durch eine einzige leere Folie. Design, Name und Live-Sitzung der Präsentation bleiben erhalten — ⌘Z macht es rückgängig.",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Alle {n} Folien durch eine leere Folie ersetzen? ⌘Z macht dies rückgängig.",
 }

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -659,4 +659,7 @@ export const es: Catalog = {
   "Add a point on the path; double-click a point to remove it": "Añade un punto en la trayectoria; doble clic en un punto para quitarlo",
   "Set how fast the element moves through that point": "Ajusta la velocidad con que el elemento pasa por ese punto",
   "Scroll a point": "Desplázate sobre un punto",
+  "Start from scratch…": "Empezar de cero…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Reemplaza todas las diapositivas por una diapositiva en blanco. Conserva el tema, el nombre y la sesión en vivo de la presentación — ⌘Z lo deshace.",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "¿Reemplazar las {n} diapositivas por una diapositiva en blanco? ⌘Z lo deshace.",
 }

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -659,4 +659,7 @@ export const fr: Catalog = {
   "Add a point on the path; double-click a point to remove it": "Ajoute un point sur la trajectoire ; double-clic sur un point pour le retirer",
   "Set how fast the element moves through that point": "Définit la vitesse à laquelle l'élément passe par ce point",
   "Scroll a point": "Faites défiler un point",
+  "Start from scratch…": "Repartir de zéro…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Remplace toutes les diapositives par une seule diapositive vierge. Conserve le thème, le nom et la session en direct de la présentation — ⌘Z annule.",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Remplacer les {n} diapositives par une diapositive vierge ? ⌘Z annule cette action.",
 }

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -659,4 +659,7 @@ export const it: Catalog = {
   "Add a point on the path; double-click a point to remove it": "Aggiungi un punto sulla traiettoria; doppio clic su un punto per rimuoverlo",
   "Set how fast the element moves through that point": "Imposta la velocità con cui l’elemento attraversa quel punto",
   "Scroll a point": "Scorri un punto",
+  "Start from scratch…": "Ricomincia da capo…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Sostituisce tutte le diapositive con una sola diapositiva vuota. Mantiene tema, nome e sessione dal vivo della presentazione — ⌘Z annulla.",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Sostituire tutte le {n} diapositive con una diapositiva vuota? ⌘Z annulla l’operazione.",
 }

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -659,4 +659,7 @@ export const ja: Catalog = {
   "Add a point on the path; double-click a point to remove it": "パス上に点を追加。点をダブルクリックで削除",
   "Set how fast the element moves through that point": "その点を通過する速さを設定",
   "Scroll a point": "点をスクロール",
+  "Start from scratch…": "最初から始める…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "すべてのスライドを 1 枚の空白スライドに置き換えます。プレゼンテーションのテーマ、名前、ライブセッションはそのまま残ります — ⌘Z で元に戻せます。",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "{n} 枚すべてのスライドを 1 枚の空白スライドに置き換えますか？ ⌘Z で元に戻せます。",
 }

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -659,4 +659,7 @@ export const zhHans: Catalog = {
   "Add a point on the path; double-click a point to remove it": "在路径上添加点；双击某点将其删除",
   "Set how fast the element moves through that point": "设置元素通过该点的速度",
   "Scroll a point": "滚动某点",
+  "Start from scratch…": "从头开始…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "将所有幻灯片替换为一张空白幻灯片。演示文稿的主题、名称和实时协作会话都会保留 — ⌘Z 可撤销。",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "将全部 {n} 张幻灯片替换为一张空白幻灯片？⌘Z 可撤销。",
 }

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -659,4 +659,7 @@ export const zhHant: Catalog = {
   "Add a point on the path; double-click a point to remove it": "在路徑上新增點；連按兩下某點可移除",
   "Set how fast the element moves through that point": "設定元素通過該點的速度",
   "Scroll a point": "捲動某點",
+  "Start from scratch…": "從頭開始…",
+  "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "將所有投影片取代為一張空白投影片。簡報的主題、名稱與即時協作工作階段都會保留 — ⌘Z 可復原。",
+  "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "將全部 {n} 張投影片取代為一張空白投影片？⌘Z 可復原。",
 }


### PR DESCRIPTION
Closes #31.

## The ask

> A single button to delete all slides of the current presentation leaving just a default blank slide.

Today that's: delete every slide by hand, then strip the elements off the one slide the deck won't let you delete.

## What this adds

A **"Start from scratch…"** item in the Save dropdown's "document as data" section, beside "Replace from JSON…".

**Content only, deliberately.** `docId`, theme, size, layouts, title and the live session all stay — only the slide list is replaced. "Duplicate as new deck…" sits two items above and is the action that changes *identity*; conflating the two here would be the surprising choice. Under collab this lands as an ordinary edit everyone sees, which is what "let's start over on this deck" means.

**Safety.** One `store.commit`, so ⌘Z restores the entire deck. The confirm names the slide count instead of asking an abstract question, and says undo works.

## Verification

Against the starter deck (16 slides), in the browser:

- menu item appears last in the data section
- cancelling the confirm changes nothing — still 16 slides
- confirming leaves exactly **1 slide, 0 elements**
- `docId`, title and theme accent untouched
- **⌘Z restores all 16 slides**, 39 elements on slide 1, all 4 interactive states, and the sidebar re-renders 16 thumbnails; redo re-clears
- confirm interpolates: *"Replace all 16 slides with one blank slide? ⌘Z undoes this."*

## i18n

3 new strings in all 7 catalogs, matching each one's existing rendering of "deck" (Präsentation / presentación / présentation / presentazione / 演示文稿 / 簡報).

Verified through the **real lookup path** rather than by eyeballing the files: `setLocale(loc)` + `t(key)` returns a translation — not the English fallback — in every locale, with `{n}` interpolating correctly. (A key that doesn't match the source byte-for-byte silently falls back, so string-matching the catalogs would not have caught a mismatch.)

Translations are machine-drafted, consistent with the existing catalogs' own header note — native review welcome.

`tsc -b` clean.