### PR TITLE
Publish: create the GitHub release automatically

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -61,9 +61,18 @@ verify the manifest signature against the public key embedded in every shell.
    live **guestbook daemon** onto the freshly-published shell as a best-effort
    final step (see below) — no separate command needed.
 
-5. Also attach `site/releases/slides/Bento_Slides.bento.html` to a GitHub
-   Release for the tag — download counts, release-watch notifications, and a
-   permanent per-version archive.
+5. **The GitHub release is created for you** by `publish-site.mjs` — it makes
+   the release for the tag, attaches
+   `site/releases/slides/Bento_Slides.bento.html`, and takes the notes from
+   this version's CHANGELOG section (so the two can't drift). It is idempotent:
+   an existing release is left alone and only a missing asset is uploaded, so
+   re-running publish is safe.
+
+   It is deliberately **not** best-effort. If `gh` is unauthenticated, or the
+   asset is missing afterwards, publish exits non-zero and tells you the exact
+   command to run. This used to be a manual step, and it was silently missed
+   for v1.0.10 — the site was live and self-updating while the repo showed no
+   release at all. Documentation didn't prevent that, so the check now does.
 6. Sanity check: open the PREVIOUS version's file, About (topbar logo) →
    Check for updates → should offer the new version, and the downloaded copy
    must boot with the document intact.

--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -20,9 +20,10 @@
 // Destination repo: $BENTO_SITE_DIR, else ../bento-site beside this repo.
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -108,6 +109,75 @@ const ver = (() => {
   } catch { return '?' }
 })()
 console.log(`\n✓ published to bento-site @ ${head} (app v${ver})`)
+
+// ---- GitHub release --------------------------------------------------------
+// Publishing the site makes a version downloadable and self-updatable, but the
+// GitHub release is how people who arrive from the repo get the file at all —
+// and being a separate manual step in RELEASING.md, it was simply forgotten for
+// v1.0.10. Documentation did not prevent that; doing it here does.
+//
+// Idempotent: an existing release is left alone, and only a missing asset is
+// uploaded, so re-running publish is always safe. NOT best-effort — unlike the
+// guestbook re-seed below, a failure here is reported loudly and exits non-zero,
+// because a silent skip is the exact failure being fixed.
+const releaseShell = join(site, 'releases/slides/Bento_Slides.bento.html')
+const tag = `v${ver}`
+
+const ghAvailable = (() => {
+  try { capture('gh', ['auth', 'status'], { stdio: ['ignore', 'pipe', 'pipe'] }); return true }
+  catch { return false }
+})()
+
+if (ver === '?') {
+  console.warn('⚠ could not read the published version — skipping the GitHub release step')
+} else if (!ghAvailable) {
+  die(`site is published, but gh is unavailable or unauthenticated — the GitHub release for ${tag} was NOT created.\n  Fix: gh auth login, then:  gh release create ${tag} ${releaseShell} --title ${tag} --notes-file <notes>`)
+} else {
+  const exists = (() => {
+    try { capture('gh', ['release', 'view', tag], { stdio: ['ignore', 'pipe', 'pipe'] }); return true }
+    catch { return false }
+  })()
+
+  if (!exists) {
+    // Notes come from the CHANGELOG section for this version, so the release
+    // and the file in the repo can never drift apart.
+    let notes = 'See CHANGELOG.md.'
+    try {
+      const cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8')
+      const start = cl.indexOf(`## [${ver}]`)
+      const rest = cl.indexOf('\n## [', start + 1)
+      if (start >= 0) {
+        notes = cl.slice(cl.indexOf('\n', start) + 1, rest > 0 ? rest : undefined).trim()
+      }
+    } catch { /* fall back to the pointer above */ }
+    const intro = "Download the single file below and open it in any modern browser — it's the document, the viewer and the editor in one. Shipped files self-update through the signed release channel.\n\n"
+    const notesFile = join(tmpdir(), `bento-release-${ver}.md`)
+    writeFileSync(notesFile, intro + notes)
+    run('gh', ['release', 'create', tag, releaseShell, '--title', tag, '--notes-file', notesFile])
+    console.log(`✓ GitHub release ${tag} created with the signed shell attached`)
+  } else {
+    const assets = (() => {
+      try { return capture('gh', ['release', 'view', tag, '--json', 'assets', '-q', '.assets[].name']) }
+      catch { return '' }
+    })()
+    if (!assets.includes('Bento_Slides.bento.html')) {
+      run('gh', ['release', 'upload', tag, releaseShell, '--clobber'])
+      console.log(`✓ attached the signed shell to the existing release ${tag}`)
+    } else {
+      console.log(`✓ GitHub release ${tag} already published`)
+    }
+  }
+
+  // Assert rather than assume: "publish succeeded" must mean the release is
+  // actually there, with the file on it.
+  const check = (() => {
+    try { return capture('gh', ['release', 'view', tag, '--json', 'assets', '-q', '.assets[].name']) }
+    catch { return '' }
+  })()
+  if (!check.includes('Bento_Slides.bento.html')) {
+    die(`GitHub release ${tag} is missing Bento_Slides.bento.html after publishing — attach it before announcing.`)
+  }
+}
 
 // ---- keep the LIVE guestbook daemon on the freshly-published shell ---------
 // bento.page/guestbook.bento.html is served by the Cloudflare daemon from KV,


### PR DESCRIPTION
**v1.0.10 shipped without a GitHub release.** The site was live and shipped files were self-updating, but anyone arriving from the repo saw v1.0.9 as the latest download.

`RELEASING.md` had it as step 5, in writing, and it was still missed. Documentation doesn't stop a manual step from being skipped — so `publish-site.mjs` now does it, immediately after the site push that makes a version public.

- Creates the release for the tag with the **signed shell** attached.
- Takes the notes from that version's CHANGELOG section, so release text and repo can't drift.
- **Idempotent** — an existing release is left alone, a missing asset is uploaded. Re-running publish is always safe.
- **Not best-effort.** Unlike the guestbook re-seed below it, an unauthenticated `gh` or a missing asset exits non-zero with the exact remediation command. A silent skip is the precise failure being fixed.
- **Asserts at the end** that the release really carries the shell — so "publish succeeded" means the download exists, not merely that nothing threw.

## Already done by hand
The missing [v1.0.10 release](https://github.com/nyblnet/bento/releases/tag/v1.0.10) is created and marked Latest. Before attaching, I checked the local artifact was byte-identical to what `bento.page` serves (`a84df41e…`) rather than assuming the local `site/` tree was still the published one.

## Verified
Against real repo state — `gh` authenticated, release present, asset present — the logic takes the no-op path and the final assertion passes. Changelog extraction was checked to bound correctly at the next `## [` heading rather than swallowing older entries.