### PR TITLE
Keep active slide thumbnail visible during navigation

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1524,9 +1524,13 @@ export class Editor {
   }
 
   private highlightSidebar() {
+    let active: HTMLElement | undefined
     this.sidebar.querySelectorAll<HTMLElement>('.ed-thumb').forEach((n) => {
-      n.classList.toggle('active', Number(n.dataset.index) === this.store.currentIndex)
+      const isActive = Number(n.dataset.index) === this.store.currentIndex
+      n.classList.toggle('active', isActive)
+      if (isActive) active = n
     })
+    active?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
   }
 
   private scheduleThumbs() {


### PR DESCRIPTION
## Summary

- keep the active slide thumbnail visible whenever the current slide changes
- use nearest-edge scrolling so the sidebar stays put when the thumbnail is already visible

## Why

Keyboard and wheel navigation update the canvas and active thumbnail state, but the sidebar did not scroll with that state. After moving several slides, the selected thumbnail could be outside the visible sidebar.

## Impact

The thumbnail sidebar now follows arrow-key, Page Up/Down, wheel, and other current-slide changes. This is editor-only behavior; it does not change the document format or add UI strings.

## Verification

- `npm run build:single`
- `node scripts/shell-gate.mjs slides/dist-single/Bento_Slides.bento.html`
- browser QA: navigated ten slides forward and backward with arrow keys; the active thumbnail remained fully visible in both directions
- browser QA: navigating to an already-visible neighboring slide left the sidebar scroll position unchanged
- browser console: no errors
