### PR TITLE
Present: never switch to Reveal's scroll view on narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: presenting on a phone shows the deck, not a scrollable page.** Below
+  about 435px wide, the presentation was quietly switching to a scrolling
+  reading layout instead of a slideshow — so swipe navigation stopped working
+  and hidden interactive slides became scrollable content.
+
 - **Fix: presenting was broken.** Slides showed at a fraction of the screen
   with speaker notes spilling underneath. A stray missing bracket in the
   stylesheet swallowed all of the presentation layout rules. Nothing was wrong

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -149,6 +149,27 @@ export function startPresentation(
     // for tiny embeds.
     minScale: 0.1,
     maxScale: 100,
+    /**
+     * Never switch to Reveal's SCROLL VIEW, whatever the window size.
+     *
+     * Reveal 5 auto-swaps the classic one-slide-at-a-time renderer for a
+     * vertical scrolling page below `scrollActivationWidth`, default 435px.
+     * That default is meant for a deck embedded in an article, where reading
+     * beats presenting. Presenting is the only thing this overlay does, and
+     * EVERY phone is under the threshold — an iPhone is 390-430 CSS px — so
+     * the platform bento/tray exists to serve would silently get a different
+     * renderer from a laptop.
+     *
+     * The concrete cost is navigation, not layout: measured at 402px the
+     * section still scales and positions correctly. But scroll view replaces
+     * slide navigation with page scrolling, which bypasses our own swipe
+     * handling (Reveal's is off deliberately — it walks into hidden state
+     * slides), and turns those state slides into scrollable content when they
+     * are supposed to be reachable only through a link. It also renders every
+     * section at once rather than one at a time, which is the opposite of what
+     * a presentation overlay is for.
+     */
+    scrollActivationWidth: 0,
     center: false,
     hash: false,
     history: false,


### PR DESCRIPTION
Split out of #140 for visibility — **merge together with it**. Based on that branch, so it lands after.

## What happens
Reveal 5 auto-swaps the classic one-slide-at-a-time renderer for a **vertical scrolling page** below `scrollActivationWidth`, default **435px**. `present.ts` passes `embedded: true` but never sets it, so the default applies.

That default is for a deck embedded in an article, where reading beats presenting. This overlay only ever presents — and **every phone is under the threshold** (an iPhone is 390–430 CSS px), so the platform bento/tray exists to serve was silently getting a different renderer from a laptop.

## The actual cost is navigation
Scroll view replaces slide navigation with page scrolling, which:
- bypasses our own swipe handling (Reveal's is off deliberately — it walks into hidden state slides)
- turns **state slides into scrollable content** when they should be reachable only through a link
- renders every section at once, the opposite of a presentation

## Correcting myself
I first attributed **blank slide content** at 402px to scroll view. **That was wrong.** The elements sat at `opacity: 0` because entrance fx hadn't settled; past the 2.8s settle guarantee they resolve, with or without scroll view. The code comment states what was measured, not my first guess.

## Pre-existing, not a 1.0.11 regression
1.0.10 behaves the same on a narrow window. It matters more now that tray puts Bento on phones.

## Verified at 402×874
Scroll view no longer activates, the section letterboxes correctly at 402×226, and the slide renders title, body and tiles (screenshot taken). Splice gate OK, rig `SEEDS=200` ALL PASS.