### PR TITLE
Preview: leave <noscript>, so iOS can thumbnail a deck too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,10 @@ pre-1.0.
   slide over the canvas instead of squeezing it, so the slide you're editing
   is no longer the smallest thing on screen. Nothing changes on a laptop.
 
-  Known gap: the save-as menu (copy, new deck, template, password) doesn't fit
-  on a phone yet and is unreachable there for now.
+  The save-as list — save a copy, duplicate as a new deck, the password
+  actions, version history and the JSON round-trip — sits at the bottom of ⋯ on
+  a phone, because the caret that opens it on a laptop doesn't fit beside a
+  touch-sized Save button.
 
 - **Decks carry a page-one preview, so Finder and Files thumbnail them
   properly.** Every Bento file used to thumbnail as the same dark box, because

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,19 @@ names provisional.
   file-manager thumbnails**. Thumbnailers (iOS Files, macOS QuickLook/Finder,
   Bento Tray) render HTML with JS OFF, so every deck used to thumbnail as the
   same boot splash. Every save now writes a still render of page one into the
-  shell, parked in `<noscript data-bento-preview>` — rendered only when
-  scripting is off, so with JS on the host node has ZERO element children (raw
-  text) and a 0×0 box: no flash, no layout, nothing for print/present to
-  exclude. Reuses `renderSlide` with `svgAsImage:true` (svg → one `<img>`,
+  shell as a plain `[data-bento-preview]` element, followed IMMEDIATELY by a
+  parser-blocking `<script data-bento-preview>` that deletes both. The
+  thumbnailer keeps the preview (it runs no script); the reader never sees it
+  (the remover executes before the browser paints — measured: at removal
+  `readyState` is `loading` and `getEntriesByType('paint')` is EMPTY). **NOT
+  `<noscript>`** — that was v1 and it does nothing on iOS, whose thumbnailer
+  runs no script AND does not render `<noscript>` (probe: red default / green
+  from inline script / blue in noscript renders RED). Anything between host and
+  remover is markup a browser could paint, so the gate asserts the ordering.
+  A QLThumbnailProvider extension does NOT work — registers fine, never
+  launches, because iOS owns `public.html`; nor does
+  `NSURLThumbnailDictionaryKey`, silently dropped for local files.
+  Reuses `renderSlide` with `svgAsImage:true` (svg → one `<img>`,
   media → poster/icon still) + `hidePlaceholders`; `staticize()` strips active
   elements, runtime data-attrs and `on*`, and INLINES the few `.bento-*` rules
   from styles.css (the runtime CSS ships deflated and is never inflated in

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,50 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-07-27 — Thumbnails: plain markup plus a parser-blocking remover, NOT `<noscript>`
+
+**Supersedes the 2026-07-26 entry below** on the one point of where the preview
+lives. Everything else in it still stands: written at save time, replaced never
+appended, `PREVIEW_BUDGET` tiers, and above all **encrypted decks get no
+preview**.
+
+`<noscript>` renders only where scripting is DISABLED, and iOS satisfies
+neither half of that. Probed with a page that is red by default, turns green
+from an inline script, and carries a blue `<noscript>`, the iOS thumbnailer
+renders **RED** — it runs no script AND does not render `<noscript>`. So the
+feature worked in Finder and macOS QuickLook and did nothing on the platform it
+was built for; every deck in Bento Tray stayed a dark box.
+
+That same gap is the fix. A renderer that runs no script still renders ordinary
+markup, and every real reader does run script — so the preview ships as a plain
+`[data-bento-preview]` element with a **parser-blocking inline remover**
+immediately after it. The thumbnailer keeps the preview (it never runs the
+remover); the reader never sees it (the script executes before the browser
+paints). Measured: at removal `document.readyState` is `"loading"` and
+`performance.getEntriesByType('paint')` is EMPTY — zero frames containing the
+preview were ever presented. Not a fast flash; no flash.
+
+The 2026-07-26 entry chose `<noscript>` to avoid exactly that flash, and
+accepted "a thumbnailer that does run scripts sees no preview" as the trade.
+Both halves turned out to be wrong about iOS, and the replacement costs neither.
+
+**A QLThumbnailProvider extension does not work and should not be retried.** It
+registers correctly (`pluginkit` shows `SDK = com.apple.quicklook.thumbnail`)
+but its process never launches: iOS uses its own generator for `public.html`
+and does not consult third-party extensions for types it already handles.
+Likewise `NSURLThumbnailDictionaryKey` via `UIDocument.fileAttributesToWrite`,
+which is accepted and then silently dropped for local files — inspecting the
+xattrs afterwards finds only `com.apple.lastuseddate`.
+
+`previewIsSafe` is now MORE load-bearing, not less: the preview lands in the
+live DOM rather than sitting inert inside `<noscript>`, so the refusal that
+keeps a script tag out of it protects the page and not just the file structure.
+`shell-gate.mjs` gained two source assertions — that the remover is emitted at
+all, and that it sits immediately after the preview, since anything between
+them is markup a browser could paint first.
+
+---
+
 ## 2026-07-26 — File-manager thumbnails: a `<noscript>` render of page one, written at save time
 
 **Decided:** 2026-07-26. Kernel zone (`kernel/src/save.ts`), so it binds every

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -212,13 +212,19 @@ const NOSCRIPT_CLOSE = '</nosc' + 'ript'
 /**
  * Refuse any preview markup that could unbalance the file.
  *
- * The preview is generated from user content, so it is not shaped by us. Two
- * ways it could corrupt the document: a `<script>`/`</script>` would break the
- * open/close balance the frozen splice contract (and `scripts/shell-gate.mjs`)
- * depends on, and a `</noscript>` would end the host element early, spilling
- * the rest of the preview into the visible page. The app sanitizes its own
- * output; this is the kernel refusing to take its word for it. Dropping the
- * preview costs a thumbnail. Emitting it anyway could brick the file.
+ * The preview is generated from user content, so it is not shaped by us. A
+ * `<script>`/`</script>` in it would break the open/close balance the frozen
+ * splice contract (and `scripts/shell-gate.mjs`) depends on. `</noscript>` is
+ * still refused although the preview no longer lives in a `<noscript>`: it
+ * costs nothing, and a document written by an older Bento may still carry one.
+ *
+ * This check got MORE load-bearing when the preview left `<noscript>`. It is no
+ * longer inert markup that only a scripting-less renderer ever parses — it now
+ * lands in the live DOM of every reader's page until the remover runs.
+ *
+ * The app sanitizes its own output; this is the kernel refusing to take its
+ * word for it. Dropping the preview costs a thumbnail. Emitting it anyway could
+ * brick the file.
  *
  * Exported for `scripts/test-preview.ts`, like previewAllowed.
  */
@@ -226,6 +232,20 @@ export function previewIsSafe(html: string): boolean {
   const lower = html.toLowerCase()
   return !lower.includes(SCRIPT_OPEN) && !lower.includes(SCRIPT_CLOSE_START) && !lower.includes(NOSCRIPT_CLOSE)
 }
+
+/**
+ * Deletes the preview, and itself, the instant the parser reaches it.
+ *
+ * Parser-BLOCKING on purpose: a classic inline script placed immediately after
+ * the preview runs before the parser continues, so the browser never paints a
+ * frame containing it. That is what makes this free for readers.
+ *
+ * It is written as a string rather than built from a template because it must
+ * stay one line and contain no `</script>`.
+ */
+const PREVIEW_REMOVER =
+  `(function(){var a=document.querySelectorAll('[${PREVIEW_ATTR}]');` +
+  `for(var i=a.length;i--;){var n=a[i];if(n.parentNode)n.parentNode.removeChild(n)}})()`
 
 function writePreview(clone: Document, body: string, doc: KernelDoc): void {
   // REPLACE, NEVER APPEND. `capturePristine()` snapshots the document as it
@@ -235,7 +255,10 @@ function writePreview(clone: Document, body: string, doc: KernelDoc): void {
   // whether to write a new one — is also how a preview correctly DISAPPEARS
   // when a plaintext deck gains a password, or when an app stops providing
   // one. Both of those are silent leaks if the removal is conditional.
-  for (const stale of Array.from(clone.querySelectorAll(`noscript[${PREVIEW_ATTR}]`))) stale.remove()
+  // The selector is deliberately attribute-only: it must sweep the host AND the
+  // remover script beside it, and it must still find previews written by an
+  // older Bento, which parked them in a <noscript>.
+  for (const stale of Array.from(clone.querySelectorAll(`[${PREVIEW_ATTR}]`))) stale.remove()
 
   if (!previewProvider || !previewAllowed(body)) return
 
@@ -250,18 +273,44 @@ function writePreview(clone: Document, body: string, doc: KernelDoc): void {
   }
   if (!el) return
 
-  const host = clone.createElement('noscript')
+  // ORDINARY MARKUP, NOT <noscript>, AND A PARSER-BLOCKING REMOVER.
+  //
+  // `<noscript>` was the obvious home and it is wrong here. It renders only
+  // where scripting is DISABLED, and iOS — the platform this feature exists for
+  // — satisfies neither half of that: probed with a page whose inline script
+  // repaints it, the iOS thumbnailer renders neither the script's result nor
+  // the <noscript>, so a deck thumbnailed as its boot splash no matter what we
+  // put in the noscript.
+  //
+  // Since that thumbnailer runs no script, plain markup survives for it. And
+  // since every real reader DOES run script, a parser-blocking inline remover
+  // placed immediately after deletes the preview before the browser paints a
+  // frame containing it. Both audiences get the right answer with no flash and
+  // no compromise — which the <noscript> version could not manage.
+  //
+  // A reader with scripting genuinely off keeps the preview on screen, exactly
+  // as before: without scripts the deck cannot render at all, so a still of
+  // page one is the best available answer rather than a regression.
+  const host = clone.createElement('div')
   host.setAttribute(PREVIEW_ATTR, '1')
   host.appendChild(clone.importNode(el, true))
   if (!previewIsSafe(host.innerHTML)) {
     console.warn('bento: first-page preview rejected as unsafe, saving without one')
     return
   }
+  const remover = clone.createElement('script')
+  remover.setAttribute(PREVIEW_ATTR, '1')
+  remover.textContent = PREVIEW_REMOVER
+
   // Straight after the splash it replaces, so a thumbnailer reaches it before
-  // the ~550KB of compressed payload at the end of the body.
+  // the ~550KB of compressed payload at the end of the body. The remover goes
+  // immediately after the host: any markup between them is markup the parser
+  // could paint first.
   const splash = clone.getElementById('bento-splash')
-  if (splash?.parentNode) splash.parentNode.insertBefore(host, splash.nextSibling)
-  else (clone.body ?? clone.documentElement).appendChild(host)
+  const parent = splash?.parentNode ?? clone.body ?? clone.documentElement
+  const after = splash?.parentNode ? splash.nextSibling : null
+  parent.insertBefore(host, after)
+  parent.insertBefore(remover, host.nextSibling)
 }
 
 /**

--- a/scripts/shell-gate.mjs
+++ b/scripts/shell-gate.mjs
@@ -352,31 +352,37 @@ function checkEscapeIsImplemented() {
 // --- invariant 5: a preview-carrying shell ---------------------------------
 //
 // The THIRD class of plaintext content a saved file carries: the static
-// first-page preview `kernel/src/save.ts` writes into a
-// `<noscript data-bento-preview>` so file managers can thumbnail the deck
-// (docs/DECISIONS.md). Like a language pack it is not shaped by us — it is
-// rendered from whatever the author typed on page one — but unlike a pack it
-// is HTML, not JSON in a script block, so the `<` escape does not and
-// cannot apply to it. Its safety rests on the kernel REFUSING to emit markup
-// containing a script tag or a `</noscript>`, which is what this checks.
+// first-page preview `kernel/src/save.ts` writes as a `[data-bento-preview]`
+// element, followed by a parser-blocking remover script that deletes it before
+// the page is ever painted (docs/DECISIONS.md). Like a language pack it is not
+// shaped by us — it is rendered from whatever the author typed on page one —
+// but unlike a pack it is HTML, not JSON in a script block, so the `<`
+// escape does not and cannot apply to it. Its safety rests on the kernel
+// REFUSING to emit markup containing a script tag, which is what this checks —
+// and that refusal carries MORE weight now the preview lands in the live DOM
+// instead of sitting inert inside a `<noscript>`.
 
 const NOSCRIPT_CLOSE = '</nosc' + 'ript>'
+const SCRIPT_OPEN_TAG = '<scr' + 'ipt'
 
 /** A preview whose content came from a hostile deck: entity-escaped exactly as
  *  a DOM serializer escapes text, plus quotes, RTL, emoji and separators. */
 const ADVERSARIAL_PREVIEW =
-  `<noscript data-bento-preview="1"><div style="position:fixed;left:0;top:0;background:#0D1B2E">` +
+  `<div data-bento-preview="1"><div style="position:fixed;left:0;top:0;background:#0D1B2E">` +
   `<div>&lt;/script&gt; &lt;script&gt;alert(1)&lt;/script&gt; ` +
   `&lt;script type="application/bento+json" id="bento-doc"&gt;{"hijacked":true}&lt;/script&gt;` +
   `&lt;/noscript&gt; &lt;!-- --&gt; &lt;![CDATA[ &amp; &quot; ' \` \\ ` +
   `مرحبا שלום 🎌 a b c</div>` +
-  `</div>${NOSCRIPT_CLOSE}`
+  `</div></div>` +
+  // the remover that now ships beside every preview: a REAL script element,
+  // so the shell's open/close balance has to survive one more of them
+  `${SCRIPT_OPEN_TAG} data-bento-preview="1">/* remover */${SCRIPT_CLOSE}`
 
 /** …and the same content with the escapes NOT applied — what the kernel's
  *  `previewIsSafe` refusal exists to keep out of a file. */
 const UNSAFE_PREVIEW =
-  `<noscript data-bento-preview="1"><div>${SCRIPT_CLOSE} ` +
-  `${DOC_BLOCK_OPEN}{"hijacked":true}${SCRIPT_CLOSE}</div>${NOSCRIPT_CLOSE}`
+  `<div data-bento-preview="1"><div>${SCRIPT_CLOSE} ` +
+  `${DOC_BLOCK_OPEN}{"hijacked":true}${SCRIPT_CLOSE}</div></div>`
 
 /** Insert a preview where `writePreview` does — straight after the splash. */
 const withPreview = (html, preview) =>
@@ -429,6 +435,12 @@ function checkPreviewRulesAreImplemented() {
     fail('kernel/src/save.ts previewAllowed no longer checks BOTH the password flag and the body envelope')
   if (!/previewIsSafe\(host\.innerHTML\)/.test(text))
     fail('kernel/src/save.ts no longer refuses unsafe first-page preview markup')
+  // The preview is a full-bleed overlay. Since it left <noscript> it is live
+  // markup, and the remover is the ONLY thing keeping it off a reader's screen.
+  if (!/PREVIEW_REMOVER/.test(text) || !/removeChild/.test(text))
+    fail('kernel/src/save.ts no longer emits the preview remover — every reader would stare at page one')
+  if (!/insertBefore\(remover, host\.nextSibling\)/.test(text))
+    fail('kernel/src/save.ts no longer places the remover immediately after the preview — a frame could paint between the two')
 }
 
 /** Throws with a GATE: message on the first violated invariant. */

--- a/scripts/test-preview.ts
+++ b/scripts/test-preview.ts
@@ -16,8 +16,9 @@
 //      every password-protected deck ever saved, and the owner would have no
 //      way to notice.
 //   2. THE OUTPUT REFUSAL. The preview is generated from author content. A
-//      script tag or a `</noscript>` reaching the file unbalances it and
-//      breaks the frozen splice contract every shipped updater relies on.
+//      script tag reaching the file unbalances it and breaks the frozen
+//      splice contract every shipped updater relies on. `</noscript>` is
+//      still refused: it costs nothing and older files carry one.
 //
 // The rest of the feature — laying the page out, fitting it to a viewport,
 // staying inside the byte budget — needs a DOM and is verified in a browser
@@ -95,7 +96,7 @@ ok(previewIsSafe('<div>مرحبا שלום 🎌 a b c</div>') === true, 'RTL
 ok(previewIsSafe(`<div>${SCRIPT_CLOSE}</div>`) === false, 'a bare script close is refused')
 ok(previewIsSafe(`<div>${SCRIPT_OPEN}alert(1)${SCRIPT_CLOSE}</div>`) === false, 'a script element is refused')
 ok(previewIsSafe(`<div>${NOSCRIPT_CLOSE}<h1>escaped</h1></div>`) === false,
-  'a noscript close is refused — it would end the host and spill into the page')
+  'a noscript close is refused — older files park the preview in one')
 
 // Case and attribute variants: an HTML parser ends a script element at
 // `</script` regardless of case or what follows, so the check must too.


### PR DESCRIPTION
The static page-one preview worked in Finder and macOS QuickLook and did **nothing at all on iOS** — the platform the feature was built for. Every document in Bento Tray was still the same dark box.

## Why

`<noscript>` renders only where scripting is DISABLED. I assumed iOS thumbnailed with scripting enabled-but-starved, which would explain the splash. **It does not.**

Probed with a page that is red by default, turns green from an inline script, and carries a blue `<noscript>`:

| thumbnail | would mean |
|---|---|
| GREEN | inline JS runs |
| BLUE | `<noscript>` renders |
| **RED** ← actual | **neither** |

iOS runs no script *and* does not render `<noscript>`. Arguably a WebKit bug; it is what ships.

## The fix, and why it costs nothing

That same gap is the opening. A renderer that runs no script will render ordinary markup, and every real reader *does* run script. So the preview now ships as a plain `[data-bento-preview]` element followed **immediately** by a parser-blocking inline remover.

- The thumbnailer keeps the preview — it never runs the remover.
- The reader never sees it — an inline script immediately after the element executes before the browser paints.

**Measured, not argued.** At the moment the remover runs:

```
readyState:          "loading"     ← during parsing
paintsBeforeRemoval: 0             ← getEntriesByType('paint') is EMPTY
previewNodesNow:     0
booted:              true
```

Zero paint entries means no frame containing the preview was ever presented. This is not "a fast flash"; there is no flash. The 2026-07-26 decision chose `<noscript>` specifically to avoid that flash and accepted "a thumbnailer that does run scripts sees no preview" as the trade — both halves turned out to be wrong about iOS, and the replacement costs neither.

A reader with scripting genuinely off keeps the preview on screen, exactly as before. Without scripts the deck cannot render at all, so a still of page one is the best answer available, not a regression.

## Verified end to end

- A deck saved by the real build renders page one with scripting disabled (CDP `Emulation.setScriptExecutionDisabled`).
- It **thumbnails as page one in Bento Tray on the iOS simulator**, where it was a dark box minutes earlier.
- Conformance gate passes both as a shell and as a saved document; `test-preview` 18/18, `test-packs` 17/17, `tsc` clean for slides, kernel and spaces.

## Two dead ends, recorded so nobody repeats them

- **A QLThumbnailProvider extension does not work.** Built, then thrown away. It registers correctly (`pluginkit` shows `SDK = com.apple.quicklook.thumbnail`) but its process never launches: iOS uses its own generator for `public.html` and does not consult third-party extensions for types it already handles.
- **`NSURLThumbnailDictionaryKey`** via `UIDocument.fileAttributesToWrite` is accepted and then silently dropped for local files — visible only by inspecting the xattrs afterwards and finding just `com.apple.lastuseddate`.

## Safety

`previewIsSafe` is now **more** load-bearing, not less: the preview lands in the live DOM instead of sitting inert inside `<noscript>`, so the refusal keeping a script tag out of it protects the page and not just the file structure. `shell-gate.mjs` gained two source assertions — that the remover is emitted at all, and that it sits immediately after the preview, since anything between them is markup a browser could paint first. The adversarial fixture now carries a real script element beside the preview, so the shell's open/close balance has to survive one more of them.

Everything else from the original design is untouched, including the load-bearing rule: **encrypted decks still get no preview**, and one that gains a password still loses the preview it had.

## Docs

`docs/DECISIONS.md` gets a new entry superseding the 2026-07-26 one rather than an edit, per that file's own rules; it supersedes exactly one point and says so. `CLAUDE.md` described the `<noscript>` design as current and now describes what ships. `CHANGELOG.md` carried a "known gap: the save-as menu is unreachable on a phone" that #156 closed.