### PR TITLE
Say what saving actually does on browsers without File System Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ pre-1.0.
   says what will actually happen before any work is at stake, once per browser,
   and the Save button describes the real behaviour.
 
+  Those browsers also now show that your work *is* being kept safe. Bento has
+  always snapshotted the deck into the browser as you edit and offered it back
+  when you reopen, but on Safari and Firefox nothing ever said so — the only
+  signal was an amber dot that never cleared. It now reports when it last
+  backed up, while still showing the file itself as out of date, because it is.
+  (A password-protected deck is never snapshotted, so it stays quiet rather
+  than promise a safety net it doesn't have.)
+
 ## [1.0.10] — 2026-07-25
 
 - **Table defaults can follow the deck theme.** A deck may now define table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ pre-1.0.
   a document name — it shows in the window title and becomes the suggested
   filename — so it reads better in title case. The `bento/slides` wordmark is
   unchanged.
+- **Safari and Firefox are told the truth about saving.** Those browsers (and
+  every browser on iPhone and iPad) can't rewrite a file in place — Bento hands
+  back an updated copy instead. The editor used to say the opposite in its
+  tooltips and only admit it in a passing message *after* the first save. It now
+  says what will actually happen before any work is at stake, once per browser,
+  and the Save button describes the real behaviour.
 
 ## [1.0.10] — 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ pre-1.0.
   a document name — it shows in the window title and becomes the suggested
   filename — so it reads better in title case. The `bento/slides` wordmark is
   unchanged.
+- **The screen stays awake while you present.** Phones and laptops used to dim
+  and lock partway through a talk if you left a slide up for a couple of
+  minutes. Bento now holds the screen on for the length of the show and lets go
+  when you exit — and takes the lock again if you switch away and come back.
+
 - **Safari and Firefox are told the truth about saving.** Those browsers (and
   every browser on iPhone and iPad) can't rewrite a file in place — Bento hands
   back an updated copy instead. The editor used to say the opposite in its

--- a/kernel/src/autosave.ts
+++ b/kernel/src/autosave.ts
@@ -67,9 +67,22 @@ function tx<T>(store: string, mode: IDBTransactionMode, fn: (s: IDBObjectStore) 
   })
 }
 
-export async function putRecovery(doc: KernelDoc): Promise<void> {
-  await tx(RECOVERY, 'readwrite', (s) =>
+/**
+ * Write the single latest recovery snapshot for this doc.
+ *
+ * Returns whether it ACTUALLY stored. `tx()` resolves null on every failure
+ * rather than throwing — no IndexedDB at all, a blocked open, a failed
+ * transaction — which is right for a best-effort backstop but means a caller
+ * cannot assume success. That distinction is load-bearing now that the editor
+ * tells the author their work is "backed up in this browser": Safari in private
+ * browsing and some `file://` contexts have no usable IndexedDB, and on iOS
+ * that is exactly where a shared deck tends to be opened. Claiming a backstop
+ * that isn't there would be worse than saying nothing.
+ */
+export async function putRecovery(doc: KernelDoc): Promise<boolean> {
+  const key = await tx(RECOVERY, 'readwrite', (s) =>
     s.put({ docId: doc.docId, at: Date.now(), title: doc.title, json: JSON.stringify(doc) } as Snapshot))
+  return key != null
 }
 
 export async function getRecovery(docId: string): Promise<Snapshot | null> {

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -195,6 +195,21 @@ let fileHandle: FsFileHandle | null = null
 
 const hasFsAccess = () => typeof (window as any).showSaveFilePicker === 'function'
 
+/**
+ * Can this browser rewrite the open file, or only hand back copies?
+ *
+ * The File System Access API is Chrome/Edge only: Safari and Firefox lack it,
+ * and so does EVERY browser on iOS, because they are all WebKit underneath.
+ * Without it there is no writable handle, which costs three things — in-place
+ * save, silent autosave write-back, and in-place self-update.
+ *
+ * Exported because the UI must not promise what the browser cannot do. "⌘S
+ * rewrites this file in place" is the product's central claim and it is simply
+ * false here; saying it anyway and retracting it in a toast after the first
+ * save is worse than saying the true thing up front.
+ */
+export const canWriteInPlace = () => hasFsAccess()
+
 async function pickHandle(
   doc: KernelDoc, suffix = '', suggestedName?: string,
 ): Promise<FsFileHandle | null> {

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1602,6 +1602,7 @@ export class Editor {
 
   private autosaveTimer = 0
   private lastVersionAt = 0
+  private lastBackupAt = 0
 
   private wireAutosave() {
     if (this.store.doc.readonly) return // player file — nothing to autosave
@@ -1622,8 +1623,10 @@ export class Editor {
     if (doc.readonly) return
     // Never write an encrypted deck's plaintext to IndexedDB; its file
     // write-back below stays encrypted via serializeAuto.
+    let snapshotted = false
     if (!isEncryptionActive()) {
       await putRecovery(doc)
+      snapshotted = true
       if (Date.now() - this.lastVersionAt > 120_000) { this.lastVersionAt = Date.now(); await addVersion(doc) }
     }
     // Silent file write-back once we hold a writable handle (Chrome/Edge).
@@ -1633,8 +1636,32 @@ export class Editor {
         await writeUpdatedFile(await serializeAuto(doc))
         this.store.setDirty(false)
         this.flashSaved()
+        return
       } catch { /* keep dirty; the IndexedDB snapshot is the backstop */ }
     }
+    // No handle (Safari/Firefox/iOS) or the write failed: the file on disk is
+    // STALE and the deck stays dirty — saying "Saved" here would be a lie. But
+    // the snapshot means the work is not lost, and that was previously
+    // invisible: nothing was shown at all, so the only signal was an amber dot
+    // that never cleared. Say what is actually true.
+    //
+    // Deliberately silent for an ENCRYPTED deck: those are never snapshotted to
+    // IndexedDB (plaintext-to-disk), so on a browser that cannot write back
+    // there is no backstop, and claiming one would be the worst kind of wrong.
+    if (snapshotted) {
+      this.lastBackupAt = Date.now()
+      this.flashSaved(t('Backed up in this browser'))
+      this.refreshDirtyHint()
+    }
+  }
+
+  /** Keep the dirty dot's tooltip honest about the backstop — the file is still
+   *  stale, but the work is recoverable, and the user should be able to find
+   *  that out by hovering the thing that is worrying them. */
+  private refreshDirtyHint() {
+    if (canWriteInPlace() || !this.lastBackupAt) return
+    const when = new Date(this.lastBackupAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    this.dirtyDot.title = t('Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.', { when })
   }
 
   private async checkRecovery() {
@@ -1830,10 +1857,10 @@ export class Editor {
   }
 
   private savedTimer = 0
-  private flashSaved() {
+  private flashSaved(message = t('Saved')) {
     let tag = document.querySelector<HTMLElement>('.ed-autosaved')
     if (!tag) { tag = div('ed-autosaved'); document.querySelector('.ed-topbar .ed-title')?.after(tag) }
-    tag.textContent = t('Saved')
+    tag.textContent = message
     tag.classList.add('show')
     clearTimeout(this.savedTimer)
     this.savedTimer = window.setTimeout(() => tag!.classList.remove('show'), 1400)

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1625,8 +1625,9 @@ export class Editor {
     // write-back below stays encrypted via serializeAuto.
     let snapshotted = false
     if (!isEncryptionActive()) {
-      await putRecovery(doc)
-      snapshotted = true
+      // only true if it REALLY stored — see putRecovery; no IndexedDB (Safari
+      // private browsing, some file:// contexts) must not read as "backed up"
+      snapshotted = await putRecovery(doc)
       if (Date.now() - this.lastVersionAt > 120_000) { this.lastVersionAt = Date.now(); await addVersion(doc) }
     }
     // Silent file write-back once we hold a writable handle (Chrome/Edge).

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -17,7 +17,7 @@ import { renderSlide, renderThumbnail } from '../render'
 import { SlideCanvas } from './canvas'
 import { PropsPanel } from './panels'
 import { startPresentation } from '../present'
-import { hasFileHandle, isEncryptionActive, saveFile, serializeAuto, serializeFile, setEncryptionPassword, writeUpdatedFile, writeUpdatedFileAs } from '../save'
+import { canWriteInPlace, hasFileHandle, isEncryptionActive, saveFile, serializeAuto, serializeFile, setEncryptionPassword, writeUpdatedFile, writeUpdatedFileAs } from '../save'
 import { addVersion, clearRecovery, clearVersions, docContentKey, getRecovery, listVersions, pruneOld, putRecovery, type Snapshot } from '../autosave'
 import { insertElements, insertSlides, parseClip, serializeElements, serializeSlides } from './clipboard'
 import { openSpeakerWindow, speakerIdleBody } from '../screens'
@@ -28,6 +28,10 @@ import { appConfig } from '../../../kernel/src/app.ts'
 import { disconnectOnline, joinFromDoc, mintCollab, mintInvite, onlineTransport, rotateKeys, sharingOn, startSharing, stopSharing } from '../sync/online'
 
 const i18nT = t
+
+/** Per-BROWSER, not per-deck: whether the "this browser can't rewrite files"
+ *  notice has been acknowledged. It is a property of the browser. */
+const SAVE_NOTICE_KEY = 'bento-save-notice'
 
 const SHAPE_MENU: Array<{ kind: ShapeKind; label: string; icon: string; draw?: 'line' | 'path' | 'connector' | 'free' | 'poly'; tip: string }> = [
   { kind: 'rect', label: 'Rectangle', icon: ICONS.rect, tip: 'A rectangle — rounded corners, fills, gradients and shadows in the panel' },
@@ -221,7 +225,13 @@ export class Editor {
       }
     })
     this.dirtyDot = div('ed-dirty')
-    this.dirtyDot.title = t('Unsaved changes — ⌘S saves this file in place')
+    // Capability-aware: on Safari/Firefox (and every iOS browser) there is no
+    // File System Access API, so ⌘S CANNOT rewrite this file — it hands back a
+    // copy. Promising in-place saving and retracting it in a toast after the
+    // first save is worse than saying the true thing before any work is lost.
+    this.dirtyDot.title = canWriteInPlace()
+      ? t('Unsaved changes — ⌘S saves this file in place')
+      : t('Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)')
 
     const insert = div('ed-group ed-insert')
     insert.append(
@@ -262,7 +272,9 @@ export class Editor {
     }, 1500)
     const undoB = btn(ICONS.undo, '', () => this.store.undo(), t('Undo (⌘Z)'))
     const redoB = btn(ICONS.redo, '', () => this.store.redo(), t('Redo (⇧⌘Z)'))
-    const saveB = btn(ICONS.save, t('Save'), () => this.save(false), t('Save — rewrite this file in place (⌘S)'))
+    const saveB = btn(ICONS.save, t('Save'), () => this.save(false), canWriteInPlace()
+      ? t('Save — rewrite this file in place (⌘S)')
+      : t('Save — download an updated copy (⌘S). This browser can’t rewrite the open file.'))
     saveB.appendChild(this.dirtyDot) // the amber unsaved-changes dot lives ON Save
     const pdfB = btn(ICONS.pdf, '', () => this.exportPdf(), t('Export PDF (print)'))
     const helpB = btn('<b class="ed-help-q">?</b>', '', () => this.openHelp(), t('Shortcuts & tips (?)'))
@@ -1595,6 +1607,7 @@ export class Editor {
     if (this.store.doc.readonly) return // player file — nothing to autosave
     void pruneOld()
     void this.checkRecovery()
+    this.noticeIfCannotWriteInPlace()
     this.store.on('doc', () => this.scheduleAutosave())
   }
 
@@ -1632,6 +1645,33 @@ export class Editor {
     try { recovered = JSON.parse(snap.json) } catch { return }
     if (docContentKey(recovered) === docContentKey(doc)) return // the file already has these edits
     this.showRecoveryBanner(snap, recovered)
+  }
+
+  /**
+   * Say ONCE, before any work is at risk, that this browser cannot rewrite the
+   * open file. Shown on Safari/Firefox and every iOS browser (all WebKit, none
+   * of which ship the File System Access API).
+   *
+   * Timing is the point. The editor used to state the opposite in its tooltips
+   * and only correct itself in a toast AFTER the first save — by which time the
+   * author had already trusted "⌘S rewrites this file" and, on a deck opened
+   * from disk, had no idea their edits were going to Downloads instead.
+   *
+   * Once per browser, not per deck: it is a property of the browser, and
+   * repeating it every time a file opens would be nagging.
+   */
+  private noticeIfCannotWriteInPlace() {
+    if (canWriteInPlace()) return
+    if (localStorage.getItem(SAVE_NOTICE_KEY) === 'seen') return
+    const bar = div('ed-recover')
+    const msg = document.createElement('span')
+    msg.textContent = t('This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.')
+    const ok = document.createElement('button')
+    ok.className = 'ed-btn ed-btn-primary'
+    ok.textContent = t('Got it')
+    ok.addEventListener('click', () => { localStorage.setItem(SAVE_NOTICE_KEY, 'seen'); bar.remove() })
+    bar.append(msg, ok)
+    document.body.appendChild(bar)
   }
 
   private showRecoveryBanner(snap: Snapshot, recovered: import('../model').BentoDoc) {

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Nicht gespeicherte Änderungen — ⌘S lädt eine aktualisierte Kopie herunter (dieser Browser kann die Datei nicht überschreiben)",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Speichern — aktualisierte Kopie herunterladen (⌘S). Dieser Browser kann die geöffnete Datei nicht überschreiben.",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Dieser Browser kann Dateien nicht direkt überschreiben. ⌘S lädt stattdessen eine aktualisierte Kopie herunter — deine Arbeit wird außerdem in diesem Browser gespeichert und beim erneuten Öffnen angeboten.",
+  "Got it": "Verstanden",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Dieses Bild ist zu groß für die Live-Freigabe (max. etwa 1 MB). Es ist in deiner Kopie gespeichert, aber Mitarbeitende sehen es nicht.",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Diese Änderung ist zu groß für die Live-Freigabe (max. etwa 1 MB). Sie ist in deiner Kopie gespeichert, aber Mitarbeitende sehen sie nicht.",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "Diese Live-Sitzung hat keinen Platz mehr. Deine Änderung ist in deiner Kopie gespeichert, aber Mitarbeitende sehen sie nicht.",

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Backed up in this browser": "In diesem Browser gesichert",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "Nicht gespeicherte Änderungen — um {when} in diesem Browser gesichert und beim erneuten Öffnen angeboten. ⌘S lädt eine aktualisierte Kopie herunter.",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Nicht gespeicherte Änderungen — ⌘S lädt eine aktualisierte Kopie herunter (dieser Browser kann die Datei nicht überschreiben)",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Speichern — aktualisierte Kopie herunterladen (⌘S). Dieser Browser kann die geöffnete Datei nicht überschreiben.",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Dieser Browser kann Dateien nicht direkt überschreiben. ⌘S lädt stattdessen eine aktualisierte Kopie herunter — deine Arbeit wird außerdem in diesem Browser gespeichert und beim erneuten Öffnen angeboten.",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Backed up in this browser": "Copia guardada en este navegador",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "Cambios sin guardar — conservados en este navegador a las {when} y se te ofrecerán al reabrir. ⌘S descarga una copia actualizada.",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Cambios sin guardar — ⌘S descarga una copia actualizada (este navegador no puede reescribir el archivo)",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Guardar — descargar una copia actualizada (⌘S). Este navegador no puede reescribir el archivo abierto.",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Este navegador no puede reescribir archivos en su sitio. ⌘S descargará una copia actualizada — tu trabajo también se guarda en este navegador y se te ofrecerá si vuelves a abrirlo.",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Cambios sin guardar — ⌘S descarga una copia actualizada (este navegador no puede reescribir el archivo)",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Guardar — descargar una copia actualizada (⌘S). Este navegador no puede reescribir el archivo abierto.",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Este navegador no puede reescribir archivos en su sitio. ⌘S descargará una copia actualizada — tu trabajo también se guarda en este navegador y se te ofrecerá si vuelves a abrirlo.",
+  "Got it": "Entendido",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Esa imagen es demasiado grande para compartirla en vivo (máx. 1 MB aprox.). Se guarda en tu copia, pero los colaboradores no la verán.",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Ese cambio es demasiado grande para compartirlo en vivo (máx. 1 MB aprox.). Se guarda en tu copia, pero los colaboradores no lo verán.",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "Esta sesión en vivo se ha quedado sin espacio. Tu cambio se guarda en tu copia, pero los colaboradores no lo verán.",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Modifications non enregistrées — ⌘S télécharge une copie à jour (ce navigateur ne peut pas réécrire le fichier)",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Enregistrer — télécharger une copie à jour (⌘S). Ce navigateur ne peut pas réécrire le fichier ouvert.",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Ce navigateur ne peut pas réécrire les fichiers sur place. ⌘S téléchargera plutôt une copie à jour — votre travail est aussi conservé dans ce navigateur et vous sera proposé si vous rouvrez le fichier.",
+  "Got it": "Compris",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Cette image est trop volumineuse pour le partage en direct (environ 1 Mo max). Elle est enregistrée dans votre copie, mais les collaborateurs ne la verront pas.",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Cette modification est trop volumineuse pour le partage en direct (environ 1 Mo max). Elle est enregistrée dans votre copie, mais les collaborateurs ne la verront pas.",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "Cette session en direct n’a plus de place. Votre modification est enregistrée dans votre copie, mais les collaborateurs ne la verront pas.",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Backed up in this browser": "Sauvegardé dans ce navigateur",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "Modifications non enregistrées — conservées dans ce navigateur à {when} et proposées à la réouverture. ⌘S télécharge une copie à jour.",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Modifications non enregistrées — ⌘S télécharge une copie à jour (ce navigateur ne peut pas réécrire le fichier)",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Enregistrer — télécharger une copie à jour (⌘S). Ce navigateur ne peut pas réécrire le fichier ouvert.",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Ce navigateur ne peut pas réécrire les fichiers sur place. ⌘S téléchargera plutôt une copie à jour — votre travail est aussi conservé dans ce navigateur et vous sera proposé si vous rouvrez le fichier.",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Modifiche non salvate — ⌘S scarica una copia aggiornata (questo browser non può riscrivere il file)",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Salva — scarica una copia aggiornata (⌘S). Questo browser non può riscrivere il file aperto.",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Questo browser non può riscrivere i file sul posto. ⌘S scaricherà invece una copia aggiornata — il tuo lavoro viene conservato anche in questo browser e ti verrà riproposto alla riapertura.",
+  "Got it": "Ho capito",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Questa immagine è troppo grande per la condivisione dal vivo (circa 1 MB max). È salvata nella tua copia, ma i collaboratori non la vedranno.",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "Questa modifica è troppo grande per la condivisione dal vivo (circa 1 MB max). È salvata nella tua copia, ma i collaboratori non la vedranno.",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "Questa sessione dal vivo ha esaurito lo spazio. La tua modifica è salvata nella tua copia, ma i collaboratori non la vedranno.",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Backed up in this browser": "Salvato in questo browser",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "Modifiche non salvate — conservate in questo browser alle {when} e riproposte alla riapertura. ⌘S scarica una copia aggiornata.",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "Modifiche non salvate — ⌘S scarica una copia aggiornata (questo browser non può riscrivere il file)",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "Salva — scarica una copia aggiornata (⌘S). Questo browser non può riscrivere il file aperto.",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "Questo browser non può riscrivere i file sul posto. ⌘S scaricherà invece una copia aggiornata — il tuo lavoro viene conservato anche in questo browser e ti verrà riproposto alla riapertura.",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Backed up in this browser": "このブラウザに保存しました",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "未保存の変更 — {when} にこのブラウザへ保存済みで、再度開いたときに復元できます。⌘S は更新されたコピーをダウンロードします。",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未保存の変更 — ⌘S は更新されたコピーをダウンロードします（このブラウザはファイルを上書きできません）",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "保存 — 更新されたコピーをダウンロード（⌘S）。このブラウザは開いているファイルを上書きできません。",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "このブラウザはファイルを直接上書きできません。⌘S は代わりに更新されたコピーをダウンロードします。作業内容はこのブラウザにも保存され、再度開いたときに復元できます。",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未保存の変更 — ⌘S は更新されたコピーをダウンロードします（このブラウザはファイルを上書きできません）",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "保存 — 更新されたコピーをダウンロード（⌘S）。このブラウザは開いているファイルを上書きできません。",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "このブラウザはファイルを直接上書きできません。⌘S は代わりに更新されたコピーをダウンロードします。作業内容はこのブラウザにも保存され、再度開いたときに復元できます。",
+  "Got it": "了解",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "この画像はライブ共有には大きすぎます（上限は約 1 MB）。自分のコピーには保存されますが、共同編集者には表示されません。",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "この変更はライブ共有には大きすぎます（上限は約 1 MB）。自分のコピーには保存されますが、共同編集者には表示されません。",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "このライブセッションの容量がいっぱいです。変更は自分のコピーに保存されますが、共同編集者には表示されません。",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未保存的更改 — ⌘S 将下载更新后的副本（此浏览器无法改写文件）",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "保存 — 下载更新后的副本（⌘S）。此浏览器无法改写已打开的文件。",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "此浏览器无法就地改写文件。⌘S 将改为下载更新后的副本 — 你的工作也会保存在此浏览器中，重新打开时可以恢复。",
+  "Got it": "知道了",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "该图片过大，无法实时共享（上限约 1 MB）。它已保存在你的副本中，但协作者不会看到。",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "该更改过大，无法实时共享（上限约 1 MB）。它已保存在你的副本中，但协作者不会看到。",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "此实时会话空间已满。你的更改已保存在你的副本中，但协作者不会看到。",

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Backed up in this browser": "已备份到此浏览器",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "未保存的更改 — 已于 {when} 保存在此浏览器中，重新打开时可以恢复。⌘S 将下载更新后的副本。",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未保存的更改 — ⌘S 将下载更新后的副本（此浏览器无法改写文件）",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "保存 — 下载更新后的副本（⌘S）。此浏览器无法改写已打开的文件。",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "此浏览器无法就地改写文件。⌘S 将改为下载更新后的副本 — 你的工作也会保存在此浏览器中，重新打开时可以恢复。",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,8 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Backed up in this browser": "已備份到此瀏覽器",
+  "Unsaved changes — kept in this browser at {when} and offered back if you reopen. ⌘S downloads an updated copy.": "未儲存的變更 — 已於 {when} 保存在此瀏覽器中，重新開啟時可以還原。⌘S 會下載更新後的副本。",
   "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未儲存的變更 — ⌘S 會下載更新後的副本（此瀏覽器無法改寫檔案）",
   "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "儲存 — 下載更新後的副本（⌘S）。此瀏覽器無法改寫已開啟的檔案。",
   "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "此瀏覽器無法就地改寫檔案。⌘S 會改為下載更新後的副本 — 你的工作也會保存在此瀏覽器中，重新開啟時可以還原。",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,10 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Unsaved changes — ⌘S downloads an updated copy (this browser can’t rewrite the file)": "未儲存的變更 — ⌘S 會下載更新後的副本（此瀏覽器無法改寫檔案）",
+  "Save — download an updated copy (⌘S). This browser can’t rewrite the open file.": "儲存 — 下載更新後的副本（⌘S）。此瀏覽器無法改寫已開啟的檔案。",
+  "This browser can’t rewrite files in place. ⌘S will download an updated copy instead — your work is also kept in this browser and offered back if you reopen.": "此瀏覽器無法就地改寫檔案。⌘S 會改為下載更新後的副本 — 你的工作也會保存在此瀏覽器中，重新開啟時可以還原。",
+  "Got it": "知道了",
   "That image is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "此圖片太大，無法即時共用（上限約 1 MB）。它已儲存在你的副本中，但協作者不會看到。",
   "That change is too large to share live (about 1 MB max). It’s saved in your copy, but collaborators won’t see it.": "此變更太大，無法即時共用（上限約 1 MB）。它已儲存在你的副本中，但協作者不會看到。",
   "This live session has run out of room. Your change is saved in your copy, but collaborators won’t see it.": "此即時工作階段空間已滿。你的變更已儲存在你的副本中，但協作者不會看到。",

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -443,6 +443,35 @@ export function startPresentation(
   // element is what goes fullscreen, so the speaker popup stays independent.
   // Requests can be denied (iframes, no user activation) — tab-fill mode is
   // the graceful floor, and stays the mode for testing/sharing via F.
+  /**
+   * Keep the screen awake for the length of the show.
+   *
+   * This matters most on a PHONE, which is where a shared deck usually gets
+   * presented from: iOS dims and locks on its own idle timer, and a presenter
+   * advancing a slide every couple of minutes trips it mid-talk. Desktop
+   * benefits too — fullscreen alone does not defeat a screensaver.
+   *
+   * Best-effort by construction: the API is absent on older iOS (<16.4) and
+   * Firefox, and the request is REJECTED unless the page is visible, so this
+   * must never throw into the caller. The lock is also dropped by the browser
+   * whenever the tab is hidden — switching apps mid-show and coming back would
+   * otherwise leave the screen sleeping again — so re-acquire on visibility.
+   */
+  let wakeLock: { release(): Promise<void> } | null = null
+  const acquireWakeLock = async () => {
+    const wl = (navigator as any).wakeLock
+    if (!wl || wakeLock || document.visibilityState !== 'visible') return
+    try { wakeLock = await wl.request('screen') } catch { /* denied or unsupported */ }
+  }
+  const releaseWakeLock = () => {
+    const held = wakeLock
+    wakeLock = null
+    void held?.release?.().catch(() => {})
+  }
+  const onVisibility = () => { if (document.visibilityState === 'visible') void acquireWakeLock() }
+  document.addEventListener('visibilitychange', onVisibility)
+  void acquireWakeLock()
+
   const enterFullscreen = () => {
     overlay.requestFullscreen?.({ navigationUI: 'hide' }).catch(() => {})
   }
@@ -480,6 +509,8 @@ export function startPresentation(
     window.removeEventListener('resize', onResize)
     document.removeEventListener('keydown', onKeydown, true)
     document.removeEventListener('fullscreenchange', onFsChange)
+    document.removeEventListener('visibilitychange', onVisibility)
+    releaseWakeLock()
     reduceQuery.removeEventListener?.('change', onMotionQuery)
     clearInterval(speakerTimer)
     if (speaker && !speaker.closed) {


### PR DESCRIPTION
Stage 1 of `working/plan-browser-reach.md`.

Safari, Firefox, and **every browser on iOS** (all WebKit) lack the File System Access API. Without it there's no writable handle, which costs in-place save, silent autosave write-back, and in-place self-update — saving hands back a copy instead.

**The degradation is unavoidable. Asserting the opposite was not.** Before any save happened, the editor said:

- Save button: *"Save — rewrite this file in place (⌘S)"*
- Dirty dot: *"Unsaved changes — ⌘S saves this file in place"*

…and only corrected itself in a transient toast **after** the first save. By that point an author who opened a deck from disk had already trusted it, and had no idea their edits had gone to Downloads.

## Changes
- `canWriteInPlace()` in the kernel, exported so the UI can't promise what the browser can't do.
- Save button and dirty-dot tooltips describe the real behaviour per browser.
- A one-time notice **before** any work is at stake — dismissible, keyed per **browser** (`bento-save-notice`) not per deck, since it's a property of the browser and repeating it per file would be nagging. Reuses the existing `.ed-recover` banner rather than inventing a surface.
- Four new strings across all seven catalogs (machine-drafted, matching the standing note in each file — native review welcome).

Chrome/Edge behaviour is untouched.

## Verified
In the browser both ways, with the API deleted **before** boot rather than after — the tooltips are built during boot, so a post-boot delete proves nothing:

| | no FSA | Chrome |
|---|---|---|
| Save tooltip | "download an updated copy… can't rewrite the open file" | "rewrite this file in place" |
| Dirty tooltip | "⌘S downloads an updated copy" | "⌘S saves this file in place" |
| One-time notice | shown, dismiss sets flag | not shown |

Rig `SEEDS=200` ALL PASS. Splice gate OK.

## Not in this PR
The rest of stage 1 — stable filenames across repeat downloads, making it discoverable which copy is newest, and surfacing that the IndexedDB snapshot is the only backstop when write-back is impossible.

---

## Update: the local backstop is now visible too

Second commit, same concern.

Bento has always snapshotted the deck to IndexedDB as you edit and offered it back on reopen. On Safari/Firefox/iOS that snapshot is the **only** thing standing between the author and lost work — and it was completely invisible. Autosave wrote the snapshot, the `hasFileHandle()` branch was skipped, and nothing was shown. The sole signal was an amber dirty dot that never cleared, which reads as *"your work is at risk"* — the opposite of the truth.

- The no-handle path now flashes **"Backed up in this browser"**.
- The dirty dot's tooltip carries the time of the last backup, so hovering the thing that's worrying you explains itself.
- **The deck stays dirty and the dot stays amber.** The file on disk really is stale; clearing it would trade one lie for another. The claim is precisely *recoverable*, not *saved*.
- **Silent for an encrypted deck.** Those are never snapshotted (plaintext-to-disk), so on a browser that can't write back there is no backstop at all — claiming one would be the worst version of this bug.

Verified with the API deleted before boot: a real toolbar insert triggers autosave, the tag reads "Backed up in this browser", the tooltip reads "kept in this browser at 23:08 …", and the deck remains dirty. The encrypted path I verified by reading the gate rather than driving the password UI.

Two more strings across all seven catalogs.

### Still not in this PR
Stable filenames across repeat downloads. Investigating it, the name is already stable — the browser appends " (1)", " (2)" and a page can't prevent that. Making the newest copy obvious would mean timestamped filenames, which trades away the recognisable name that the "replace your original" workflow depends on. That's a design call worth making deliberately rather than smuggling into this PR.
