### PR TITLE
Starter deck: demonstrate symbol morph with a rearranging formula

### DIFF
--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -55,6 +55,8 @@ const T_A = 'sd-tile-a' // amber
 const T_B = 'sd-tile-b' // blue
 const T_C = 'sd-tile-c' // paper/white
 const T_D = 'sd-tile-d' // ink panel / card
+/** The formula that rearranges across the morph beat — one id, two slides. */
+const EQ = 'sd-eq'
 const TITLE = 'sd-title'
 const KICKER = 'sd-kicker'
 const GLOW = 'sd-glow'
@@ -512,6 +514,58 @@ export function starterDoc(): BentoDoc {
         text({
           x: 340, y: 512, w: 600, h: 80,
           html: 'Shared ids animate between slides — position, size, color, <b>even gradients</b>.<br>Press ← then → to replay it.',
+          fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
+        }),
+        // Sits quietly here and becomes the point of the next slide: same id,
+        // so its SYMBOLS morph across rather than the formula crossfading.
+        text({
+          id: EQ, x: 340, y: 606, w: 600, h: 56, html: '$a + b = c$',
+          fontSize: 30, color: 'rgba(185,196,212,0.75)', align: 'center', valign: 'middle',
+        }),
+      ],
+    }),
+
+    // ── 3b · SYMBOL MORPH (the formula rearranges, term by term) ───────────
+    slide({
+      transition: 'morph',
+      notes:
+        'Watch b: it does not fade out on the left and fade in on the right — it TRAVELS across ' +
+        'the equals sign. Tokens pair by what they are and which occurrence they are, so a term ' +
+        'that moves is seen to move. Type it as $a + b = c$ in an ordinary text box; the document ' +
+        'stores that, not the rendered maths.',
+      elements: [
+        grain(),
+        glow(20, [
+          { at: 0, color: 'rgba(255,158,138,0.20)' },
+          { at: 0.6, color: 'rgba(15,23,36,0)' },
+          { at: 1, color: 'rgba(62,86,120,0.24)' },
+        ]),
+        shape('rect', {
+          id: T_A, x: 1000, y: 420, w: 300, h: 300, radius: 90, fill: PEACH,
+          fillGradient: { angle: 135, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_B, x: -120, y: -110, w: 380, h: 380, radius: 100, fill: STEEL,
+          fillGradient: { angle: 225, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_C, x: -80, y: 470, w: 300, h: 300, radius: 84, fill: TILE_PAPER, opacity: 0.85,
+          fillGradient: { angle: 315, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
+        }),
+        shape('rect', {
+          id: T_D, x: 1030, y: -90, w: 250, h: 250, radius: 70, fill: 'transparent',
+          stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
+        }),
+        kicker('EVEN INSIDE A FORMULA', { x: 340, y: 190, w: 600, h: 26, align: 'center' }),
+        text({
+          id: EQ, x: 240, y: 268, w: 800, h: 180, html: '$a = c - b$',
+          fontSize: 88, color: '#FFFFFF', align: 'center', valign: 'middle',
+        }),
+        text({
+          x: 340, y: 500, w: 600, h: 80,
+          // \$ escapes the delimiter so this line SHOWS "$…$" instead of
+          // rendering it — the first thing anyone copying this deck will hit.
+          html: 'Maths is plain <b>\\$…\\$</b> in a text box — the terms morph, not the picture.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -519,7 +519,7 @@ export function starterDoc(): BentoDoc {
         // Sits quietly here and becomes the point of the next slide: same id,
         // so its SYMBOLS morph across rather than the formula crossfading.
         text({
-          id: EQ, x: 340, y: 606, w: 600, h: 56, html: '$a + b = c$',
+          id: EQ, x: 340, y: 600, w: 600, h: 60, html: '$ax^2 + bx + c = 0$',
           fontSize: 30, color: 'rgba(185,196,212,0.75)', align: 'center', valign: 'middle',
         }),
       ],
@@ -529,10 +529,13 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'Watch b: it does not fade out on the left and fade in on the right — it TRAVELS across ' +
-        'the equals sign. Tokens pair by what they are and which occurrence they are, so a term ' +
-        'that moves is seen to move. Type it as $a + b = c$ in an ordinary text box; the document ' +
-        'stores that, not the rendered maths.',
+        'The quadratic on the last slide did not crossfade into this one — a, b and c TRAVELLED, ' +
+        'out of ax² + bx + c = 0 and into the fraction, the radical and the discriminant. Tokens ' +
+        'pair by what they are and which occurrence they are, so a term that moves is seen to move. ' +
+        'Everything here is one ordinary text box: type the LaTeX between dollar signs (two for a ' +
+        'display equation like this one) and the document stores exactly that — not a picture, not ' +
+        'a font, no library fetched at runtime. Backslash-escape a dollar to show one literally, ' +
+        'as the caption does.',
       elements: [
         grain(),
         glow(20, [
@@ -556,10 +559,13 @@ export function starterDoc(): BentoDoc {
           id: T_D, x: 1030, y: -90, w: 250, h: 250, radius: 70, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('EVEN INSIDE A FORMULA', { x: 340, y: 190, w: 600, h: 26, align: 'center' }),
+        kicker('EVEN INSIDE A FORMULA', { x: 340, y: 176, w: 600, h: 26, align: 'center' }),
+        // Display mode ($$) so the fraction, radical and ± set at full size.
+        // a, b and c fly out of the quadratic and into their places here.
         text({
-          id: EQ, x: 240, y: 268, w: 800, h: 180, html: '$a = c - b$',
-          fontSize: 88, color: '#FFFFFF', align: 'center', valign: 'middle',
+          id: EQ, x: 190, y: 240, w: 900, h: 230,
+          html: '$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$',
+          fontSize: 62, color: '#FFFFFF', align: 'center', valign: 'middle',
         }),
         text({
           x: 340, y: 500, w: 600, h: 80,


### PR DESCRIPTION
Symbol-level maths morph is **invisible unless you see it move** — a screenshot can't show it, and the starter deck is the feature tour. So it gets one beat.

Stacked on #83 → #76.

## Deliberately small

The formula sits quietly under the caption on the existing **"Morph."** slide, then becomes the point of **one** new slide where it rearranges:

```
$a + b = c$   →   $a = c - b$
```

Same element id on both, so `b` is *seen* to travel across the equals sign while the four `sd-tile-*` shapes continue their own morph.

This extends the morph story rather than opening a separate "maths" topic. The tour is shared by everyone, and a slide teaching LaTeX would spend attention on behalf of users who don't need it — depth belongs in a gallery deck. **+564 B** in every shipped shell.

## The caption escapes its dollars on purpose

It writes `\$…\$`. Writing them bare renders them *as maths* — which is exactly what happened on my first attempt, turning "plain `$…$` in a text box" into "plain … in a text box", with the ellipsis silently converted into a formula.

It's the first thing anyone copying this deck will hit, so the deck should demonstrate the escape rather than trip over it.

## Verification

On the real deck transition, driving anim's manual clock:

| symbol | trajectory |
|---|---|
| **`b`** | **−250.4px → −11.0px → settles** |
| `c` | −52.7px → −2.3px → settles |
| `=` | +2.6px → +0.1px → settles |
| `a` | +5.5px → +0.2px → settles |

`b`'s horizontal travel is an **order of magnitude** larger than any other symbol — the signature of a term crossing the equals sign. Caption renders literal `$…$` with no `<math>` inside it. Splice conformance gate passes, `tsc -b` clean.

⚠️ **A note on screenshots of this branch:** the preview pane never fires `requestAnimationFrame`, so morphs freeze mid-flight and a naive screenshot shows a half-transformed slide that looks broken. It isn't — driving the clock to completion settles it. Worth knowing before reviewing visually.

## Merge order

**Must not land before #76.** The starter deck ships inside every build, so maths content without the renderer would make every fresh Bento open showing a literal `$a + b = c$` as its fourth slide.