### PR TITLE
Fix present mode: close the .ed-lang-warn rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: presenting was broken.** Slides showed at a fraction of the screen
+  with speaker notes spilling underneath. A stray missing bracket in the
+  stylesheet swallowed all of the presentation layout rules. Nothing was wrong
+  with your decks — presenting is back to full screen.
+
 - **You can see what changed, on both sides of an update.** When an update is
   available the About dialog now lists the headlines from that release inline,
   instead of only a version number and a link off to GitHub — and because they

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2103,6 +2103,8 @@ input.ed-toggle { width: 16px; height: 16px; accent-color: #5E7699; cursor: poin
   font-size: 11.5px; line-height: 1.5; color: var(--muted);
   background: var(--bg); border-left: 2px solid var(--line);
   padding: 5px 8px; margin: 0 0 6px; border-radius: 0 5px 5px 0;
+}
+
 /* ————— RTL chrome: the marks that don't flip themselves ————————————————————
    Logical properties turn the LAYOUT around on their own. These are the few
    glyphs that encode a direction in their SHAPE, so they have to be flipped by


### PR DESCRIPTION
**Presenting is broken on `main`** — slides render at a fraction of the screen with unstyled speaker notes spilling underneath and a bare `1 / 13` link. None of Reveal's layout CSS applies.

## Cause
`.ed-lang-warn` in `styles.css` is **never closed**. The bundler nests everything after it *inside* that rule — including all of `reveal.js/dist/reveal.css`, which `present.ts` imports. So the rule that positions the deck became:

```css
.ed-lang-warn .reveal .slides { position: absolute; width:100%; height:100%; ... }
```

`.ed-lang-warn` is a language-pack notice — never an ancestor of the deck. Every selector existed; not one could match. Introduced by `c96a61f` ("Say when a language pack is out of date").

## The build was telling us
Every build since printed a CSS minifier warning naming `.ed-lang-warn`. It was read as noise — **by me, twice, including in the release-candidate build**. A warning that names a specific selector is not noise.

## Verified against shipped 1.0.10 as the reference
| | `.slides` position | section size |
|---|---|---|
| 1.0.10 (shipped, working) | `absolute` | 1280×720 |
| 1.0.11 candidate | `static` | — **broken** |
| this fix | `absolute` | 1280×720 — **matches** |

Mis-scoped `.ed-lang-warn .reveal` rules: **0**. Braces balance 456/456. CSS shrank 101KB → 93KB as the mis-nested block collapsed. Screenshot confirms a full-bleed slide.

## Separate, pre-existing
Below Reveal's `scrollActivationWidth` (435px) it switches to scroll view — that's stock Reveal 5 behaviour, not a regression, but it made the break look worse on a narrow window. Worth deciding separately whether to disable it.

Splice gate OK, rig `SEEDS=200` ALL PASS. **This blocks 1.0.11.**