### PR TITLE
Changelog: the entries math and language packs shipped without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Maths, written the way you'd write it.** Type `$E=mc^2$` in a text box and
+  it renders as a formula — `$$…$$` for a display equation on its own line.
+  The document stores exactly what you typed, so a deck with maths still opens
+  in an older copy of Bento: you'll see the plain `$E=mc^2$` rather than a
+  broken slide.
+
+- **Formulas rearrange symbol by symbol.** On a morph transition, a term that
+  crosses the equals sign is *seen to travel there* instead of the whole
+  formula crossfading. Give the element the same id on both slides and
+  `$a + b = c$` becomes `$a = c - b$` with the `b` moving across. The starter
+  deck demonstrates it.
+
+- **Twenty-one more languages, added only if you want them.** The globe menu
+  gains **Manage languages…** — install a language from the release channel or
+  remove one you don't need. Arabic, Hebrew, Hindi, Korean, Russian, Ukrainian,
+  Vietnamese and fourteen others are available without adding a byte to files
+  that don't use them. Each pack's fingerprint is signed alongside the release,
+  so installing a language is verified exactly like an update.
+
+  Your choice lives in the browser, never in the document — a deck written in
+  Tokyo opens in French chrome for a French reader, and the deck itself is
+  unchanged either way.
+
 - **Fix: a large chart legend no longer crowds the axis labels.** Charts that
   don't set their own margins now leave room for the legend at whatever size
   it's set to, instead of assuming the default one.


### PR DESCRIPTION
Both features landed on main with **no user-facing note**. As it stands, 1.0.11 would announce "we fixed some save messaging" while quietly containing LaTeX maths, symbol-level formula morphing and twenty-one installable languages.

That matters more than usual now: with #131, the CHANGELOG headlines become the notes shown *inline in the About dialog* before someone updates. An empty entry is a silently undersold release.

## Written from the PRs, then checked against the code
Drafted from #76, #83, #84 (maths) and #81, #86, #91 (packs) — then verified in the source, which corrected **three** things the PR prose would have left wrong:

| claim | reality |
|---|---|
| "Add or remove languages…" | the menu says **Manage languages…** |
| "Korean is the first pack" | there are **21** packs on disk now |
| maths works "anywhere text does: slides, tables, speaker notes" | `resolveMath` has **one** call site — the text-element path in `render.ts`. Not table cells, not notes. |

That last one would have sent people to try maths in a table and conclude it was broken.

Docs only — no code, no build impact.