### PR TITLE
publish: fail loudly when a release has no CHANGELOG section

### DIFF
--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -164,15 +164,28 @@ if (ver === '?') {
   if (!exists) {
     // Notes come from the CHANGELOG section for this version, so the release
     // and the file in the repo can never drift apart.
-    let notes = 'See CHANGELOG.md.'
-    try {
-      const cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8')
+    //
+    // This used to degrade silently to a 'See CHANGELOG.md.' pointer when the
+    // section could not be found, which is how v1.0.11 shipped with no notes at
+    // all while every earlier release carried its entries. A contentless release
+    // is the same class of failure as a missing one, so it dies here for the
+    // same reason the gh check above does. Publishing is idempotent: fix the
+    // CHANGELOG and re-run.
+    const notes = (() => {
+      let cl
+      try { cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8') }
+      catch (e) { die(`site is published, but CHANGELOG.md could not be read from ${root} — the GitHub release for ${tag} was NOT created.\n  ${e.message}`) }
       const start = cl.indexOf(`## [${ver}]`)
-      const rest = cl.indexOf('\n## [', start + 1)
-      if (start >= 0) {
-        notes = cl.slice(cl.indexOf('\n', start) + 1, rest > 0 ? rest : undefined).trim()
+      if (start < 0) {
+        die(`site is published, but CHANGELOG.md has no '## [${ver}]' section — the GitHub release for ${tag} was NOT created.\n  Add the section, then re-run: node scripts/publish-site.mjs`)
       }
-    } catch { /* fall back to the pointer above */ }
+      const rest = cl.indexOf('\n## [', start + 1)
+      const body = cl.slice(cl.indexOf('\n', start) + 1, rest > 0 ? rest : undefined).trim()
+      if (!body) {
+        die(`site is published, but the '## [${ver}]' CHANGELOG section is empty — the GitHub release for ${tag} was NOT created.`)
+      }
+      return body
+    })()
     const intro = "Download the single file below and open it in any modern browser — it's the document, the viewer and the editor in one. Shipped files self-update through the signed release channel.\n\n"
     const notesFile = join(tmpdir(), `bento-release-${ver}.md`)
     writeFileSync(notesFile, intro + notes)


### PR DESCRIPTION
`scripts/publish-site.mjs` states its own contract at line 143:

> Idempotent: an existing release is left alone… **NOT best-effort** — a failure here is reported loudly and exits non-zero, because a silent skip is the exact failure being fixed.

The notes lookup underneath it did the opposite. A failed `readFileSync` or a missing `## [ver]` heading fell through to a bare `See CHANGELOG.md.` pointer, with no warning and a zero exit.

**That is how [v1.0.11](https://github.com/nyblnet/bento/releases/tag/v1.0.11) shipped with only the two-line intro** while v1.0.10 and everything before it carried their entries. It went unnoticed until a reader compared the two pages. A contentless release is the same class of failure as a missing one — the step exists precisely because v1.0.10's release was forgotten.

All three degenerate cases now `die()` with the tag, the reason and the fix:

| case | before | after |
|---|---|---|
| `CHANGELOG.md` unreadable | silent pointer | dies, names the path and the read error |
| no `## [ver]` section | silent pointer | dies, names the section to add |
| section present but empty | silent pointer | dies |

Publishing is idempotent, so recovery is to fix the CHANGELOG and re-run.

Verified: the `1.0.11` section still extracts (8,118 chars, bounded by the next heading), a nonexistent version takes the die path, and `node --check` passes.

The v1.0.11 release notes have already been backfilled by hand, so this is about the next release, not that one.