### PR TITLE
Fix: removing a file's last language pack left it in the file

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,54 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-07-26 — A language pack lives in the FILE and nowhere else
+
+No browser-local install. A "keep it on this computer" option (localStorage)
+was **built and then removed**, because `localStorage` is scoped per ORIGIN
+and that is fatally misaligned with how Bento is used: the download comes from
+`bento.page` (an https origin) and the file is then opened from disk (a
+`file://` origin). A language added on the website was therefore GONE the
+moment the user saved the deck and reopened it locally — the exact journey the
+product encourages, and "I added Korean and it vanished" is not a bug a user
+can diagnose.
+
+One home also matches the platform: the file *is* the software, so a language
+belongs to the deck. The trade — adding a language requires saving the file —
+is stated plainly in the UI ("Added when you next save") rather than hidden.
+Adding is staged on click and written on the next save because on browsers
+without File System Access, writing on click means silently downloading a
+second copy of the user's deck.
+
+Corollary: anything that remembers pack *content* outside the file
+reintroduces this. Viewer *preferences* (locale, reduce-motion) stay
+browser-local on purpose; that asymmetry is deliberate. Details:
+`docs/i18n-packs.md`, `slides/src/packs.ts`.
+
+## 2026-07-26 — The pack carrier is generic; pack POLICY is not. This is not a plugin system.
+
+The kernel mechanism is already extension-agnostic and should stay that way:
+`registerShellBlocks` / `readShellBlocks` (`kernel/src/save.ts`) carry
+arbitrary typed blocks in the shell and know nothing about languages, and
+`registerUpdatePrepare` (`kernel/src/update.ts`) is a generic "refresh
+version-bound extras" hook. Signature verification and hash pinning are being
+made generic in the kernel too (branch `claude/i18n-pack-verify`). Reuse all
+of that freely.
+
+**Do not generalize the policy.** Language packs are DATA and their worst case
+is bounded — a tampered or stale pack shows wrong or English words. That bound
+is why degrade-per-string, keep-on-refresh-failure, and auto-refresh on update
+are the right rules *for packs*.
+
+Anything carrying CODE is categorically different: unbounded failure (it would
+hold the document, the file handle, and the collab keys), and it breaks the
+property that makes self-update trustworthy — that the shell only ever runs
+bytes from a signed release. Such a thing would need its own policy (pinned at
+install, never auto-refreshed) and must not inherit the pack rules by reusing
+the pack machinery.
+
+So: reuse the carrier and the crypto; do not treat "we have packs" as evidence
+that a plugin system is designed or wanted. It is not.
+
 ## 2026-07-25 — i18n: a bundled core of 9 languages, everything else a signed pack
 
 The 7 non-English catalogs cost **115,572 B** of the shell even after key-once

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -30,8 +30,13 @@ build of every app must keep:
 
 - a `<script type="application/bento+json" id="bento-doc">` block that is
   **plaintext** (never inside the compressed payloads), same id, forever;
-- block content that is JSON with `<` escaped as `<` — it can never
+- block content that is JSON with `<` escaped as `\u003c` — it can never
   contain `</script>`;
+- the SAME escaping on every other plaintext data block the shell carries
+  (`application/bento+*`, written by `registerShellBlocks` — language packs
+  today): their bodies are not authored by us, so an unescaped one could
+  close its own block or forge a second `#bento-doc` opening tag for an old
+  updater to splice into;
 - a file that survives `DOMParser → splice → outerHTML` round-trips, with
   balanced script tags and a v0.1.0-style *text* splice still producing a
   well-formed document.
@@ -122,6 +127,27 @@ is a **signed pack**, released centrally and spliced into the file on demand;
 see `i18n-packs.md`. Packs are additive — a file that never fetches one behaves
 exactly as before — and both tiers fall back per string to the English key,
 which is what lets a stale or partial pack degrade instead of break.
+
+Four pack rules are platform-level, not app choices:
+
+- **A pack lives in the FILE and nowhere else.** No browser-local copy: the
+  download comes from an https origin and the file is then opened from
+  `file://`, so anything stored per-origin vanishes on the journey the product
+  encourages. A pack rides in an `application/bento+lang` block written by
+  `registerShellBlocks` (kernel `save.ts`), under the same `\u003c`-escaping
+  and the same §2 splice contract as `#bento-doc` — `scripts/shell-gate.mjs`
+  proves a pack-carrying shell conformant, with an adversarial pack, on every
+  build.
+- **Adding is staged, and written on the next save.** Writing on click means a
+  silent second download of the user's deck on every browser without File
+  System Access.
+- **Self-update carries packs forward** and refreshes them for the incoming
+  version (`registerUpdatePrepare` in kernel `update.ts`), best effort — a pack
+  that cannot be re-fetched is kept, never dropped.
+- **Fetched packs are verified against the signed release channel; embedded
+  packs are not re-verified** — they carry the same trust as the document
+  around them, and opening a file must never require the network. (Design
+  settled; the client-side check lands on `claude/i18n-pack-verify`.)
 
 ## 9. What is kernel vs what is app
 

--- a/docs/i18n-packs.md
+++ b/docs/i18n-packs.md
@@ -1,8 +1,10 @@
 # Language packs — design
 
-*Design document, July 2026. Status: **agreed, not built**. Companion to
-`PLATFORM.md` §6 (signed self-update) and §8 (i18n). The bundled-core half is
-settled; the pack half is specified here and implemented incrementally.*
+*Design document, July 2026. Companion to `PLATFORM.md` §6 (signed
+self-update) and §8 (i18n). The bundled core, the pack format and the in-app
+"Add language…" flow are **built**; release-side publishing and client-side
+signature verification are landing on their own branches — see
+[Status](#status), which says per item what is shipped and what is not.*
 
 ## The problem
 
@@ -109,6 +111,37 @@ sha256, verified against the `PUBLIC_KEY_JWK` already embedded in every shell
 signs packs beside the shell, and the manifest gains a `packs` array listing
 `{lang, version, sha256, url}`. No new trust root, no second key.
 
+### Verification: what is checked, and what deliberately is not
+
+> **Landing separately.** The design below is settled; the client-side
+> implementation is on branch `claude/i18n-pack-verify`. Until that merges,
+> `fetchPack` validates *shape* only (`lang`, `strings`, matching `app`) — do
+> not read this section as describing shipped behaviour.
+
+Two rules, and the asymmetry between them is the point.
+
+- **A pack fetched from the network is verified.** The pack *index* is signed
+  with the release key; each entry pins its pack by sha256. So a client
+  verifies the index signature once, then checks the bytes it downloaded
+  against the signed hash — the same two-step the shell itself goes through on
+  self-update. You cannot substitute a pack without breaking its hash, and you
+  cannot fix the hash without breaking the signature. A pack that fails is
+  refused, not degraded: a *wrong* pack is worse than no pack, and there is a
+  working English fallback right there.
+- **A pack already embedded in a file is NOT re-verified.** It carries exactly
+  the same trust as the document it travels with: someone who can rewrite a
+  block in your `.bento.html` can rewrite the document, the CRDT state and the
+  collab keys in the same file, so re-checking one block buys nothing.
+  Re-verification would also mean a *network round trip to open a deck*, which
+  breaks the property the whole format exists for — a file that works offline,
+  forever, from `file://`. The blast radius is bounded in a way that makes
+  this an easy trade: a pack is DATA, and its worst case is wrong words on
+  screen.
+
+That bound is load-bearing and does not transfer. See `docs/DECISIONS.md` —
+the carrier is generic, the policy is not, and nothing carrying **code** may
+inherit these rules.
+
 ### Loading
 
 `registerI18n` already accepts a packed table (kernel). Pack loading adds a
@@ -119,11 +152,89 @@ partial or stale pack degrade gracefully rather than break.
 ### Incorporation into the file
 
 A pack is fetched **only on explicit user action** ("Add language…"), verified,
-then spliced into the shell as an additional payload block and written out as
-a new file — the same fetch → verify → re-splice flow `update.ts` already
-performs. Nothing phones home by default; a file that never adds a language
-never talks to the network. Once spliced, the pack travels with the file and
-works offline forever, like everything else.
+then written into the shell as an additional plaintext data block. Nothing
+phones home by default; a file that never adds a language never talks to the
+network. Once written, the pack travels with the file and works offline
+forever, like everything else.
+
+Mechanically the block is a `<script type="application/bento+lang"
+id="bento-lang-<lang>">` in `<head>`, holding the pack JSON with `<` escaped as
+`\u003c` — exactly the treatment `#bento-doc` gets. The kernel side is
+deliberately ignorant: `registerShellBlocks` / `readShellBlocks`
+(`kernel/src/save.ts`) carry *typed blocks*, and know nothing about languages.
+The app registers `shellBlocksForPacks()` once, at boot, and every serialize
+re-declares the whole set.
+
+## Where a pack lives
+
+### A pack lives in the FILE and nowhere else
+
+This was decided the hard way: a second home — "install for this browser",
+backed by `localStorage` — was **built and then removed**. The reasoning must
+survive, because the idea looks obviously good and will otherwise be proposed
+again.
+
+`localStorage` is scoped per **origin**. Bento's actual journey crosses
+origins: the download comes from `bento.page` (an `https` origin), and the
+file is then opened from disk (a `file://` origin, where every file is
+effectively its own storage bucket anyway). So a language added on the website
+was **gone** the moment the user saved the deck and reopened it locally — the
+exact journey the product encourages. "I added Korean and it vanished" is not
+something a user can diagnose, and no wording fixes it.
+
+It also matches everything else here: the file *is* the software, so a
+language belongs to the deck. The trade is that adding a language requires
+saving the file, which the UI states plainly instead of hiding.
+
+Corollary for future work: anything that "remembers" a pack outside the file
+reintroduces this bug. Viewer *preferences* (chosen locale, reduce-motion) are
+browser-local on purpose; pack *content* never is.
+
+### Adding is staged on click, written on the next save
+
+Clicking Add registers the pack immediately — the editor switches language
+right away — and marks it pending. The row says **"Added when you next save"**,
+and the file gains it on the next save (`markFileSaved()` clears the pending
+flags once the bytes are out).
+
+It is staged rather than written-on-click because on every browser without the
+File System Access API, "write" means **silently downloading a second copy of
+the user's deck**. Handing someone an unexpected `deck (1).bento.html` because
+they asked for Korean is a worse surprise than asking them to save.
+
+Removal is meant to be symmetric and to need no deletion path: `serializeBody`
+drops every block of a managed type and rewrites the current set, so "remove
+from this file" is just *stop listing it*.
+
+> **Known gap (kernel, unfixed at time of writing).** `serializeBody` derives
+> the managed types from the blocks it is *about* to write, so when the set is
+> EMPTY it removes nothing. Removing the file's **last** pack therefore leaves
+> the old block in the saved file — every other removal works. The fix is for
+> the provider to declare its managed types rather than have them inferred.
+> Kernel zone, so it wants its own small PR (`docs/PARALLEL-WORK.md` §1).
+
+### Staying current
+
+Two mechanisms, because a pack is frozen at the version it was built for while
+the app around it keeps gaining strings — so a translated deck otherwise
+drifts back toward English one release at a time, silently, per string.
+
+- **Update refreshes packs.** `registerUpdatePrepare` (`kernel/src/update.ts`)
+  gives the app a moment after a release is verified and before the document
+  is serialized into the new shell; slides uses it to run
+  `refreshPacksForVersion(version)`, re-fetching each carried language at the
+  incoming version. It is **best effort and never fatal**: any pack that
+  cannot be re-fetched — offline, not published yet, anything — is kept as it
+  is. Degraded beats absent; losing a language the author baked in is far
+  worse than one that is a release out of date.
+- **The Languages dialog says when a pack is stale.** `packCoverage(pack)`
+  counts how many of the *running app's* strings the pack does not cover
+  (`PACKED`'s keys are exactly the strings the app asks for), and the row
+  reads "Built for v1.0.11 — 23 phrases still show in English. Updating Bento
+  refreshes it." Measured, not inferred from the version number: a pack built
+  against an older release may still cover everything, and a same-version pack
+  can be incomplete. Naming the number turns "why is some of this English?"
+  into a fact, and saying it fixes itself stops anyone hunting for a button.
 
 ## Risks
 
@@ -132,17 +243,34 @@ if it isn't designed in.** `update.ts` fetches a *new shell* and re-splices the
 current *document* into it. Packs live in the shell, not the document, so the
 naive path hands a Korean user back an English file after an update, silently
 and with no error to describe. Pack migration is part of the update path, not
-a follow-up.
+a follow-up. *Handled:* the registered block provider is consulted on every
+serialize, including the update one, so packs ride across by construction —
+and `registerUpdatePrepare` refreshes them to the incoming version first (see
+[Staying current](#staying-current)).
 
 **Pack/app version coupling.** Every release adds strings. A 1.0.10 pack in a
 1.1.0 shell must degrade per string to English, never fail to load. The
 manifest is versioned per pack; the policy for "pack older than app" is
 load-and-degrade.
 
-**Splice contract.** Packs are additional payload blocks. `#bento-doc` stays
-plaintext and the file must still survive `DOMParser → outerHTML`
-(`PLATFORM.md` §2). `shell-gate.mjs` must cover a shell carrying packs — the
-gate is what protects updaters already frozen in the wild.
+**Splice contract.** Packs are additional plaintext blocks beside `#bento-doc`,
+and a pack body is arbitrary translated text — it can contain `<`, quotes, and
+the literal sequence that closes a script tag. Unescaped, a single pack string
+could terminate its own block, or forge a second `#bento-doc` opening tag that
+an old updater (which splices into the FIRST regex match) would write into
+instead of the real one. Both would brick files already in the wild.
+
+*Handled:* `serializeBody` applies the same `<`→`\u003c` escape to registered
+blocks as to the document, and `scripts/shell-gate.mjs` now proves it. Because
+a fresh build carries no packs, the gate synthesises an adversarial one — a
+script-close sequence, a forged `#bento-doc` opening tag, an HTML comment
+opener, CJK/RTL/emoji, U+2028/U+2029 — inserts it both above and below the doc
+block, and re-runs the whole contract plus a lossless JSON round-trip and a
+v0.1.0-style text splice. A negative control (the same pack written unescaped)
+must fail, so the check cannot quietly become vacuous, and one source
+assertion keeps `kernel/src/save.ts` applying the escape on both write paths.
+The gate covers the splice contract only; it says nothing about whether a
+pack's *contents* are right.
 
 **RTL is not a pack.** Arabic, Urdu, Persian and Hebrew are among the largest
 gaps by population, but they need bidi and mirroring work in the CSS. Ranking
@@ -163,15 +291,34 @@ turns native review into a continuous process instead of a release blocker.
   self-contained? Slides, Spaces and Dash have overlapping but distinct string
   sets.
 - Should a saved deck record which packs it carries, for the People/About UI?
+  (Partly answered: the Languages dialog reads them straight out of the shell,
+  so nothing needs recording in the *document*.)
+- Should a spliced pack be compressed? It is written as plaintext JSON today,
+  which is simple and keeps the splice contract trivially checkable; the shell
+  already has deflate+base64 payload blocks that would roughly halve it, at
+  the cost of a second block shape for the gate to reason about.
 
 ## Status
 
-- [ ] Key-once packing of the bundled catalogs — **PR #75, in flight**. A
-      prerequisite: it shrinks the core and its kernel change (`registerI18n`
-      accepting a packed table) is the loading path packs will reuse.
-- [ ] Portuguese catalog, bundled
-- [ ] Pack format + `release.mjs` emitting and signing packs
-- [ ] Manifest `packs` array
-- [ ] In-app "Add language…" (fetch → verify → splice)
-- [ ] **Update carries packs forward**
-- [ ] `shell-gate.mjs` covers a pack-carrying shell
+Answered: **is this shipped?** Anything marked *branch* is designed and
+written but not merged — do not describe it as shipped.
+
+- [x] Key-once packing of the bundled catalogs (PR #75) — the prerequisite:
+      it shrank the core, and its kernel change (`registerI18n` accepting a
+      packed table) is the loading path packs reuse.
+- [x] Portuguese catalog, bundled (PR #79)
+- [x] Pack format + `build-i18n.mjs --packs` emission, Korean first (PR #81)
+- [x] Runtime loading: `addPack`/`removePack`, per-string fallback
+      (`kernel/src/i18n.ts`)
+- [x] In-app "Add language…" / "Remove", staged and written on the next save
+      — *branch `claude/i18n-pack-ui`, PR #86*
+- [x] **Update carries packs forward** + `refreshPacksForVersion` — same branch
+- [x] Per-pack staleness note from `packCoverage` — same branch
+- [x] `shell-gate.mjs` covers a pack-carrying shell — *branch
+      `claude/i18n-pack-gate`, stacked on #86*
+- [ ] `release.mjs` publishing packs + the signed manifest `packs` array —
+      *branch `claude/i18n-pack-release`*
+- [ ] Client-side signature/hash verification of fetched packs —
+      *branch `claude/i18n-pack-verify`*
+- [ ] A published pack index at the release channel (`packs.json`), so
+      "Available to add" is non-empty in the wild

--- a/docs/i18n-packs.md
+++ b/docs/i18n-packs.md
@@ -162,8 +162,8 @@ id="bento-lang-<lang>">` in `<head>`, holding the pack JSON with `<` escaped as
 `\u003c` — exactly the treatment `#bento-doc` gets. The kernel side is
 deliberately ignorant: `registerShellBlocks` / `readShellBlocks`
 (`kernel/src/save.ts`) carry *typed blocks*, and know nothing about languages.
-The app registers `shellBlocksForPacks()` once, at boot, and every serialize
-re-declares the whole set.
+The app registers `shellBlocksForPacks()` once, at boot — together with the
+block types it owns — and every serialize re-declares the whole set.
 
 ## Where a pack lives
 
@@ -202,16 +202,11 @@ File System Access API, "write" means **silently downloading a second copy of
 the user's deck**. Handing someone an unexpected `deck (1).bento.html` because
 they asked for Korean is a worse surprise than asking them to save.
 
-Removal is meant to be symmetric and to need no deletion path: `serializeBody`
-drops every block of a managed type and rewrites the current set, so "remove
-from this file" is just *stop listing it*.
-
-> **Known gap (kernel, unfixed at time of writing).** `serializeBody` derives
-> the managed types from the blocks it is *about* to write, so when the set is
-> EMPTY it removes nothing. Removing the file's **last** pack therefore leaves
-> the old block in the saved file — every other removal works. The fix is for
-> the provider to declare its managed types rather than have them inferred.
-> Kernel zone, so it wants its own small PR (`docs/PARALLEL-WORK.md` §1).
+Removal is symmetric and needs no deletion path: `serializeBody` drops every
+block of a managed type and rewrites the current set, so "remove from this
+file" is just *stop listing it*. The managed types are the ones the provider
+DECLARED at registration, not the ones it is about to write — so an empty set
+still clears, which is exactly what removing the file's last pack looks like.
 
 ### Staying current
 

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -46,10 +46,21 @@ export interface ShellBlock {
   attrs?: Record<string, string>
 }
 let shellBlocks: () => ShellBlock[] = () => []
+let managedTypes: string[] = []
 
-/** Register the provider consulted on every serialize. Call once, at boot. */
-export function registerShellBlocks(fn: () => ShellBlock[]): void {
+/**
+ * Register the provider consulted on every serialize, and the block types it
+ * OWNS. Call once, at boot.
+ *
+ * The types are declared rather than inferred from what the provider returns,
+ * because the empty list is meaningful: "this file should carry no language
+ * pack" has to clear the blocks the file arrived with, and a set derived from
+ * the blocks about to be written would be empty exactly then — leaving the
+ * last removed pack in the file (it would come back on the next open).
+ */
+export function registerShellBlocks(fn: () => ShellBlock[], types: string[]): void {
   shellBlocks = fn
+  managedTypes = types
 }
 
 /** Every extra block currently in THIS document (as loaded from disk). */
@@ -67,9 +78,12 @@ function serializeBody(shell: Document, body: string, title: string): string {
 
   // Re-declare the app's extra blocks: drop every one of a managed type, then
   // write the current set back. Removing a language from the file is therefore
-  // just "stop listing it" — no deletion path to get wrong.
+  // just "stop listing it" — no deletion path to get wrong. The clear-set is
+  // the DECLARED types, never the types about to be written: an empty write
+  // set still has to clear (that is what removing the file's last pack looks
+  // like).
   const wanted = shellBlocks()
-  for (const type of new Set(wanted.map((b) => b.type))) {
+  for (const type of new Set([...managedTypes, ...wanted.map((b) => b.type)])) {
     for (const stale of Array.from(clone.querySelectorAll(`script[type="${type}"]`))) stale.remove()
   }
   for (const b of wanted) {

--- a/scripts/shell-gate.mjs
+++ b/scripts/shell-gate.mjs
@@ -6,29 +6,264 @@
 // #bento-doc, regex-extractable, balanced script tags, and a v0.1.0-style
 // text splice must produce a well-formed document.
 //
+// It also covers the SECOND class of plaintext block: `application/bento+*`
+// data blocks written by kernel/src/save.ts `registerShellBlocks` — language
+// packs today (docs/i18n-packs.md), other version-bound extras later. A pack
+// body is arbitrary translated text from the release channel, so unlike the
+// document it is not shaped by us: it can contain `<`, quotes, non-ASCII, and
+// — if nothing stopped it — the literal sequence that closes a script tag.
+// A fresh build carries no packs, so the gate SYNTHESIZES an adversarial one
+// and proves the contract holds with it in the file (and, as a negative
+// control, that the same pack written *unescaped* is caught).
+//
+// The `<`-escape rule is deliberately restated here rather than imported: a
+// gate that shares code with the thing it gates cannot notice the thing
+// drifting. The one link back to the implementation is a source assertion
+// (checkEscapeIsImplemented) that the rule is still applied on both write
+// paths in kernel/src/save.ts.
+//
 // One implementation, two callers: release.mjs runs it before signing, and
 // CI runs it on every PR's build (node scripts/shell-gate.mjs <shell.html>).
 // CI validating the contract is NOT a release — signing stays local-only
 // (docs/RELEASING.md); this file must never touch keys or manifests.
 
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(here)
+
+// Never write these literals: this file is not bundled, but the habit is the
+// hard rule (AGENTS.md #1) and the adversarial fixtures below need them as
+// data, not as tokens the reader's tooling might act on.
+const SCRIPT_CLOSE = '</scr' + 'ipt>'
+const DOC_BLOCK_OPEN = '<script type="application/bento+json" id="bento-doc">'
+const DOC_BLOCK_RE = /<script type="application\/bento\+json" id="bento-doc">[\s\S]*?<\/script>/
+
+/** The escape every plaintext Bento block is written with. `<` can then never
+ *  start a close tag, a comment, or a nested `<script` — and stays valid JSON. */
+const escapeBlockText = (json) => json.replace(/</g, '\\u003c')
+
+const fail = (msg) => { throw new Error('GATE: ' + msg) }
+
+// --- a small rawtext scanner ------------------------------------------------
+//
+// Script content is RAWTEXT: an HTML parser ends the element at the first
+// `</script` followed by whitespace, `/` or `>` (case-insensitive). Modelling
+// that is enough to reason about DOMParser → outerHTML without a DOM in node,
+// because the escaped/double-escaped script-data states it ignores can only be
+// entered through a raw `<` — which every check below forbids in a data block.
+
+const CLOSE_RE = /<\/script[\s/>]/i
+
+/** Index of the parser-visible end of script data starting at `from`, or -1. */
+function scriptDataEnd(html, from) {
+  const rest = html.slice(from)
+  const m = rest.match(CLOSE_RE)
+  return m ? from + m.index : -1
+}
+
+/** Every `<script>` in the file, with its attributes and raw text. */
+function scanScripts(html) {
+  const out = []
+  const openRe = /<script\b([^>]*)>/gi
+  let m
+  while ((m = openRe.exec(html))) {
+    const bodyStart = m.index + m[0].length
+    const end = scriptDataEnd(html, bodyStart)
+    if (end < 0) fail(`unterminated <script> at offset ${m.index}`)
+    const attrs = m[1]
+    out.push({
+      attrs,
+      id: (attrs.match(/\bid="([^"]*)"/i) ?? [])[1] ?? '',
+      type: (attrs.match(/\btype="([^"]*)"/i) ?? [])[1] ?? '',
+      text: html.slice(bodyStart, end),
+      start: m.index,
+    })
+    openRe.lastIndex = end + SCRIPT_CLOSE.length
+  }
+  return out
+}
+
+/** HTML attribute-value escaping, as a DOM serializer does it. */
+const attrValue = (s) => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+
+// --- invariant 1: the frozen splice contract --------------------------------
+
+/** The checks the gate has always run, on any candidate file. */
+function checkSpliceContract(html, label) {
+  if (!DOC_BLOCK_RE.test(html)) fail(`#bento-doc block not found/extractable (${label})`)
+  const opens = (html.match(/<script[\s>]/g) ?? []).length
+  const closes = html.split(SCRIPT_CLOSE).length - 1
+  if (opens !== closes) fail(`script tag imbalance ${opens}/${closes} (${label})`)
+
+  const fakeDoc = escapeBlockText(JSON.stringify({ format: 'bento/slides', probe: '<tag> & </close>' }))
+  // function replacement throughout: `$` in generated text must stay literal
+  const spliced = html.replace(DOC_BLOCK_RE, () => `${DOC_BLOCK_OPEN}\n${fakeDoc}\n${SCRIPT_CLOSE}`)
+  if (!spliced.includes(fakeDoc)) fail(`splice failed (${label})`)
+  const opens2 = (spliced.match(/<script[\s>]/g) ?? []).length
+  const closes2 = spliced.split(SCRIPT_CLOSE).length - 1
+  if (opens2 !== closes2) fail(`spliced document imbalanced (${label})`)
+  return spliced
+}
+
+// --- invariant 2: every plaintext data block is escaped and lossless --------
+
+/**
+ * `application/bento+*` blocks are the app's plaintext data: the document
+ * itself and anything `registerShellBlocks` writes beside it. All of them are
+ * JSON with `<` escaped, so none can terminate its own script element, open a
+ * comment, or forge another block's opening tag.
+ */
+function checkDataBlocks(html, label) {
+  const blocks = scanScripts(html).filter((s) => /^application\/bento\+/.test(s.type))
+  const docs = blocks.filter((b) => b.id === 'bento-doc')
+  if (docs.length !== 1) fail(`expected exactly one #bento-doc, found ${docs.length} (${label})`)
+
+  const ids = new Set()
+  for (const b of blocks) {
+    const where = `${b.type}#${b.id || '(no id)'} (${label})`
+    if (b.id && ids.has(b.id)) fail(`duplicate block id ${b.id} (${label})`)
+    if (b.id) ids.add(b.id)
+    if (b.text.includes('<')) fail(`unescaped "<" in ${where} — must be written as \\u003c`)
+    const text = b.text.trim()
+    // The released shell ships an EMPTY doc block (the demo boots the starter
+    // deck); an empty block is legal, anything present must be JSON.
+    if (!text) continue
+    try {
+      JSON.parse(text)
+    } catch (e) {
+      fail(`${where} is not parseable JSON: ${e.message}`)
+    }
+  }
+  return blocks
+}
+
+// --- invariant 3: a pack-carrying shell ------------------------------------
+
+/**
+ * A pack designed to break the file if anything is unescaped: it closes a
+ * script tag, forges a `#bento-doc` opening tag (an old updater splices into
+ * the FIRST match, so a forged one placed above the real block would hijack
+ * the document), opens an HTML comment, and carries non-ASCII, RTL, emoji and
+ * the line separators JSON leaves raw.
+ */
+const ADVERSARIAL_PACK = {
+  app: 'slides',
+  version: '9.9.9',
+  // ampersand + quote: the lang also lands in the `id` and `data-lang`
+  // ATTRIBUTES — a second escaping path (attrValue here, a DOM serializer
+  // in the product), which must not let a pack break out of the tag.
+  lang: 'zz-Adv&"ersarial',
+  label: '한국어 · 日本語 · Ελληνικά · «Z» 🎌',
+  strings: {
+    Save: SCRIPT_CLOSE,
+    Open: `${DOC_BLOCK_OPEN}{\"format\":\"bento/slides\",\"hijacked\":true}${SCRIPT_CLOSE}`,
+    Close: '</SCRIPT\t> </script/ <script> <!-- --> <![CDATA[',
+    Quotes: '\"\'`\\ & &amp; &quot; \u0000\u001f',
+    // JSON.stringify leaves these RAW in its output: a JS parser reads them
+    // as line terminators even though JSON does not.
+    Separators: 'a\u2028b\u2029c',
+    RTL: 'مرحبا — שלום',
+  },
+}
+
+/** Exactly how kernel/src/save.ts serializes one registered block. */
+function packBlockHtml(pack, { escaped = true } = {}) {
+  const json = JSON.stringify(pack)
+  const text = escaped ? escapeBlockText(json) : json
+  return (
+    `<script type="application/bento+lang" id="${attrValue('bento-lang-' + pack.lang)}"` +
+    ` data-lang="${attrValue(pack.lang)}">\n${text}\n${SCRIPT_CLOSE}`
+  )
+}
+
+// Function replacements: a `$` in a pack body must stay literal.
+/** Insert a block where `serializeBody` does — appended to <head>. */
+const withBlockInHead = (html, block) => html.replace('</head>', () => `${block}\n</head>`)
+/** …and, for the forged-doc-block case, ABOVE the real #bento-doc. */
+const withBlockBeforeDoc = (html, block) => html.replace(DOC_BLOCK_OPEN, () => `${block}\n${DOC_BLOCK_OPEN}`)
+
+function checkPackCarryingShell(shell) {
+  const pack = ADVERSARIAL_PACK
+  const block = packBlockHtml(pack)
+  const realDoc = shell.match(DOC_BLOCK_RE)[0]
+
+  for (const [where, html] of [
+    ['pack after #bento-doc', withBlockInHead(shell, block)],
+    ['pack before #bento-doc', withBlockBeforeDoc(shell, block)],
+  ]) {
+    checkSpliceContract(html, where)
+    const blocks = checkDataBlocks(html, where)
+
+    // The forged opening tag inside the pack must not become what an updater
+    // extracts — the real block, wherever the pack sits, is still the match.
+    if (html.match(DOC_BLOCK_RE)[0] !== realDoc) fail(`#bento-doc extraction hijacked by a pack (${where})`)
+
+    // Round-trip: what a parser sees in the block is byte-identical to what we
+    // wrote, and JSON.parse of it reproduces the pack exactly.
+    // by id, not by type: a shell may already carry real packs of its own
+    const wantId = attrValue('bento-lang-' + pack.lang)
+    const got = blocks.find((b) => b.id === wantId)
+    if (!got) fail(`pack block not found after insertion (${where})`)
+    if (got.text.trim() !== escapeBlockText(JSON.stringify(pack)))
+      fail(`pack block text changed on round-trip (${where})`)
+    const parsed = JSON.parse(got.text)
+    if (JSON.stringify(parsed) !== JSON.stringify(pack)) fail(`pack did not round-trip losslessly (${where})`)
+
+    // …and it survives the frozen text splice unchanged: an updater rewriting
+    // the document must not disturb the languages riding beside it.
+    const spliced = checkSpliceContract(html, where + ' + splice')
+    if (!spliced.includes(block)) fail(`pack block did not survive the doc splice (${where})`)
+    checkDataBlocks(spliced, where + ' + splice')
+  }
+
+  // NEGATIVE CONTROL — the same pack written without the escape must be
+  // caught. If this passes, the checks above prove nothing.
+  const raw = packBlockHtml(pack, { escaped: false })
+  let caught = 0
+  for (const html of [withBlockInHead(shell, raw), withBlockBeforeDoc(shell, raw)]) {
+    try {
+      checkSpliceContract(html, 'unescaped control')
+      checkDataBlocks(html, 'unescaped control')
+      if (html.match(DOC_BLOCK_RE)[0] !== realDoc) fail('hijack')
+    } catch {
+      caught++
+    }
+  }
+  if (caught !== 2) fail('negative control passed — the pack-block checks have no teeth')
+}
+
+// --- invariant 4: the product still applies the escape ----------------------
+
+/**
+ * The only assertion that reaches into the implementation. The gate works on
+ * built artifacts, and a fresh shell carries no packs, so nothing above could
+ * notice `serializeBody` quietly dropping the escape on the block it writes at
+ * save time — which is precisely the change that would brick shipped files.
+ * If a refactor moves the rule, re-point this check; do not delete it.
+ */
+function checkEscapeIsImplemented() {
+  const src = join(repoRoot, 'kernel/src/save.ts')
+  if (!existsSync(src)) return // an app repo vendored without the kernel
+  const text = readFileSync(src, 'utf8')
+  const applied = (text.match(/replace\(\/<\/g, *'\\\\u003c'\)/g) ?? []).length
+  if (applied < 2)
+    fail(
+      'kernel/src/save.ts no longer applies the \\u003c escape on both write paths ' +
+        `(#bento-doc and registerShellBlocks) — found ${applied}`,
+    )
+}
 
 /** Throws with a GATE: message on the first violated invariant. */
 export function gateShell(shellPath) {
   const shell = readFileSync(shellPath, 'utf8')
-  const blockRe = /<script type="application\/bento\+json" id="bento-doc">[\s\S]*?<\/script>/
-  if (!blockRe.test(shell)) throw new Error('GATE: #bento-doc block not found/extractable')
-  const opens = (shell.match(/<script[\s>]/g) ?? []).length
-  const closes = shell.split('</scr' + 'ipt>').length - 1
-  if (opens !== closes) throw new Error(`GATE: script tag imbalance (${opens}/${closes})`)
-  const fakeDoc = JSON.stringify({ format: 'bento/slides', probe: '<tag> & </close>' }).replace(/</g, '\\u003c')
-  const spliced = shell.replace(blockRe, `<script type="application/bento+json" id="bento-doc">\n${fakeDoc}\n</scr` + 'ipt>')
-  if (!spliced.includes(fakeDoc)) throw new Error('GATE: splice failed')
-  const opens2 = (spliced.match(/<script[\s>]/g) ?? []).length
-  const closes2 = spliced.split('</scr' + 'ipt>').length - 1
-  if (opens2 !== closes2) throw new Error('GATE: spliced document imbalanced')
-  console.log('conformance gate: old-updater splice contract OK')
+  checkSpliceContract(shell, 'shell')
+  checkDataBlocks(shell, 'shell')
+  checkPackCarryingShell(shell)
+  checkEscapeIsImplemented()
+  console.log('conformance gate: old-updater splice contract OK (incl. pack-carrying shell)')
 }
 
 // CLI: node scripts/shell-gate.mjs <path-to-shell.html>

--- a/slides/src/i18n.ts
+++ b/slides/src/i18n.ts
@@ -18,7 +18,7 @@
 //     node scripts/build-i18n.mjs
 //
 import { PACKED, PACKED_LOCALES } from './i18n/packed'
-import { readPacksFromShell, refreshPacksForVersion, shellBlocksForPacks } from './packs'
+import { PACK_BLOCK_TYPE, readPacksFromShell, refreshPacksForVersion, shellBlocksForPacks } from './packs'
 import { registerShellBlocks } from '../../kernel/src/save.ts'
 import { registerUpdatePrepare } from '../../kernel/src/update.ts'
 import { registerI18n } from '../../kernel/src/i18n.ts'
@@ -64,8 +64,10 @@ registerI18n({
 readPacksFromShell()
 
 // Every save re-declares the file's packs, so staging one is enough to make
-// it travel and dropping it is enough to remove it.
-registerShellBlocks(shellBlocksForPacks)
+// it travel and dropping it is enough to remove it. The type is declared here
+// so the kernel clears pack blocks even when the list is empty — removing the
+// file's last pack must actually remove it.
+registerShellBlocks(shellBlocksForPacks, [PACK_BLOCK_TYPE])
 
 // A self-update fetches a NEW shell and re-splices this document into it. The
 // block provider above already carries the file's packs across; this also

--- a/slides/src/packs.ts
+++ b/slides/src/packs.ts
@@ -43,7 +43,7 @@ export interface PackListing {
 export type PackError = 'offline' | 'bad-pack' | 'wrong-app'
 
 /** The block type carrying a pack inside a saved shell. */
-const BLOCK_TYPE = 'application/bento+lang'
+export const PACK_BLOCK_TYPE = 'application/bento+lang'
 const blockId = (lang: string) => `bento-lang-${lang}`
 
 /** Packs destined for the file: those already in it, plus any staged since. */
@@ -58,7 +58,7 @@ const pending = new Set<string>()
  */
 export function readPacksFromShell(): number {
   let n = 0
-  for (const { body } of readShellBlocks(BLOCK_TYPE)) {
+  for (const { body } of readShellBlocks(PACK_BLOCK_TYPE)) {
     try {
       const pack = JSON.parse(body) as LanguagePack
       if (pack?.lang && pack.strings && addPack(pack, 'slides')) {
@@ -144,7 +144,7 @@ export function markFileSaved(): void {
 export function shellBlocksForPacks(): ShellBlock[] {
   return [...inFile.values()].map((p) => ({
     id: blockId(p.lang),
-    type: BLOCK_TYPE,
+    type: PACK_BLOCK_TYPE,
     body: JSON.stringify(p),
     attrs: { 'data-lang': p.lang },
   }))


### PR DESCRIPTION
`serializeBody` derived its set of managed block types from the blocks it was about to **write**:

```ts
const wanted = shellBlocks()
for (const type of new Set(wanted.map((b) => b.type))) { … }
```

so when `wanted` is empty, nothing is cleared.

**Repro.** Open a deck carrying exactly one language pack → Languages → Remove → save. `unstageFromFile()` drops it from `inFile`, `shellBlocksForPacks()` returns `[]`, the loop never runs, and the `<script type="application/bento+lang">` from the pristine boot clone is still in the saved file. Reopening re-registers it via `readPacksFromShell()` — the language comes back. Removing one of two packs always worked.

**Fix.** The provider declares the types it owns at registration — `registerShellBlocks(shellBlocksForPacks, [PACK_BLOCK_TYPE])` — and the clear-set is those declared types, independent of the write-set. (The write-set's types are still unioned in, so an undeclared type can never be written twice.)

Small and single-purpose: `kernel/src/save.ts` is the serialize-don't-parallelize zone (`docs/PARALLEL-WORK.md` §1).

### Verified

Built shell, opened over `file://` with a pack block spliced into `<head>`, driving the real Languages dialog:

- one pack → Remove → `window.bento.serialize()` emits **zero** pack blocks, `#bento-doc` intact
- two packs → Remove one → the other survives (`bento-lang-yy` remains)

Gates: `tsc -b`, `npm run build:single`, `node scripts/shell-gate.mjs slides/dist-single/Bento_Slides.bento.html` (*"old-updater splice contract OK (incl. pack-carrying shell)"*).

### Base

Stacked on #95, not #86 — the "Known gap" block this PR deletes lives in `docs/i18n-packs.md` on `claude/i18n-pack-gate`, so code fix and doc removal only land together from there. Retarget to `main` once #86 and #95 are in.