### PR TITLE
Charts: reserve legend height, and fix the starter deck's axis contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ pre-1.0.
   don't set their own margins now leave room for the legend at whatever size
   it's set to, instead of assuming the default one.
 
+- **Fix: readable axis numbers on the showcase deck's linked chart.** They were
+  being drawn half-transparent against a dark panel.
+
 - **Chart labels and legends now honor their visual options.** The lightweight
   chart renderer applies configured font sizes and weights to axis labels and
   legends, respects legend spacing and placement, and measures CJK legend text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: a large chart legend no longer crowds the axis labels.** Charts that
+  don't set their own margins now leave room for the legend at whatever size
+  it's set to, instead of assuming the default one.
+
 - **Chart labels and legends now honor their visual options.** The lightweight
   chart renderer applies configured font sizes and weights to axis labels and
   legends, respects legend spacing and placement, and measures CJK legend text

--- a/kernel/src/charts.ts
+++ b/kernel/src/charts.ts
@@ -164,13 +164,33 @@ function digest(option: Opt, w: number, h: number): Digest {
   const twoAxes = !isPie && yAxes.length > 1
   const pieTop = legend?.top !== undefined ? legend.top + legendH : 0
   const pieBottom = legend && legend.top === undefined ? legend.bottom + legendH : 0
+  // A cartesian plot has to make room for the legend too, not just a pie.
+  //
+  // The legend's height now follows its own font size, so a big legend gets
+  // taller — but the default bottom inset is a fixed 44px, sized for the old
+  // 12px legend. Past roughly 20px the legend simply grew into the x-axis
+  // labels and the two overlapped. Only ever visible on a chart that does NOT
+  // set `grid` explicitly, which is why a chart authored with generous margins
+  // looks fine and the default one does not.
+  //
+  // An EXPLICIT grid value always wins: someone who wrote `grid.bottom` meant
+  // it, and silently enlarging their inset would be its own bug. This only
+  // raises the DEFAULT, and only by however much the legend actually outgrew
+  // the space that default assumed.
+  const legendPad = Math.max(0, legendH - 12) // 12px legend == the old default
+  const gridBottom = g.bottom !== undefined
+    ? num(g.bottom, 44)
+    : 44 + (legend && legend.top === undefined ? legendPad : 0)
+  const gridTop = g.top !== undefined
+    ? num(g.top, 24)
+    : 24 + (legend?.top !== undefined ? legendPad : 0)
   const grid = isPie
     ? { x: 0, y: pieTop, w, h: Math.max(0, h - pieTop - pieBottom) }
     : {
         x: num(g.left, 48),
-        y: num(g.top, 24),
+        y: gridTop,
         w: w - num(g.left, 48) - num(g.right, twoAxes ? 56 : 16),
-        h: h - num(g.top, 24) - num(g.bottom, 44),
+        h: Math.max(0, h - gridTop - gridBottom),
       }
   return {
     w, h,

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -774,9 +774,16 @@ export function starterDoc(): BentoDoc {
             color: [PEACH, STEEL],
             grid: { left: 48, right: 42, top: 16, bottom: 26 },
             xAxis: { type: 'category', data: ['Q1', 'Q2', 'Q3', 'Q4'], axisLabel: { color: MIST } },
+            // MIST, not a half-transparent MIST. The engine used to ignore a
+            // y-axis's own label colour and reuse the x-axis one, so these read
+            // as MIST however they were written; once charts started honouring
+            // each axis, the declared 50% alpha became visible and dropped
+            // these numbers to 3.17:1 on the #16273E panel — under AA. The deck
+            // had been tuned against the old behaviour, so it now says what it
+            // always looked like: 8.28:1.
             yAxis: [
-              { type: 'value', axisLabel: { color: 'rgba(182,193,210,0.5)' }, splitLine: { lineStyle: { color: 'rgba(255,255,255,0.08)' } } },
-              { type: 'value', name: 'Growth', axisLabel: { color: 'rgba(182,193,210,0.5)', formatter: '{value}%' }, splitLine: { show: false } },
+              { type: 'value', axisLabel: { color: MIST }, splitLine: { lineStyle: { color: 'rgba(255,255,255,0.08)' } } },
+              { type: 'value', name: 'Growth', axisLabel: { color: MIST, formatter: '{value}%' }, splitLine: { show: false } },
             ],
             series: [
               { type: 'bar', name: 'Signups', yAxisIndex: 0, data: [1204, 3880, 9140, 21500], itemStyle: { borderRadius: [4, 4, 0, 0] } },


### PR DESCRIPTION
The two follow-ups promised on #123, which merged as-is.

## 1. Cartesian grid now reserves the legend's height
#123 made the legend's height follow its own font size but applied that height only to the **pie** grid. Cartesian plots kept the fixed `num(g.bottom, 44)` default — sized for a 12px legend — so a larger legend grew toward the x-axis labels with nothing making room.

An **explicit** `grid` value still wins: someone who wrote `grid.bottom` meant it. This raises only the *default*, and only by however much the legend outgrew what that default assumed. Same for a numeric `legend.top`, which #123 also newly honours.

Measured with one harness on both builds — bar chart, no `grid` key, legend at bottom, set via the panel's Advanced JSON:

| legend fontSize | 12 | 20 | 28 |
|---|---|---|---|
| main (after #123) | 0.8px | 0.8px | 0.8px |
| this branch | **13px** | **11.1px** | **10.6px** |

Being precise: at the default insert size main yields a constant 0.8px clearance — labels effectively touching, not a negative gap. The review that found this measured true overlaps (2 hits at 20px, 4 at 28px) at 640×360, a geometry I didn't reproduce. Either way the grid wasn't accounting for the legend, and now it does.

## 2. Starter deck declares the colour it always looked like
**Not a defect in #123 — the opposite.** The engine used to ignore a y-axis's own `axisLabel.color` and reuse the x-axis one, so these labels rendered as `MIST` however they were written. The deck was tuned against that and declared `rgba(182,193,210,0.5)`. Once #123 correctly honoured each axis, the declared 50% alpha became visible:

| | contrast on `#16273E` |
|---|---|
| `rgba(182,193,210,0.5)` | **3.17:1** — below AA (4.5:1) for 12px text |
| `MIST` `#B6C1D2` | **8.28:1** |

Computed directly, not eyeballed. This matters more than a normal deck: the starter deck is what every new user opens, and slide 9 is the live table→chart demo.

Verified both y-axis colours read `#B6C1D2` in the built shell. Splice gate OK, rig `SEEDS=200` ALL PASS.