### PR TITLE
Changelog: move the formula-redraw fix in with the other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,6 @@ pre-1.0.
 
 ## [1.0.11] — 2026-07-27
 
-- **Fix: a formula you opened but didn't change now redraws when you finish.**
-  Editing a formula (or a `{{page}}`-style field) shows its raw source; leaving
-  without typing anything used to leave that source on the slide until
-  something else happened to repaint.
-
 - **LaTeX maths in any text box, rendered as MathML.** Type `$E=mc^2$` and it
   renders as a formula — `$$…$$` for a display equation on its own line. The
   document stores exactly what you typed, so a deck with maths still opens in
@@ -126,6 +121,11 @@ pre-1.0.
   The lightweight chart renderer applies configured font sizes and weights to
   axis labels and legends, respects legend spacing and placement, and measures
   CJK legend text correctly so localized series names no longer overlap.
+
+- **Fix: a formula you opened but didn't change now redraws when you finish.**
+  Editing a formula (or a `{{page}}`-style field) shows its raw source; leaving
+  without typing anything used to leave that source on the slide until
+  something else happened to repaint.
 
 - **Fix: Reveal's scroll view no longer activates below 435px.** Below about
   435px wide, the presentation was quietly switching to a scrolling reading


### PR DESCRIPTION
It was prepended to the section, so it **led the five headlines that go into the signed manifest** — the ones shown in the About dialog before updating. A fix about redrawing a formula shouldn't introduce the release that brought maths, twenty-one languages and a phone editor. That ordering is what #145 was for.

**Kept, not dropped** — unlike the two never-shipped fixes removed in #145, this one genuinely shipped: v1.0.10 already swapped in raw source for `{{…}}` fields (`model.html.includes('{{')`), and the maths work only widened the condition to catch `$` too. A 1.0.10 user who opened a `{{page}}` field and changed nothing saw the raw token left behind.

Restores the intended lead:
```
• LaTeX maths in any text box, rendered as MathML.
• Symbol-level formula morphing.
• Twenty-one installable language packs, each hash-signed.
• The editor is usable at 402px — the topbar folds instead of overflowing.
• Decks carry a page-one preview, so Finder and Files thumbnail them properly.
```
Docs only.