### PR TITLE
Community: point people at Discussions, and ask contributors to claim work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,39 @@ If you touch the boot, save, or build path, keep these invariants intact — the
 release process gates on them. The details are in
 [docs/architecture.md](docs/architecture.md).
 
+## Before you build something substantial
+
+**Check what's already in flight, and claim it.** Bento moves fast and several
+things are usually half-built at once — twice now, contributors have written
+thousands of lines that duplicated work already open as a PR. That is our
+fault, not theirs, so:
+
+1. Skim [open pull requests](https://github.com/nyblnet/bento/pulls) and the
+   pinned **What's in flight** issue.
+2. For anything beyond a small fix, open an issue (or a
+   [Discussion](https://github.com/nyblnet/bento/discussions) under *Ideas*)
+   saying what you plan to do, before you write it. A maintainer will tell you
+   quickly if it clashes with something unreleased or with a platform
+   invariant.
+
+That second step matters most for changes that touch
+[docs/PLATFORM.md](docs/PLATFORM.md) §1–2 — the single-file promise and the
+splice contract. Those are the two rules the project will not bend, and a
+change that breaks them cannot be merged however good the code is.
+
+## AI-assisted contributions
+
+They're welcome — the maintainer uses AI on this repo too. Two conditions:
+
+- **You have read and understood what you're submitting**, and you can answer
+  questions about it. Review it as if you had written every line, because as
+  far as the project is concerned, you did.
+- **Commits are authored under your own name**, not a bot identity.
+
+An AI will happily produce something locally coherent that violates a rule
+stated plainly in `docs/PLATFORM.md`. Checking your change against that file is
+worth more than any amount of polish.
+
 ## Pull requests
 
 - Branch off `main` and keep PRs focused — one concern per PR is easier to
@@ -98,10 +131,16 @@ release process gates on them. The details are in
 - Please don't bump the version or cut releases in a PR — releases are signed
   and cut locally by a maintainer (see [docs/RELEASING.md](docs/RELEASING.md)).
 
-## Reporting bugs & ideas
+## Questions, bugs & ideas
 
-Open a GitHub issue. For bugs, include your browser and OS, what you expected,
-what happened, and — when you can — a minimal `.bento.html` that reproduces it.
+- **Questions and help** — [Discussions →
+  Q&A](https://github.com/nyblnet/bento/discussions/categories/q-a). Answers
+  there are searchable and help the next person with the same question.
+- **Ideas and feature requests** — [Discussions →
+  Ideas](https://github.com/nyblnet/bento/discussions/categories/ideas).
+- **Bugs** — open a GitHub issue. Include your browser and OS, what you
+  expected, what happened, and — when you can — a minimal `.bento.html` that
+  reproduces it.
 
 Security issues are different: please **do not** open a public issue. Follow
 [SECURITY.md](SECURITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ locally so the signing key never leaves the maintainer's machine — see
 Contributions welcome — start with [CONTRIBUTING.md](CONTRIBUTING.md). Found a
 security issue? See [SECURITY.md](SECURITY.md).
 
+## Community
+
+- **Questions and help** — [Discussions →
+  Q&A](https://github.com/nyblnet/bento/discussions/categories/q-a)
+- **Ideas and feature requests** — [Discussions →
+  Ideas](https://github.com/nyblnet/bento/discussions/categories/ideas)
+- **Built something with Bento?** — [Show and
+  tell](https://github.com/nyblnet/bento/discussions/categories/show-and-tell)
+- **Bugs** — [open an issue](https://github.com/nyblnet/bento/issues).
+  Security issues go through [SECURITY.md](SECURITY.md) instead, never a
+  public issue.
+
+Planning a substantial contribution? Check the pinned **What's in flight**
+issue and the open PRs first, and say what you're planning before you build it
+— see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Roadmap
 
 **bento/slides** is the first app — a PowerPoint alternative, shipping now.


### PR DESCRIPTION
Groundwork for using GitHub Discussions, plus the fix for the problem that prompted it.

## Why
Two contributors have now independently built something already open as a PR — math (#68, superseded by the Temml work) and a native wrapper (#87, overlapping `bento/tray`). **Neither could have known.** The README roadmap says which *apps* are coming and nothing about what's being built *right now*, and CONTRIBUTING never asked anyone to check.

## Changes
- **README** gains a Community section pointing at Discussions (Q&A, Ideas, Show and tell). Bugs still go to issues, security still to SECURITY.md.
- **CONTRIBUTING** gains *"Before you build something substantial"* — check open PRs and the pinned [What's in flight](https://github.com/nyblnet/bento/issues/124) issue, and say what you're planning before writing anything large. With a specific warning that PLATFORM.md §1–2 can't be bent however good the code is, which is exactly what sank #68.
- **CONTRIBUTING** gains an **AI-assisted contributions** policy: welcome, provided you've read and understood what you submit and can answer for it, and commits are authored under your own name rather than a bot identity.

## Also done, outside this PR
[Issue #124 — *What's in flight*](https://github.com/nyblnet/bento/issues/124) is created and **pinned**: current work, recently landed, the settled platform decisions people should ask about before reopening, and what's genuinely unclaimed (spaces, dash, vault, Android).

## Still yours to do
Discussions categories are **UI-only** — no API. The defaults (Announcements, General, Ideas, Polls, Q&A, Show and tell) are good as-is; I'd only consider removing **Polls**, which tends to sit unused. And a welcome post in Announcements should be in your voice, not mine — happy to draft one if you'd like.