### PR TITLE
publish: name the app in the GitHub release title

### DIFF
--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -145,6 +145,14 @@ console.log(`\n✓ published to bento-site @ ${head} (app v${ver})`)
 // because a silent skip is the exact failure being fixed.
 const releaseShell = join(site, 'releases/slides/Bento_Slides.bento.html')
 const tag = `v${ver}`
+// The title names the APP, not just the version: this repo ships more than one
+// (bento/spaces and bento/dash are starting), and a page titled 'v1.0.12' does
+// not say which one the file below it is. v1.0.6 was titled by hand and got
+// this right; every release after it went through the automated step below and
+// came out as a bare tag, so the convention was lost until the six existing
+// releases were retitled on 2026-07-27. Hardcoding it here is what stops it
+// drifting a second time.
+const releaseTitle = `bento/slides ${tag}`
 
 const ghAvailable = (() => {
   try { capture('gh', ['auth', 'status'], { stdio: ['ignore', 'pipe', 'pipe'] }); return true }
@@ -154,7 +162,7 @@ const ghAvailable = (() => {
 if (ver === '?') {
   console.warn('⚠ could not read the published version — skipping the GitHub release step')
 } else if (!ghAvailable) {
-  die(`site is published, but gh is unavailable or unauthenticated — the GitHub release for ${tag} was NOT created.\n  Fix: gh auth login, then:  gh release create ${tag} ${releaseShell} --title ${tag} --notes-file <notes>`)
+  die(`site is published, but gh is unavailable or unauthenticated — the GitHub release for ${tag} was NOT created.\n  Fix: gh auth login, then:  gh release create ${tag} ${releaseShell} --title ${releaseTitle} --notes-file <notes>`)
 } else {
   const exists = (() => {
     try { capture('gh', ['release', 'view', tag], { stdio: ['ignore', 'pipe', 'pipe'] }); return true }
@@ -189,7 +197,7 @@ if (ver === '?') {
     const intro = "Download the single file below and open it in any modern browser — it's the document, the viewer and the editor in one. Shipped files self-update through the signed release channel.\n\n"
     const notesFile = join(tmpdir(), `bento-release-${ver}.md`)
     writeFileSync(notesFile, intro + notes)
-    run('gh', ['release', 'create', tag, releaseShell, '--title', tag, '--notes-file', notesFile])
+    run('gh', ['release', 'create', tag, releaseShell, '--title', releaseTitle, '--notes-file', notesFile])
     console.log(`✓ GitHub release ${tag} created with the signed shell attached`)
   } else {
     const assets = (() => {


### PR DESCRIPTION
The release step passed `'--title', tag`, so every automated release page read `v1.0.11` — a version with no app name on it. This repo ships more than one app (`bento/spaces` and `bento/dash` are starting), so that page does not say which one the attached file is.

`v1.0.6` was titled by hand as `Bento/Slides v1.0.6` and got this right. **Every release from v1.0.7 onward went through this line** and came out as a bare tag, which is exactly how the convention was lost — the same shape as the notes regression in #158: the automated path silently did something worse than the manual one it replaced.

The six existing releases have been retitled to `bento/slides vX.Y.Z`, matching `doc.type` and the `docs/PLATFORM.md` spelling. Verified after retitling: notes and the signed shell asset are intact on each.

| tag | title |
|---|---|
| v1.0.11 | bento/slides v1.0.11 |
| v1.0.10 | bento/slides v1.0.10 |
| v1.0.9 | bento/slides v1.0.9 |
| v1.0.8 | bento/slides v1.0.8 |
| v1.0.7 | bento/slides v1.0.7 |
| v1.0.6 | bento/slides v1.0.6 |

This PR stops it drifting again. The `die()` hint prints the same title, so the manual recovery command produces a correctly-titled release too.

When Spaces ships its own release channel it will want its own title — the constant is per-app and sits next to the per-app `releaseShell` path, so that stays a one-line change.