### PR TITLE
RTL text: infer base direction from the content

### DIFF
--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -473,7 +473,11 @@ export function renderTableHtml(el: TableElement, doc: BentoDoc): string {
             `<td data-r="${r}" data-c="${c}" style="${border}padding:${st.cellPadY}px ${st.cellPadX}px;` +
             `text-align:${align};vertical-align:middle;color:${color};background:${bg};` +
             `font-weight:${weight};overflow:hidden;word-break:break-word;">` +
-            `<div class="bento-cell-inner">${sanitizeHtml(cell.html || '') || '<br>'}</div></td>`
+            // dir="auto" per cell for the same reason text elements carry it:
+            // a table of Arabic terms is otherwise laid out as if it were
+            // English. Per cell, so a bilingual table stays correct in both
+            // columns.
+            `<div class="bento-cell-inner" dir="auto">${sanitizeHtml(cell.html || '') || '<br>'}</div></td>`
           )
         })
         .join('')
@@ -512,6 +516,14 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
       node.style.justifyContent = VALIGN[el.valign]
       const inner = document.createElement('div')
       inner.className = 'bento-text-inner'
+      // Base direction from the text itself. Without it every box is LTR, and
+      // Arabic/Hebrew/Persian/Urdu render with their neutral characters in the
+      // wrong place — a trailing full stop jumps to the head of the line, and
+      // mixed-language runs reorder. PER ELEMENT, not per document: one deck
+      // can hold an Arabic heading and an English caption and both are right.
+      // This is about the CONTENT the author typed; it says nothing about the
+      // editor's own language.
+      inner.dir = 'auto'
       inner.style.fontSize = `${el.fontSize}px`
       inner.style.fontFamily = el.fontFamily || doc.theme.fontFamily
       inner.style.fontWeight = String(el.fontWeight)


### PR DESCRIPTION
Arabic, Hebrew, Persian and Urdu render **wrongly in Bento today** — in any UI language, with no language packs involved.

There is no `dir` handling anywhere in the codebase, so every text box is LTR and the Unicode bidi algorithm places neutral characters against the wrong base:

```
typed:     السعر هو 25 دولارًا.
rendered:  .السعر هو 25 دولارًا      ← full stop at the HEAD of the line
```

Mixed-direction runs reorder the same way, and a Hebrew line's parenthetical lands on the wrong side. **An author cannot fix this by typing differently.**

## Fix

`dir="auto"` on the text inner and on each table cell. The browser infers base direction from the first strong character, so it's decided **per element** — one deck can hold an Arabic heading and an English caption and both are right, and a bilingual table gets an RTL column beside an LTR one.

Two lines, one shared renderer.

## Deliberately scoped to content

This says nothing about the editor's own language, and it must not. **The slide canvas is absolutely positioned artwork** — mirroring it would move every element in every existing deck. UI mirroring is a separate project (72 physical directional CSS properties, zero logical ones, plus panel sides and font coverage) and it has to stop cleanly at the chrome/canvas boundary. Worth stating because `dir="rtl"` on the root is exactly the shortcut a reasonable person would reach for, and it would silently wreck layouts.

## Not covered

`text-align` stays physical, because the model stores `align: 'left'`. For RTL an author usually wants alignment to follow direction — but that's a model question (*does `left` mean physical-left or start?*) plus a default-for-new-text question. Both worth deciding on their own rather than smuggling into a bug fix.

## Verification

- Arabic and Hebrew elements compute `direction: rtl`; an English element beside them stays `ltr`
- A two-column table renders `المصطلح` as `rtl` and `Term` as `ltr` **in the same row**
- Punctuation lands correctly (before/after screenshots taken during review)
- **Present mode and sidebar thumbnails inherit it** — one shared renderer, so canvas, thumbnails, present and print all agree

Splice conformance gate passes on a real build; `tsc -b` clean.