### PR TITLE
Editor: toggles for the slide number, progress bar and corner arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Hide the slide number or progress bar.** The Slide panel now has toggles
+  for both, plus Reveal's corner arrows. They're deck-wide and travel in the
+  file, so a deck you hand to someone else presents the way you designed it.
+
 - **Fix: presenting on a phone shows the deck, not a scrollable page.** Below
   about 435px wide, the presentation was quietly switching to a scrolling
   reading layout instead of a slideshow — so swipe navigation stopped working

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -29,6 +29,9 @@ const ROW_TIPS: Record<string, string> = {
   'Page size': 'Deck-wide slide size. Elements keep their positions — changing size reframes the canvas, never rescales your art.',
   'Width': 'Custom slide width in pixels',
   'Height': 'Custom slide height in pixels',
+  'Slide number': 'Deck-wide. Show the slide counter to the audience while presenting.',
+  'Progress bar': 'Deck-wide. Show the thin progress bar along the bottom while presenting.',
+  'Corner arrows': 'Deck-wide. Reveal’s own navigation arrows. Off by default — links and keys already navigate.',
   'Background': 'This slide’s background colour',
   'Transition': 'How this slide enters. Morph animates elements that share ids with the previous slide.',
   'Name': 'A friendly name for this slide — shown in link pickers and state badges',
@@ -240,6 +243,30 @@ export class PropsPanel {
       this.row('Height', this.number(dh, 10, (v, fin) =>
         this.edit(() => { this.store.doc.size.height = Math.max(320, Math.min(4000, Math.round(v))) }, fin)))
     }
+    // Deck-wide presentation chrome. These live in doc.present because they are
+    // AUDIENCE-facing: what the author designs is what a recipient's audience
+    // sees. Contrast reduce-motion and locale, which are viewer preferences and
+    // deliberately never enter the document.
+    //
+    // Each writes `undefined` at its default rather than the default value, so
+    // a deck that never touches these carries no `present` block at all.
+    const pres = this.store.doc.present ?? {}
+    const setPresent = (k: 'slideNumber' | 'progress' | 'controls', v: boolean, dflt: boolean) =>
+      this.edit(() => {
+        const d = this.store.doc
+        const cur = { ...(d.present ?? {}) }
+        if (v === dflt) delete cur[k]
+        else cur[k] = v
+        if (Object.keys(cur).length) d.present = cur
+        else delete d.present
+      }, true)
+    this.row('Slide number', this.toggle(pres.slideNumber ?? true,
+      (v) => setPresent('slideNumber', v, true)))
+    this.row('Progress bar', this.toggle(pres.progress ?? true,
+      (v) => setPresent('progress', v, true)))
+    this.row('Corner arrows', this.toggle(pres.controls ?? false,
+      (v) => setPresent('controls', v, false)))
+
     this.row('Background', this.color(slide.background, (v, fin) =>
       this.edit(() => { this.store.slide.background = v }, fin)))
     this.row('Transition', this.select(

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const de: Catalog = {
+  "Slide number": "Foliennummer",
+  "Progress bar": "Fortschrittsleiste",
+  "Corner arrows": "Ecknavigation",
   "Updated to v{v}.": "Auf v{v} aktualisiert.",
   "More": "Mehr",
   "Insert": "Einfügen",

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const es: Catalog = {
+  "Slide number": "Número de diapositiva",
+  "Progress bar": "Barra de progreso",
+  "Corner arrows": "Flechas de esquina",
   "Updated to v{v}.": "Actualizado a la v{v}.",
   "More": "Más",
   "Insert": "Insertar",

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const fr: Catalog = {
+  "Slide number": "Numéro de diapo",
+  "Progress bar": "Barre de progression",
+  "Corner arrows": "Flèches d’angle",
   "Updated to v{v}.": "Mis à jour vers la v{v}.",
   "More": "Plus",
   "Insert": "Insérer",

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const it: Catalog = {
+  "Slide number": "Numero diapositiva",
+  "Progress bar": "Barra di avanzamento",
+  "Corner arrows": "Frecce d’angolo",
   "Updated to v{v}.": "Aggiornato alla v{v}.",
   "More": "Altro",
   "Insert": "Inserisci",

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const ja: Catalog = {
+  "Slide number": "スライド番号",
+  "Progress bar": "進行状況バー",
+  "Corner arrows": "隅の矢印",
   "Updated to v{v}.": "v{v} に更新しました。",
   "More": "その他",
   "Insert": "挿入",

--- a/slides/src/i18n/packed.ts
+++ b/slides/src/i18n/packed.ts
@@ -15,6 +15,9 @@ export const PACKED_LOCALES = ["ja","zh-Hans","zh-Hant","es","fr","de","it","pt"
 
 /** English source string -> translations, positional by PACKED_LOCALES. */
 export const PACKED: Record<string, ReadonlyArray<string | 0>> = {
+  "Slide number": ["スライド番号","幻灯片编号","投影片編號","Número de diapositiva","Numéro de diapo","Foliennummer","Numero diapositiva"],
+  "Progress bar": ["進行状況バー","进度条","進度列","Barra de progreso","Barre de progression","Fortschrittsleiste","Barra di avanzamento"],
+  "Corner arrows": ["隅の矢印","角落箭头","角落箭頭","Flechas de esquina","Flèches d’angle","Ecknavigation","Frecce d’angolo"],
   "Updated to v{v}.": ["v{v} に更新しました。","已更新到 v{v}。","已更新到 v{v}。","Actualizado a la v{v}.","Mis à jour vers la v{v}.","Auf v{v} aktualisiert.","Aggiornato alla v{v}."],
   "More": ["その他","更多","更多","Más","Plus","Mehr","Altro"],
   "Insert": ["挿入","插入","插入","Insertar","Insérer","Einfügen","Inserisci"],

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const zhHans: Catalog = {
+  "Slide number": "幻灯片编号",
+  "Progress bar": "进度条",
+  "Corner arrows": "角落箭头",
   "Updated to v{v}.": "已更新到 v{v}。",
   "More": "更多",
   "Insert": "插入",

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -4,6 +4,9 @@
 import type { Catalog } from '../i18n'
 
 export const zhHant: Catalog = {
+  "Slide number": "投影片編號",
+  "Progress bar": "進度列",
+  "Corner arrows": "角落箭頭",
   "Updated to v{v}.": "已更新到 v{v}。",
   "More": "更多",
   "Insert": "插入",


### PR DESCRIPTION
`doc.present.{slideNumber,progress,controls}` has been in the format all along, with no way to reach it but hand-editing the document JSON. This adds the UI.

## Where, and why there
**Slide panel, beside Page size** — the existing home for deck-wide settings (`doc.size` is per-document and edited there).

**Kept in the document, not a viewer preference.** These are *audience-facing*: what the author designs is what a recipient's audience sees. That's the line the codebase already draws — reduce-motion and locale are deliberately viewer-scoped and never enter the document, because they're about the viewer's own comfort.

## Format stays clean
Each toggle writes `undefined` at its default and drops the whole `present` block when nothing is left, so a deck that never touches these carries no extra bytes. Verified through a real `serialize()`, not just the live model.

## Verified in the browser
| step | result |
|---|---|
| default | `doc.present` **absent** |
| slide number off | `{slideNumber:false}` |
| progress off too | `{slideNumber:false, progress:false}` |
| corner arrows on | `+ {controls:true}` |
| **present with those** | slide number hidden, progress hidden, corner arrows **visible** |
| restore all defaults | `present` gone from live doc **and** the serialized file |

Three new strings across all seven catalogs, packed table regenerated (701×8). Splice gate OK, rig `SEEDS=200` ALL PASS.

Independent of 1.0.11 — happy for this to land after the cut.