### PR TITLE
Release: emit language packs and sign their hashes in the manifest

### DIFF
--- a/docs/i18n-packs.md
+++ b/docs/i18n-packs.md
@@ -164,14 +164,30 @@ turns native review into a continuous process instead of a release blocker.
   sets.
 - Should a saved deck record which packs it carries, for the People/About UI?
 
+## Splicing a pack into a file — compress it
+
+Measured on the Korean pack: **56.8 KB raw JSON, 26.4 KB** through the
+deflate+base64 pipeline the shell already uses for its runtime payloads.
+
+Leave the artifact on the CDN **uncompressed** — GitHub Pages gzips it in
+transit anyway (17–20 KB on the wire), and a readable `.json` is worth keeping
+for translators. But the splice step MUST compress, because a spliced pack
+lives in every saved copy of that file forever: **30 KB per file, per
+language, permanently**, and unfixable once files are in the wild. Reuse
+`postbuild-compress.mjs`'s existing block format rather than inventing a
+second one.
+
 ## Status
 
-- [ ] Key-once packing of the bundled catalogs — **PR #75, in flight**. A
-      prerequisite: it shrinks the core and its kernel change (`registerI18n`
-      accepting a packed table) is the loading path packs will reuse.
-- [ ] Portuguese catalog, bundled
-- [ ] Pack format + `release.mjs` emitting and signing packs
-- [ ] Manifest `packs` array
-- [ ] In-app "Add language…" (fetch → verify → splice)
+- [x] Key-once packing of the bundled catalogs — #75
+- [x] Portuguese catalog, bundled — #79
+- [x] Pack format + `build-i18n.mjs --packs` emitting them — #81
+- [x] Kernel `addPack()` loading path — #81
+- [x] Korean, the first pack (662/662) — #81
+- [x] `release.mjs` emits packs; their hashes ride in the **signed manifest
+      payload** — no second key, no second signature
+- [ ] In-app "Add language…" (fetch → verify → splice, compressed)
 - [ ] **Update carries packs forward**
-- [ ] `shell-gate.mjs` covers a pack-carrying shell
+- [ ] Shell smoke check covers a pack-carrying shell (note: `shell-gate.mjs`
+      deliberately checks only the splice contract — it passed a build with a
+      silently corrupted stylesheet, so it is the wrong place for this)

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -13,6 +13,8 @@
 //     slides/index.html                      live demo (the shell itself)
 //     releases/slides/Bento_Slides.bento.html   the download
 //     releases/slides/manifest.json          signed update manifest
+//     releases/slides/packs/*.pack.json      language packs (hashes signed
+//                                            inside the manifest payload)
 //
 // The bytes that get SIGNED are the bytes that get SERVED — everything is
 // staged from one local build, so the manifest sha256 always matches the
@@ -56,11 +58,18 @@ cpSync(shellSrc, join(site, 'slides/index.html'))
 // scripts/shell-gate.mjs (shared with CI, which runs it on every PR build).
 gateShell(join(site, 'releases/slides/Bento_Slides.bento.html'))
 
+// Language packs: every non-core language, emitted from its catalog and
+// staged beside the shell. Their hashes go INTO the signed manifest payload
+// (docs/i18n-packs.md), so no separate signing step and no second key.
+const packsOut = join(site, 'releases/slides/packs')
+execFileSync('node', [join(root, 'scripts/build-i18n.mjs'), '--packs', packsOut], { stdio: 'inherit' })
+
 // Sign the manifest against the staged bytes.
 const signArgs = [
   join(root, 'scripts/sign-release.mjs'),
   join(site, 'releases/slides/Bento_Slides.bento.html'),
   '--out', join(site, 'releases/slides/manifest.json'),
+  '--packs', packsOut,
 ]
 const key = opt('key', null)
 if (key) signArgs.push('--key', key)

--- a/scripts/sign-release.mjs
+++ b/scripts/sign-release.mjs
@@ -7,7 +7,7 @@
 //   node scripts/sign-release.mjs slides/dist-single/Bento_Slides.bento.html \
 //     [--url https://bento.page/releases/slides/Bento_Slides.bento.html] \
 //     [--version 0.2.0] [--notes "What changed"] [--key ~/.bento/release-key.json] \
-//     [--out manifest.json]
+//     [--out manifest.json] [--packs <dir>] [--packs-url <base>]
 //
 // The manifest is { payload: "<json string>", sig: "<base64>" } — the
 // signature covers the exact payload string bytes (no canonicalization
@@ -17,7 +17,7 @@
 // Version defaults to slides/package.json — keep them in lockstep.
 
 import { createHash, createPrivateKey, createPublicKey, sign, verify } from 'node:crypto'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -44,12 +44,41 @@ const outPath = opt('out', join(dirname(shellPath), 'manifest.json'))
 const shell = readFileSync(shellPath)
 const sha256 = createHash('sha256').update(shell).digest('hex')
 
+/**
+ * Language packs ride INSIDE the signed payload (docs/i18n-packs.md).
+ *
+ * No second key and no second signature: the manifest signature covers the
+ * whole payload string, so listing each pack's sha256 here means the hashes
+ * are signed too. A client verifies the manifest once, then checks a
+ * downloaded pack against its signed hash — exactly the two-step the shell
+ * itself already goes through. Adding a separate pack-signing path would be
+ * a new trust root to get wrong for no gain.
+ */
+const packsDir = opt('packs', null)
+const packs = []
+if (packsDir) {
+  const baseUrl = opt('packs-url', url.replace(/\/[^/]*$/, '/packs'))
+  for (const name of readdirSync(packsDir).filter((f) => f.endsWith('.pack.json')).sort()) {
+    const bytes = readFileSync(join(packsDir, name))
+    const meta = JSON.parse(bytes.toString('utf8'))
+    packs.push({
+      lang: meta.lang,
+      label: meta.label,
+      version: meta.version,
+      bytes: bytes.length,
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+      url: `${baseUrl}/${name}`,
+    })
+  }
+}
+
 const payload = JSON.stringify({
   app: 'bento-slides',
   version,
   sha256,
   url,
   ...(notes ? { notes } : {}),
+  ...(packs.length ? { packs } : {}),
   at: new Date().toISOString(),
 })
 
@@ -71,4 +100,8 @@ writeFileSync(outPath, JSON.stringify({ payload, sig: sig.toString('base64') }, 
 console.log(`Signed release v${version}`)
 console.log(`  shell   ${shellPath} (${(shell.length / 1024).toFixed(0)} KB, sha256 ${sha256.slice(0, 16)}…)`)
 console.log(`  url     ${url}`)
+if (packs.length) {
+  const total = packs.reduce((n, p) => n + p.bytes, 0)
+  console.log(`  packs   ${packs.length} (${packs.map((p) => p.lang).join(', ')}) — ${(total / 1024).toFixed(0)} KB, hashes signed`)
+}
 console.log(`  out     ${outPath}`)


### PR DESCRIPTION
Next item on the `docs/i18n-packs.md` checklist: **packs now ship.**

`release.mjs` emits every non-core language beside the shell, and each pack's `sha256` goes **into the signed manifest payload**.

## No second key, no second signature

The manifest signature already covers the whole payload string, so listing pack hashes there means they're signed too. A client verifies the manifest once, then checks a downloaded pack against its signed hash — the same two-step the shell itself already goes through.

A separate pack-signing path would be a new trust root to get wrong, for no gain.

```
site/releases/slides/
  Bento_Slides.bento.html
  manifest.json                 ← payload now carries packs[]
  packs/bento-slides-1.0.10-ko.pack.json
```

## Verification

End-to-end with a **throwaway key** — the real key at `~/.bento/release-key.json` was never touched, and the test key is deleted:

| | |
|---|---|
| 1 | manifest signature valid ✅ |
| 2 | packs in the signed payload — `ko (한국어)`, 60,114 B ✅ |
| 3 | signed hash matches the emitted pack file ✅ |
| 4 | pack tampered → **hash mismatch**, client rejects the download ✅ |
| 5 | manifest tampered to swap that hash → **signature fails** ✅ |

That's the whole chain: you can't substitute a pack without breaking the hash, and you can't fix the hash without breaking the signature.

## Also recorded

**A pack must be compressed when spliced into a file** — measured at 56.8 KB raw against **26.4 KB** through the shell's existing deflate+base64 blocks. I found this earlier and hadn't written it down.

The CDN artifact stays uncompressed (Pages gzips in transit, and a readable `.json` is worth keeping for translators), but a spliced pack lives in every saved copy of that file **forever** — 30 KB per file per language, permanent and unfixable once files are in the wild.

The status list is also refreshed (it still showed #75/#79/#81 as unbuilt), and the `shell-gate.mjs` note is corrected: the gate deliberately checks only the splice contract, and it passed a build with a silently corrupted stylesheet, so pack-carrying coverage belongs in a separate smoke check rather than there.

## Remaining

- [ ] In-app "Add language…" (fetch → verify → **splice compressed**)
- [ ] **Update carries packs forward** — the one that ships broken if skipped
- [ ] Shell smoke check covering a pack-carrying shell