### PR TITLE
Changelog: order 1.0.11 by what it means, and drop what never shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,44 +11,7 @@ pre-1.0.
 
 ## [Unreleased]
 
-- **Fix: the toolbar buttons were in the wrong order until you switched
-  language.** Comment and Export PDF sat in the wrong group and Save came after
-  Help. Switching language happened to put them right, which made it look like
-  switching language caused it — the first load was the wrong one.
-
-- **Hide the slide number or progress bar.** A new **Slideshow** section in the
-  slide panel has toggles for both, plus the corner navigation arrows. They're
-  deck-wide and travel in the file, so a deck you hand to someone else presents
-  the way you designed it.
-
-- **Fix: presenting on a phone shows the deck, not a scrollable page.** Below
-  about 435px wide, the presentation was quietly switching to a scrolling
-  reading layout instead of a slideshow — so swipe navigation stopped working
-  and hidden interactive slides became scrollable content.
-
-- **Fix: presenting was broken.** Slides showed at a fraction of the screen
-  with speaker notes spilling underneath. A stray missing bracket in the
-  stylesheet swallowed all of the presentation layout rules. Nothing was wrong
-  with your decks — presenting is back to full screen.
-
-- **You can see what changed, on both sides of an update.** When an update is
-  available the About dialog now lists the headlines from that release inline,
-  instead of only a version number and a link off to GitHub — and because they
-  travel in the signed manifest, they can't be tampered with. After the update
-  lands and you reload, Bento says once which version you're now on, with a
-  link to the full notes. It only says it if you actually upgraded: someone
-  opening a deck you sent them never sees it.
-- **The editor fits on a phone.** The toolbar used to need about 680px of a
-  402px screen: it ran off the edge, took the Save button with it, and because
-  nothing clipped it, swiping the toolbar dragged the whole canvas sideways.
-  On a phone it now folds into two menus — ＋ for inserting and ⋯ for
-  everything occasional — leaving slides, insert, undo, format, save and more,
-  at proper touch size. The side panels slide over the canvas instead of
-  squeezing it, so the slide you're editing is no longer the smallest thing on
-  screen. Nothing changes on a laptop.
-
-  Known gap: the save-as menu (copy, new deck, template, password) doesn't fit
-  on a phone yet and is unreachable there for now.
+## [1.0.11] — 2026-07-27
 
 - **Maths, written the way you'd write it.** Type `$E=mc^2$` in a text box and
   it renders as a formula — `$$…$$` for a display equation on its own line.
@@ -73,24 +36,17 @@ pre-1.0.
   Tokyo opens in French chrome for a French reader, and the deck itself is
   unchanged either way.
 
-- **Fix: saved files no longer grow by 100 KB on every save.** Each save wrote
-  a fresh, uncompressed copy of the app's stylesheet into the file, which the
-  next save then copied again — a deck saved ten times carried ten of them and
-  had put on a megabyte for nothing. The stylesheet belongs in the compressed
-  runtime payload, where it takes 27 KB and is written exactly once; a file
-  that already accumulated copies drops all of them the next time you save it.
+- **The editor fits on a phone.** The toolbar used to need about 680px of a
+  402px screen: it ran off the edge, took the Save button with it, and because
+  nothing clipped it, swiping the toolbar dragged the whole canvas sideways.
+  On a phone it now folds into two menus — ＋ for inserting and ⋯ for
+  everything occasional — leaving slides, insert, undo, format, save and more,
+  at proper touch size. The side panels slide over the canvas instead of
+  squeezing it, so the slide you're editing is no longer the smallest thing on
+  screen. Nothing changes on a laptop.
 
-- **Fix: a large chart legend no longer crowds the axis labels.** Charts that
-  don't set their own margins now leave room for the legend at whatever size
-  it's set to, instead of assuming the default one.
-
-- **Fix: readable axis numbers on the showcase deck's linked chart.** They were
-  being drawn half-transparent against a dark panel.
-
-- **Chart labels and legends now honor their visual options.** The lightweight
-  chart renderer applies configured font sizes and weights to axis labels and
-  legends, respects legend spacing and placement, and measures CJK legend text
-  correctly so localized series names no longer overlap.
+  Known gap: the save-as menu (copy, new deck, template, password) doesn't fit
+  on a phone yet and is unreachable there for now.
 
 - **Your decks look like themselves in Finder, Files and the Bento Tray app.**
   Every Bento file used to thumbnail as the same dark box, because thumbnails
@@ -110,19 +66,19 @@ pre-1.0.
   thumbnail — and a deck that had a preview loses it the moment you set a
   password.
 
-- **Updating a file now suggests that file's own name.** When an update asks
-  where to save, the dialog is pre-filled with the name of the deck you have
-  open rather than one derived from its title — so a file called
-  `Q3-board.bento.html` no longer offers to save itself as
-  `Q3_Board_Review.bento.html`. The backup written alongside an in-place update
-  follows the same name. Where the save dialog opens is set by the browser and
-  can't be pointed at a folder by the page, but it now remembers the last place
-  you saved, so the second update onwards starts in the right directory.
-- **The starter deck is called “Bento Slides Showcase” again.** The lowercase
-  rebrand swept the deck's own title along with the app's, but a deck title is
-  a document name — it shows in the window title and becomes the suggested
-  filename — so it reads better in title case. The `bento/slides` wordmark is
-  unchanged.
+- **Hide the slide number or progress bar.** A new **Slideshow** section in the
+  slide panel has toggles for both, plus the corner navigation arrows. They're
+  deck-wide and travel in the file, so a deck you hand to someone else presents
+  the way you designed it.
+
+- **You can see what changed, on both sides of an update.** When an update is
+  available the About dialog now lists the headlines from that release inline,
+  instead of only a version number and a link off to GitHub — and because they
+  travel in the signed manifest, they can't be tampered with. After the update
+  lands and you reload, Bento says once which version you're now on, with a
+  link to the full notes. It only says it if you actually upgraded: someone
+  opening a deck you sent them never sees it.
+
 - **The screen stays awake while you present.** Phones and laptops used to dim
   and lock partway through a talk if you left a slide up for a couple of
   minutes. Bento now holds the screen on for the length of the show and lets go
@@ -142,9 +98,45 @@ pre-1.0.
   backed up, while still showing the file itself as out of date, because it is.
   (A password-protected deck is never snapshotted, so it stays quiet rather
   than promise a safety net it doesn't have.)
-- **See what's new before you update.** When an update is available, the About
-  dialog now offers a "What's new" link straight to that version's release
-  notes.
+
+- **Updating a file now suggests that file's own name.** When an update asks
+  where to save, the dialog is pre-filled with the name of the deck you have
+  open rather than one derived from its title — so a file called
+  `Q3-board.bento.html` no longer offers to save itself as
+  `Q3_Board_Review.bento.html`. The backup written alongside an in-place update
+  follows the same name. Where the save dialog opens is set by the browser and
+  can't be pointed at a folder by the page, but it now remembers the last place
+  you saved, so the second update onwards starts in the right directory.
+
+- **The starter deck is called “Bento Slides Showcase” again.** The lowercase
+  rebrand swept the deck's own title along with the app's, but a deck title is
+  a document name — it shows in the window title and becomes the suggested
+  filename — so it reads better in title case. The `bento/slides` wordmark is
+  unchanged.
+
+- **Chart labels and legends now honor their visual options.** The lightweight
+  chart renderer applies configured font sizes and weights to axis labels and
+  legends, respects legend spacing and placement, and measures CJK legend text
+  correctly so localized series names no longer overlap.
+
+- **Fix: presenting on a phone shows the deck, not a scrollable page.** Below
+  about 435px wide, the presentation was quietly switching to a scrolling
+  reading layout instead of a slideshow — so swipe navigation stopped working
+  and hidden interactive slides became scrollable content.
+
+- **Fix: saved files no longer grow by 100 KB on every save.** Each save wrote
+  a fresh, uncompressed copy of the app's stylesheet into the file, which the
+  next save then copied again — a deck saved ten times carried ten of them and
+  had put on a megabyte for nothing. The stylesheet belongs in the compressed
+  runtime payload, where it takes 27 KB and is written exactly once; a file
+  that already accumulated copies drops all of them the next time you save it.
+
+- **Fix: a large chart legend no longer crowds the axis labels.** Charts that
+  don't set their own margins now leave room for the legend at whatever size
+  it's set to, instead of assuming the default one.
+
+- **Fix: readable axis numbers on the showcase deck's linked chart.** They were
+  being drawn half-transparent against a dark panel.
 
 - **Fix: the About dialog's update section overlapped the controls beneath it.**
   Once an update was found, the extra heading and buttons collapsed into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,52 +13,53 @@ pre-1.0.
 
 ## [1.0.11] — 2026-07-27
 
-- **Maths, written the way you'd write it.** Type `$E=mc^2$` in a text box and
-  it renders as a formula — `$$…$$` for a display equation on its own line.
-  The document stores exactly what you typed, so a deck with maths still opens
-  in an older copy of Bento: you'll see the plain `$E=mc^2$` rather than a
-  broken slide.
+- **LaTeX maths in any text box, rendered as MathML.** Type `$E=mc^2$` and it
+  renders as a formula — `$$…$$` for a display equation on its own line. The
+  document stores exactly what you typed, so a deck with maths still opens in
+  an older copy of Bento: you'll see the plain `$E=mc^2$` rather than a broken
+  slide.
 
-- **Formulas rearrange symbol by symbol.** On a morph transition, a term that
+- **Symbol-level formula morphing.** On a morph transition, a term that
   crosses the equals sign is *seen to travel there* instead of the whole
-  formula crossfading. Give the element the same id on both slides and
-  `$a + b = c$` becomes `$a = c - b$` with the `b` moving across. The starter
-  deck demonstrates it.
+  formula crossfading. Give the element the same id on both slides and `$a + b
+  = c$` becomes `$a = c - b$` with the `b` moving across. The starter deck
+  demonstrates it.
 
-- **Twenty-one more languages, added only if you want them.** The globe menu
+- **Twenty-one installable language packs, each hash-signed.** The globe menu
   gains **Manage languages…** — install a language from the release channel or
-  remove one you don't need. Arabic, Hebrew, Hindi, Korean, Russian, Ukrainian,
-  Vietnamese and fourteen others are available without adding a byte to files
-  that don't use them. Each pack's fingerprint is signed alongside the release,
-  so installing a language is verified exactly like an update.
+  remove one you don't need. Arabic, Hebrew, Hindi, Korean, Russian,
+  Ukrainian, Vietnamese and fourteen others are available without adding a
+  byte to files that don't use them. Each pack's fingerprint is signed
+  alongside the release, so installing a language is verified exactly like an
+  update.
 
   Your choice lives in the browser, never in the document — a deck written in
   Tokyo opens in French chrome for a French reader, and the deck itself is
   unchanged either way.
 
-- **The editor fits on a phone.** The toolbar used to need about 680px of a
-  402px screen: it ran off the edge, took the Save button with it, and because
-  nothing clipped it, swiping the toolbar dragged the whole canvas sideways.
-  On a phone it now folds into two menus — ＋ for inserting and ⋯ for
-  everything occasional — leaving slides, insert, undo, format, save and more,
-  at proper touch size. The side panels slide over the canvas instead of
-  squeezing it, so the slide you're editing is no longer the smallest thing on
-  screen. Nothing changes on a laptop.
+- **The editor is usable at 402px — the topbar folds instead of overflowing.**
+  The toolbar used to need about 680px of a 402px screen: it ran off the edge,
+  took the Save button with it, and because nothing clipped it, swiping the
+  toolbar dragged the whole canvas sideways. On a phone it now folds into two
+  menus — ＋ for inserting and ⋯ for everything occasional — leaving slides,
+  insert, undo, format, save and more, at proper touch size. The side panels
+  slide over the canvas instead of squeezing it, so the slide you're editing
+  is no longer the smallest thing on screen. Nothing changes on a laptop.
 
   Known gap: the save-as menu (copy, new deck, template, password) doesn't fit
   on a phone yet and is unreachable there for now.
 
-- **Your decks look like themselves in Finder, Files and the Bento Tray app.**
-  Every Bento file used to thumbnail as the same dark box, because thumbnails
-  are drawn without running a page's JavaScript and, until Bento boots, every
-  deck genuinely is the same bytes plus the same boot splash. Saving now writes
-  a still picture of page one into the file, which is what those previews draw
-  instead — so a folder of decks is finally something you can read. It costs
-  about 14 KB on a typical deck (under 2% of the file), never more than 64 KB: a
-  page with a big photograph keeps its layout and its words and drops the
-  photograph rather than carrying it twice. Nothing changes when you open a
-  deck normally — the picture is written for software that can't run the file,
-  and is never shown to a reader.
+- **Decks carry a page-one preview, so Finder and Files thumbnail them
+  properly.** Every Bento file used to thumbnail as the same dark box, because
+  thumbnails are drawn without running a page's JavaScript and, until Bento
+  boots, every deck genuinely is the same bytes plus the same boot splash.
+  Saving now writes a still picture of page one into the file, which is what
+  those previews draw instead — so a folder of decks is finally something you
+  can read. It costs about 14 KB on a typical deck (under 2% of the file),
+  never more than 64 KB: a page with a big photograph keeps its layout and its
+  words and drops the photograph rather than carrying it twice. Nothing
+  changes when you open a deck normally — the picture is written for software
+  that can't run the file, and is never shown to a reader.
 
   **A password-protected deck gets no preview at all.** A readable picture of
   the title page sitting next to the encrypted document would give away exactly
@@ -66,30 +67,32 @@ pre-1.0.
   thumbnail — and a deck that had a preview loses it the moment you set a
   password.
 
-- **Hide the slide number or progress bar.** A new **Slideshow** section in the
-  slide panel has toggles for both, plus the corner navigation arrows. They're
-  deck-wide and travel in the file, so a deck you hand to someone else presents
-  the way you designed it.
+- **Deck-level toggles for slide number, progress bar and corner arrows.**
+  They live in a new **Slideshow** section of the slide panel. They're
+  deck-wide and travel in the file, so a deck you hand to someone else
+  presents the way you designed it.
 
-- **You can see what changed, on both sides of an update.** When an update is
-  available the About dialog now lists the headlines from that release inline,
-  instead of only a version number and a link off to GitHub — and because they
-  travel in the signed manifest, they can't be tampered with. After the update
-  lands and you reload, Bento says once which version you're now on, with a
-  link to the full notes. It only says it if you actually upgraded: someone
-  opening a deck you sent them never sees it.
+- **Release notes ride in the signed manifest, shown before and after
+  updating.** When an update is available the About dialog now lists the
+  headlines from that release inline, instead of only a version number and a
+  link off to GitHub — and because they travel in the signed manifest, they
+  can't be tampered with. After the update lands and you reload, Bento says
+  once which version you're now on, with a link to the full notes. It only
+  says it if you actually upgraded: someone opening a deck you sent them never
+  sees it.
 
-- **The screen stays awake while you present.** Phones and laptops used to dim
-  and lock partway through a talk if you left a slide up for a couple of
-  minutes. Bento now holds the screen on for the length of the show and lets go
-  when you exit — and takes the lock again if you switch away and come back.
+- **A Screen Wake Lock is held for the length of a presentation.** Phones and
+  laptops used to dim and lock partway through a talk if you left a slide up
+  for a couple of minutes. Bento now holds the screen on for the length of the
+  show and lets go when you exit — and takes the lock again if you switch away
+  and come back.
 
-- **Safari and Firefox are told the truth about saving.** Those browsers (and
-  every browser on iPhone and iPad) can't rewrite a file in place — Bento hands
-  back an updated copy instead. The editor used to say the opposite in its
-  tooltips and only admit it in a passing message *after* the first save. It now
-  says what will actually happen before any work is at stake, once per browser,
-  and the Save button describes the real behaviour.
+- **Honest save messaging where the File System Access API is missing.** Those
+  browsers (and every browser on iPhone and iPad) can't rewrite a file in
+  place — Bento hands back an updated copy instead. The editor used to say the
+  opposite in its tooltips and only admit it in a passing message *after* the
+  first save. It now says what will actually happen before any work is at
+  stake, once per browser, and the Save button describes the real behaviour.
 
   Those browsers also now show that your work *is* being kept safe. Bento has
   always snapshotted the deck into the browser as you edit and offered it back
@@ -99,14 +102,14 @@ pre-1.0.
   (A password-protected deck is never snapshotted, so it stays quiet rather
   than promise a safety net it doesn't have.)
 
-- **Updating a file now suggests that file's own name.** When an update asks
-  where to save, the dialog is pre-filled with the name of the deck you have
-  open rather than one derived from its title — so a file called
-  `Q3-board.bento.html` no longer offers to save itself as
-  `Q3_Board_Review.bento.html`. The backup written alongside an in-place update
-  follows the same name. Where the save dialog opens is set by the browser and
-  can't be pointed at a folder by the page, but it now remembers the last place
-  you saved, so the second update onwards starts in the right directory.
+- **The update save dialog pre-fills the open file's own name.** It offers the
+  name of the deck you have open rather than one derived from its title — so a
+  file called `Q3-board.bento.html` no longer offers to save itself as
+  `Q3_Board_Review.bento.html`. The backup written alongside an in-place
+  update follows the same name. Where the save dialog opens is set by the
+  browser and can't be pointed at a folder by the page, but it now remembers
+  the last place you saved, so the second update onwards starts in the right
+  directory.
 
 - **The starter deck is called “Bento Slides Showcase” again.** The lowercase
   rebrand swept the deck's own title along with the app's, but a deck title is
@@ -114,34 +117,35 @@ pre-1.0.
   filename — so it reads better in title case. The `bento/slides` wordmark is
   unchanged.
 
-- **Chart labels and legends now honor their visual options.** The lightweight
-  chart renderer applies configured font sizes and weights to axis labels and
-  legends, respects legend spacing and placement, and measures CJK legend text
-  correctly so localized series names no longer overlap.
+- **Charts honour axis and legend text styles, and measure CJK correctly.**
+  The lightweight chart renderer applies configured font sizes and weights to
+  axis labels and legends, respects legend spacing and placement, and measures
+  CJK legend text correctly so localized series names no longer overlap.
 
-- **Fix: presenting on a phone shows the deck, not a scrollable page.** Below
-  about 435px wide, the presentation was quietly switching to a scrolling
-  reading layout instead of a slideshow — so swipe navigation stopped working
-  and hidden interactive slides became scrollable content.
+- **Fix: Reveal's scroll view no longer activates below 435px.** Below about
+  435px wide, the presentation was quietly switching to a scrolling reading
+  layout instead of a slideshow — so swipe navigation stopped working and
+  hidden interactive slides became scrollable content.
 
-- **Fix: saved files no longer grow by 100 KB on every save.** Each save wrote
-  a fresh, uncompressed copy of the app's stylesheet into the file, which the
-  next save then copied again — a deck saved ten times carried ten of them and
-  had put on a megabyte for nothing. The stylesheet belongs in the compressed
-  runtime payload, where it takes 27 KB and is written exactly once; a file
-  that already accumulated copies drops all of them the next time you save it.
+- **Fix: saves no longer accumulate an uncompressed copy of the stylesheet.**
+  Each save wrote a fresh, uncompressed copy of the app's stylesheet into the
+  file, which the next save then copied again — a deck saved ten times carried
+  ten of them and had put on a megabyte for nothing. The stylesheet belongs in
+  the compressed runtime payload, where it takes 27 KB and is written exactly
+  once; a file that already accumulated copies drops all of them the next time
+  you save it.
 
-- **Fix: a large chart legend no longer crowds the axis labels.** Charts that
-  don't set their own margins now leave room for the legend at whatever size
-  it's set to, instead of assuming the default one.
+- **Fix: the cartesian grid reserves room for the legend's real height.**
+  Charts that don't set their own margins now leave room for the legend at
+  whatever size it's set to, instead of assuming the default one.
 
-- **Fix: readable axis numbers on the showcase deck's linked chart.** They were
-  being drawn half-transparent against a dark panel.
+- **Fix: starter-deck axis labels back above the WCAG AA contrast floor.**
+  They were being drawn half-transparent against a dark panel.
 
-- **Fix: the About dialog's update section overlapped the controls beneath it.**
-  Once an update was found, the extra heading and buttons collapsed into a
-  sliver and drew on top of the auto-check and offline switches. It now takes
-  the room it needs and the dialog scrolls.
+- **Fix: the About dialog's update section no longer overlaps the controls
+  below.** Once an update was found, the extra heading and buttons collapsed
+  into a sliver and drew on top of the auto-check and offline switches. It now
+  takes the room it needs and the dialog scrolls.
 
 ## [1.0.10] — 2026-07-25
 


### PR DESCRIPTION
The section had grown to **20 entries in merge order**, so a niche toolbar fix led and maths, languages and the phone editor were scattered through the middle.

That ordering isn't cosmetic any more: since #131, **the first five headlines become the notes shown inline in the About dialog** before someone updates. The five they'd have seen were toolbar-order, slideshow toggles, phone-presenting, present-was-broken and update-notes — which reads like a maintenance release when this is the largest one yet.

## Dropped three
- **"Fix: presenting was broken"** and **"Fix: the toolbar buttons were in the wrong order"** — both bugs were introduced *and* fixed **inside this unreleased cycle**. Verified: neither commit is an ancestor of `v1.0.10`. **No user ever saw either.** Announcing them tells people about breakage they didn't have, and "presenting was broken" is alarming to someone who presented fine all week. The commit history is the right home for that record.
- **"See what's new before you update"** — superseded. Its replacement literally says *"instead of only a version number and a link off to GitHub"*, describing the removal of what that entry announced.

**Kept** the scroll-view fix, which looks like the same class of thing but isn't — that one *was* in 1.0.10, so it's a genuine user-facing fix.

## Now leads with
```
• Maths, written the way you'd write it.
• Formulas rearrange symbol by symbol.
• Twenty-one more languages, added only if you want them.
• The editor fits on a phone.
• Your decks look like themselves in Finder, Files and the Bento Tray app.
…and 12 more
```

Features first, then fixes. Spacing normalised — several entries had no blank line before them and ran together.

**No wording changed**, 17 entries. Docs only.