### PR TITLE
Fix: restore the rendered form when an edit changes nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ pre-1.0.
 
 ## [1.0.11] — 2026-07-27
 
+- **Fix: a formula you opened but didn't change now redraws when you finish.**
+  Editing a formula (or a `{{page}}`-style field) shows its raw source; leaving
+  without typing anything used to leave that source on the slide until
+  something else happened to repaint.
+
 - **LaTeX maths in any text box, rendered as MathML.** Type `$E=mc^2$` and it
   renders as a formula — `$$…$$` for a display equation on its own line. The
   document stores exactly what you typed, so a deck with maths still opens in

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -34,6 +34,9 @@ export class SlideCanvas {
   private zoom = 1
   private zoomLabel: HTMLElement | null = null
   private editing: HTMLElement | null = null
+  /** startTextEdit swapped the rendered form for raw source (a field or a
+   *  formula), so commit must re-render even if the text is unchanged. */
+  private editingShowedRaw = false
   /** when editing a table cell, which cell (else null → text element edit) */
   private editingCell: { r: number; c: number } | null = null
   /** a repaint arrived (e.g. a remote collab op) while an inline edit was in
@@ -917,8 +920,12 @@ export class SlideCanvas {
     // fields ({{page}} etc.) and math ($…$) render RESOLVED; while editing,
     // show the raw source so the author edits the token, not the computed value
     const model = this.store.element(node.dataset.elId ?? '')
+    // Remember that we swapped: on commit the resolved view has to be put back
+    // even when the text did NOT change, and only a re-render can do that.
+    this.editingShowedRaw = false
     if (model?.type === 'text' && typeof model.html === 'string' && /\{\{|\$/.test(model.html)) {
       inner.innerHTML = model.html
+      this.editingShowedRaw = true
     }
     this.editing = node
     node.classList.add('bento-editing')
@@ -989,6 +996,15 @@ export class SlideCanvas {
         el.html = html
         if (grownH > el.h) el.h = Math.ceil(grownH)
       })
+    } else if (this.editingShowedRaw) {
+      // Nothing changed, so there is no commit to re-render off the back of —
+      // but startTextEdit replaced the rendered formula (or {{page}} field)
+      // with its raw source, and that raw source is still on screen. Editing a
+      // formula and changing nothing left `$$x = \\frac{…}$$` sitting on the
+      // slide until some unrelated event happened to repaint. Put the resolved
+      // view back.
+      this.editingShowedRaw = false
+      this.render()
     } else {
       this.syncTargets()
     }


### PR DESCRIPTION
**Release blocker** — found during rc5 testing.

Open a maths equation, change nothing, click away: the formula doesn't come back. The raw `$$x = \\frac{…}$$` stays on the slide.

## Cause
`startTextEdit` deliberately swaps the **rendered** form for the **raw source**, so you edit the LaTeX rather than the glyphs. But `commitTextEdit` only re-rendered as a side effect of committing a change — with nothing changed it took the `else` branch, called `syncTargets()` and returned. Nothing put the resolved view back.

**Wider than maths.** The same swap fires for any text matching `/\{\{|\$/`, so `{{page}}` and the other dynamic fields had it too — **15 elements in the starter deck alone**.

Fixed by remembering the swap (`editingShowedRaw`) and re-rendering on commit when nothing changed.

## A testing note, because I got this wrong twice
**Synthetic events don't drive this path.** Dispatching `Escape` or a synthetic `mousedown` leaves the editor *in* edit mode — so the raw source on screen is correct behaviour and proves nothing. My first two "reproductions" were measuring exactly that. It needs real mouse input; CLAUDE.md says so about Moveable/Selecto, and it applies to the commit-on-click-outside path too.

## Verified with real clicks — same sequence on both builds
| build | exited edit mode | MathML nodes | shows |
|---|---|---|---|
| rc5 (unfixed) | yes | **0** | `$$x = \\frac{-b \\pm \\sqrt{b^2…` |
| this fix | yes | **1** | `x=−b±√(b²−4ac)/2a` |

Splice gate OK, packed table current, rig `SEEDS=200` ALL PASS.