### PR TITLE
CI: give every merge commit on main its own run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,21 @@ on:
     branches: [main]
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded runs on PR branches — only the tip matters there. NOT on
-  # main: every merge commit is a distinct state, and the post-merge run is the
-  # safety net for interaction bugs between PRs merged close together. Four
-  # merges in a few minutes once left two merge commits only partly verified.
+  # PR branches share one group per ref, so a new push collapses onto the tip —
+  # only the tip matters there. Pushes to main get a group PER COMMIT, because
+  # every merge commit is a distinct state and the post-merge run is the safety
+  # net for interaction bugs between PRs merged close together.
+  #
+  # Per-commit, NOT merely cancel-in-progress:false — that setting alone does
+  # not queue every run. GitHub keeps at most ONE pending run per group, so a
+  # third push cancels the PENDING one instead of lining up behind it; it
+  # protects the run in progress, not the queue. Merging 19 PRs in a row that
+  # way cancelled 17 runs on main and left those merge commits unbuilt, and the
+  # "four merges in a few minutes" incident this setting was meant to fix was
+  # the same failure. A unique group per commit is what actually guarantees it.
+  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
+  # Moot on main now — each commit is alone in its group — but kept truthful:
+  # superseded PR-branch runs still collapse.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Fixes #126.

`main`'s post-merge run is documented as the safety net for interaction bugs
between PRs merged close together. It was not holding — **17 recent push runs
on `main` were cancelled**, so those merge commits were never built.

### Root cause

`cancel-in-progress: false` does not mean "queue everything". GitHub keeps at
most **one pending run per concurrency group**: when a third push arrives while
one run is executing and one is pending, the *pending* one is cancelled and
replaced. It protects the run in progress, not the queue behind it. Every push
to `main` shared the group `ci-CI-refs/heads/main`, so a burst of merges
collapsed to "first run, last run, nothing in between".

### The fix

```yaml
group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
```

Pushes to `main` get a group per commit — nothing shared, nothing cancelled,
every merge commit built. PR branches are untouched: same group per ref, still
collapsing onto the tip, because there only the tip matters.
`cancel-in-progress` is now moot on `main` (each commit is alone in its group)
and is kept for PR branches.

### Not new, and not just my merge burst

Merging #102–#120 back to back made it obvious, but the merge of **#100** was
cancelled the same way before that. The "four merges in a few minutes once left
two merge commits only partly verified" incident recorded in the old comment is
this same failure — the concurrency setting was the attempted fix for it and
did not work. The comment has been rewritten to explain the mechanism so the
next person does not reach for `cancel-in-progress` again.

### Cost

Runner minutes proportional to merge rate: a batch like today's is 19 full
runs, and this workflow builds two apps and runs the CRDT rig at `SEEDS=300`.
That is the price of the guarantee the comment already claimed. A merge queue
is the other answer and would also test batches *before* landing, but it
changes day-to-day merging, so I left it as a separate decision rather than
bundling it here.

### Verification

Parsed with `js-yaml` — valid, and the group expression is a single scalar.
Expression semantics: `true && '-<sha>' || ''` → `-<sha>` on `main`;
`false && … || ''` → `''` elsewhere, so PR groups are byte-identical to today.

**The `main` branch of the expression cannot be exercised until this lands** —
this PR runs as `pull_request`, where `github.ref` is `refs/pull/N/merge`. What
the PR run proves is that the expression evaluates and the workflow parses. The
real check is the run list after the next couple of merges: each merge commit
should have its own run and none should be cancelled.