### PR TITLE
Morph panel: an explicit way to unpair (#54 follow-up)

### DIFF
--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -18,6 +18,13 @@ import { t } from '../i18n'
 // i18n NOTE: both the keys (row labels) and the values here reach t() as
 // VARIABLES — literal-extraction sweeps must treat this table as in-use
 // catalog keys, never prune them.
+/**
+ * Sentinel <option> value for "clear the morph override". Safe against
+ * collision with a real morph key by construction: setMorphId strips anything
+ * outside [A-Za-z0-9._-], so no stored morphId can ever contain '#'.
+ */
+const UNPAIR = '#unpair'
+
 const ROW_TIPS: Record<string, string> = {
   'Page size': 'Deck-wide slide size. Elements keep their positions — changing size reframes the canvas, never rescales your art.',
   'Width': 'Custom slide width in pixels',
@@ -477,12 +484,23 @@ export class PropsPanel {
     this.row('Morph id', input)
 
     const targets = this.morphTargets(el)
-    if (targets.length) {
+    // `|| el.morphId`: a paired element with no OTHER slide to pair with still
+    // needs the picker — otherwise there is nowhere to unpair from.
+    if (targets.length || el.morphId) {
       const sel = document.createElement('select')
       const none = document.createElement('option')
       none.value = ''
       none.textContent = t('(pick an element)')
       sel.appendChild(none)
+      // Clearing an override had no affordance: the documented way is to retype
+      // the element's own id into the field above, which means knowing what it
+      // was (issue #54). Offer it as a choice instead.
+      if (el.morphId) {
+        const un = document.createElement('option')
+        un.value = UNPAIR
+        un.textContent = t('Don’t pair — use its own id')
+        sel.appendChild(un)
+      }
       for (const tgt of targets) {
         const o = document.createElement('option')
         o.value = tgt.key
@@ -492,7 +510,8 @@ export class PropsPanel {
       }
       sel.addEventListener('change', () => {
         if (!sel.value) return
-        const err = this.setMorphId(el, sel.value)
+        // writing the element's OWN id is what clears the override
+        const err = this.setMorphId(el, sel.value === UNPAIR ? el.id : sel.value)
         if (err) { warn.textContent = err; warn.style.display = '' }
       })
       this.row('Pair with', sel)

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -662,4 +662,5 @@ export const de: Catalog = {
   "Start from scratch…": "Von vorne beginnen…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Ersetzt alle Folien durch eine einzige leere Folie. Design, Name und Live-Sitzung der Präsentation bleiben erhalten — ⌘Z macht es rückgängig.",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Alle {n} Folien durch eine leere Folie ersetzen? ⌘Z macht dies rückgängig.",
+  "Don’t pair — use its own id": "Nicht verknüpfen — eigene ID verwenden",
 }

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -662,4 +662,5 @@ export const es: Catalog = {
   "Start from scratch…": "Empezar de cero…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Reemplaza todas las diapositivas por una diapositiva en blanco. Conserva el tema, el nombre y la sesión en vivo de la presentación — ⌘Z lo deshace.",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "¿Reemplazar las {n} diapositivas por una diapositiva en blanco? ⌘Z lo deshace.",
+  "Don’t pair — use its own id": "No emparejar — usar su propio id",
 }

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -662,4 +662,5 @@ export const fr: Catalog = {
   "Start from scratch…": "Repartir de zéro…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Remplace toutes les diapositives par une seule diapositive vierge. Conserve le thème, le nom et la session en direct de la présentation — ⌘Z annule.",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Remplacer les {n} diapositives par une diapositive vierge ? ⌘Z annule cette action.",
+  "Don’t pair — use its own id": "Ne pas associer — utiliser son propre id",
 }

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -662,4 +662,5 @@ export const it: Catalog = {
   "Start from scratch…": "Ricomincia da capo…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "Sostituisce tutte le diapositive con una sola diapositiva vuota. Mantiene tema, nome e sessione dal vivo della presentazione — ⌘Z annulla.",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "Sostituire tutte le {n} diapositive con una diapositiva vuota? ⌘Z annulla l’operazione.",
+  "Don’t pair — use its own id": "Non abbinare — usa il proprio id",
 }

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -662,4 +662,5 @@ export const ja: Catalog = {
   "Start from scratch…": "最初から始める…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "すべてのスライドを 1 枚の空白スライドに置き換えます。プレゼンテーションのテーマ、名前、ライブセッションはそのまま残ります — ⌘Z で元に戻せます。",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "{n} 枚すべてのスライドを 1 枚の空白スライドに置き換えますか？ ⌘Z で元に戻せます。",
+  "Don’t pair — use its own id": "ペアにしない — 自身の id を使う",
 }

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -662,4 +662,5 @@ export const zhHans: Catalog = {
   "Start from scratch…": "从头开始…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "将所有幻灯片替换为一张空白幻灯片。演示文稿的主题、名称和实时协作会话都会保留 — ⌘Z 可撤销。",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "将全部 {n} 张幻灯片替换为一张空白幻灯片？⌘Z 可撤销。",
+  "Don’t pair — use its own id": "不配对 — 使用自身 id",
 }

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -662,4 +662,5 @@ export const zhHant: Catalog = {
   "Start from scratch…": "從頭開始…",
   "Replace every slide with one blank slide. Keeps the deck’s theme, name and live session — ⌘Z undoes.": "將所有投影片取代為一張空白投影片。簡報的主題、名稱與即時協作工作階段都會保留 — ⌘Z 可復原。",
   "Replace all {n} slides with one blank slide? ⌘Z undoes this.": "將全部 {n} 張投影片取代為一張空白投影片？⌘Z 可復原。",
+  "Don’t pair — use its own id": "不配對 — 使用自身 id",
 }


### PR DESCRIPTION
Follow-up to #54 — the half deliberately left out of #59.

## The gap

Setting a morph id is one click; **clearing** it isn't. The documented route is to retype the element's own id into the "Morph id" field — which requires knowing what that id was, at the moment the field is showing the override instead. The "Pair with" picker could set a pairing but never undo one.

The reporter of #54 flagged this as "impossible to clear". The rendering half of that issue shipped in 1.0.10; this is the affordance half.

## Change

A **"Don't pair — use its own id"** option in the picker, shown only when an override is actually set. It routes through the existing `setMorphId` with the element's own id, so the clearing rule stays in one place.

Two details worth review:

- The picker was gated on `targets.length`, so an element that *was* paired but had no other slide to pair with rendered no picker at all — and therefore no way back. Now `targets.length || el.morphId`.
- The sentinel option value is `'#unpair'`, collision-proof by construction: `setMorphId` strips everything outside `[A-Za-z0-9._-]`, so no stored `morphId` can contain `#`.

**Left alone deliberately:** the hint text still says the field route works, because it does. Rewording it would orphan its seven existing translations for no benefit.

## Verification

In the browser, on a deck whose slide-2 shape carries `morphId: 'src-shape'` — using a **real mouse click** for selection, since synthetic events don't drive Selecto:

- option appears, correctly labelled and valued
- choosing it clears `morphId`, with no false collision warning
- the picker rebuilds **without** the option once unpaired
- ⌘Z restores the pairing

## i18n

1 new string in all 7 catalogs, matching each one's existing "Pair with" phrasing. Verified through the real lookup path — `setLocale` + `t()` returns a translation, not the English fallback, in every locale.

`tsc -b` clean.