### PR TITLE
Release 1.0.11: bump APP_VERSION

### DIFF
--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — the changelog section was dated in #145.

This is what becomes `APP_VERSION` in the shell and the `version` in the signed manifest, so it lands on `main` before the tag rather than being a detached edit at release time.