### PR TITLE
Show what changed, before and after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **You can see what changed, on both sides of an update.** When an update is
+  available the About dialog now lists the headlines from that release inline,
+  instead of only a version number and a link off to GitHub — and because they
+  travel in the signed manifest, they can't be tampered with. After the update
+  lands and you reload, Bento says once which version you're now on, with a
+  link to the full notes. It only says it if you actually upgraded: someone
+  opening a deck you sent them never sees it.
 - **The editor fits on a phone.** The toolbar used to need about 680px of a
   402px screen: it ran off the edge, took the Save button with it, and because
   nothing clipped it, swiping the toolbar dragged the whole canvas sideways.

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -61,12 +61,51 @@ gateShell(join(site, 'releases/slides/Bento_Slides.bento.html'))
 
 const key = opt('key', null)
 
+/**
+ * Release notes for the manifest, lifted from this version's CHANGELOG entry.
+ *
+ * The About dialog renders `release.notes` INLINE when an update is found, so
+ * this is what people read while deciding whether to rewrite their file. It
+ * used to be empty, which left a bare version number and a link off to GitHub
+ * — a context switch, mid-decision, to a developer-facing page, and useless to
+ * a deck opened offline from disk.
+ *
+ * Because it rides in the signed envelope, the notes are as tamper-proof as
+ * the shell itself.
+ *
+ * Kept SHORT on purpose: every shipped file fetches this manifest at launch,
+ * so the whole changelog section would be a needless payload. Bold lead-ins
+ * only — the headline of each entry — with the full text a link away.
+ */
+function releaseNotes() {
+  try {
+    const cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8')
+    const start = cl.indexOf(`## [${version}]`)
+    if (start < 0) return null
+    const next = cl.indexOf('\n## [', start + 1)
+    const body = cl.slice(cl.indexOf('\n', start) + 1, next > 0 ? next : undefined)
+    // the bold lead-in of each bullet: "- **Something changed.** detail…"
+    const heads = [...body.matchAll(/^- \*\*(.+?)\*\*/gms)].map((m) => m[1].replace(/\s+/g, ' ').trim())
+    if (!heads.length) return null
+    const MAX = 5
+    const shown = heads.slice(0, MAX).map((h) => `• ${h}`)
+    if (heads.length > MAX) shown.push(`…and ${heads.length - MAX} more`)
+    return shown.join('\n')
+  } catch {
+    return null // notes are a nicety; never fail a release over them
+  }
+}
+
 // Sign the manifest against the staged bytes.
+const notes = releaseNotes()
+if (notes) console.log(`  notes   ${notes.split('\n').length} line(s) from CHANGELOG`)
+else console.log('  notes   none — no CHANGELOG entry for this version')
 const signArgs = [
   join(root, 'scripts/sign-release.mjs'),
   join(site, 'releases/slides/Bento_Slides.bento.html'),
   '--out', join(site, 'releases/slides/manifest.json'),
 ]
+if (notes) signArgs.push('--notes', notes)
 if (key) signArgs.push('--key', key)
 execFileSync('node', signArgs, { stdio: 'inherit' })
 

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -34,6 +34,11 @@ const i18nT = t
  *  notice has been acknowledged. It is a property of the browser. */
 const SAVE_NOTICE_KEY = 'bento-save-notice'
 
+/** sessionStorage: set just before the post-update reload, read once by the
+ *  version that boots next. Deliberately NOT localStorage — see
+ *  noticeIfJustUpdated. */
+const JUST_UPDATED_KEY = 'bento-just-updated'
+
 /** Show the language search once the available list outgrows a glance. */
 const SEARCH_FROM = 8
 
@@ -1900,6 +1905,7 @@ export class Editor {
     void pruneOld()
     void this.checkRecovery()
     this.noticeIfCannotWriteInPlace()
+    this.noticeIfJustUpdated()
     this.store.on('doc', () => this.scheduleAutosave())
   }
 
@@ -1980,6 +1986,54 @@ export class Editor {
    * Once per browser, not per deck: it is a property of the browser, and
    * repeating it every time a file opens would be nagging.
    */
+  /**
+   * Say what changed, once, right after an upgrade lands.
+   *
+   * The moment matters: before the upgrade the notes are decision support (and
+   * now ride inline in the signed manifest); AFTER it the user is inside the
+   * editor, where the features actually are. "You can write $x^2$ in any text
+   * box" means something different with a text box in front of you.
+   *
+   * Keyed on sessionStorage, NOT a stored last-seen version, because those
+   * answer different questions. We want "did this reload just follow an
+   * upgrade?", not "has this browser seen 1.0.11?". The difference is
+   * recipients: most people who open a .bento.html never upgraded anything, and
+   * a version comparison would greet them with release notes for a version they
+   * never had. They cannot reach this path — they never clicked Reload.
+   *
+   * localStorage would also be wrong mechanically: it is per ORIGIN, and in
+   * bento/tray every document gets its own origin, so a "seen" flag would be
+   * per document — five decks, five notices.
+   *
+   * Only fires when the reload actually landed on the version it promised, so a
+   * failed update never claims success. One shot: read and clear.
+   */
+  private noticeIfJustUpdated() {
+    let just: string | null = null
+    try {
+      just = sessionStorage.getItem(JUST_UPDATED_KEY)
+      sessionStorage.removeItem(JUST_UPDATED_KEY)
+    } catch { return /* private mode — no note, no harm */ }
+    if (!just || just !== APP_VERSION) return
+    if (this.store.doc.readonly) return // player file: not this person's upgrade
+
+    const bar = div('ed-recover')
+    const msg = document.createElement('span')
+    msg.textContent = t('Updated to v{v}.', { v: APP_VERSION })
+    const what = document.createElement('a')
+    what.className = 'ed-btn'
+    what.href = `https://github.com/nyblnet/bento/releases/tag/v${APP_VERSION}`
+    what.target = '_blank'
+    what.rel = 'noopener'
+    what.textContent = t('What’s new →')
+    const ok = document.createElement('button')
+    ok.className = 'ed-btn ed-btn-primary'
+    ok.textContent = t('Got it')
+    ok.addEventListener('click', () => bar.remove())
+    bar.append(msg, what, ok)
+    document.body.appendChild(bar)
+  }
+
   private noticeIfCannotWriteInPlace() {
     if (canWriteInPlace()) return
     if (localStorage.getItem(SAVE_NOTICE_KEY) === 'seen') return
@@ -2418,6 +2472,10 @@ export class Editor {
           reloadB.textContent = t('Reload into new version')
           reloadB.addEventListener('click', () => {
             this.store.setDirty(false) // disk already holds this exact document
+            // Hand a note to the version we are about to become. sessionStorage
+            // because the lifetime is exactly right: it survives this reload and
+            // dies with the tab. See noticeIfJustUpdated.
+            try { sessionStorage.setItem(JUST_UPDATED_KEY, release.version) } catch { /* private mode */ }
             location.reload()
           })
           status.appendChild(reloadB)

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Updated to v{v}.": "Auf v{v} aktualisiert.",
   "More": "Mehr",
   "Insert": "Einfügen",
   "Slides": "Folien",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Updated to v{v}.": "Actualizado a la v{v}.",
   "More": "Más",
   "Insert": "Insertar",
   "Slides": "Diapositivas",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Updated to v{v}.": "Mis à jour vers la v{v}.",
   "More": "Plus",
   "Insert": "Insérer",
   "Slides": "Diapositives",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Updated to v{v}.": "Aggiornato alla v{v}.",
   "More": "Altro",
   "Insert": "Inserisci",
   "Slides": "Diapositive",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Updated to v{v}.": "v{v} に更新しました。",
   "More": "その他",
   "Insert": "挿入",
   "Slides": "スライド",

--- a/slides/src/i18n/packed.ts
+++ b/slides/src/i18n/packed.ts
@@ -15,6 +15,7 @@ export const PACKED_LOCALES = ["ja","zh-Hans","zh-Hant","es","fr","de","it","pt"
 
 /** English source string -> translations, positional by PACKED_LOCALES. */
 export const PACKED: Record<string, ReadonlyArray<string | 0>> = {
+  "Updated to v{v}.": ["v{v} に更新しました。","已更新到 v{v}。","已更新到 v{v}。","Actualizado a la v{v}.","Mis à jour vers la v{v}.","Auf v{v} aktualisiert.","Aggiornato alla v{v}."],
   "More": ["その他","更多","更多","Más","Plus","Mehr","Altro"],
   "Insert": ["挿入","插入","插入","Insertar","Insérer","Einfügen","Inserisci"],
   "Slides": ["スライド","幻灯片","投影片","Diapositivas","Diapositives","Folien","Diapositive"],

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Updated to v{v}.": "已更新到 v{v}。",
   "More": "更多",
   "Insert": "插入",
   "Slides": "幻灯片",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,7 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Updated to v{v}.": "已更新到 v{v}。",
   "More": "更多",
   "Insert": "插入",
   "Slides": "投影片",


### PR DESCRIPTION
Two halves of one gap: the release notes existed on GitHub and nowhere the user was.

## Before — inline, in the signed manifest
The About dialog has *always* rendered `release.notes` when a manifest carries them; `release.mjs` simply never set the field. It now lifts the bold headlines from that version's CHANGELOG section into the **signed** manifest.

So the notes are read where the decision is made, rather than via a context switch to a developer-facing page — and they're as tamper-proof as the shell itself. A link is also useless to a deck opened offline from disk, which is the whole premise.

Capped at five headlines plus an overflow count on purpose: every shipped file fetches this manifest at launch. No CHANGELOG entry means no notes, never a failed release.

For 1.0.10 it would have produced:
```
• Table defaults can follow the deck theme.
• Fix: deleting a slide could empty the deck entirely.
• Fix: setting a morph id by hand did nothing.
• Photos and video now work in live collaboration.
```

## After — a one-shot banner on first boot of the new version
That's when the user is inside the editor, where the features are. *"You can write $x^2$ in any text box"* means something different with a text box in front of you.

## Why sessionStorage and not a stored last-seen version
They answer different questions. We want **"did this reload just follow an upgrade?"**, not "has this browser seen 1.0.11?".

The difference is **recipients** — most people who open a `.bento.html` never upgraded anything, and a version comparison would greet them with release notes for a version they never had. They can't reach this path; they never clicked Reload.

localStorage is also wrong mechanically: it's per **origin**, and in bento/tray every document now gets its own origin — so a "seen" flag would be per document. Five decks, five notices.

## Verified in the browser, all three paths
| case | result |
|---|---|
| flag set + reload | banner reads "Updated to v1.0.10.", link to the release, flag consumed |
| **no flag** (recipient opening a deck) | no banner |
| flag for a **different** version (update didn't land) | no banner, flag still cleared — a failed update never claims success |

Also confirmed the CHANGELOG extraction bounds at the next `## [` heading rather than swallowing older entries.

One new string across all seven catalogs. Splice gate OK, rig `SEEDS=200` ALL PASS.