### PR TITLE
About: give release notes room to be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Release notes in the About dialog get room to be read.** An available
+  update is now one card — version, what changed, and the two ways to take it —
+  and the notes are a real list inside their own scroll region rather than a
+  140px porthole in a dialog that was itself scrolling. The dialog is 440px
+  wide instead of 360 (capped to the viewport, so a 375px phone keeps its
+  gutters), which is enough that the five bullets a release carries fit whole
+  at any normal window height.
+
 ## [1.0.11] — 2026-07-27
 
 - **LaTeX maths in any text box, rendered as MathML.** Type `$E=mc^2$` and it

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -2530,25 +2530,31 @@ export class Editor {
       } else {
         const { release } = result
         status.textContent = ''
+        // One card: version, what changed, and the ways to take it. Grouping
+        // them is the layout fix — as five loose children of the status block
+        // the notes were squeezed between the heading and a vertical stack of
+        // three buttons, in a dialog that also has to hold Document properties
+        // and the toggles. The card stretches full width and owns its scroll.
+        const card = div('ed-about-update')
+        status.appendChild(card)
         const line = div('ed-about-new')
         line.textContent = t('Version {v} is available.', { v: release.version })
-        status.appendChild(line)
-        if (release.notes) {
-          const notes = div('ed-about-notes')
-          notes.textContent = release.notes
-          status.appendChild(notes)
-        }
+        card.appendChild(line)
+        if (release.notes) card.appendChild(releaseNotes(release.notes))
+        const actions = div('ed-about-actions')
         const fail = (err: any) => { status.textContent = t('Update failed: {m}', { m: String(err?.message ?? err) }) }
         const done = () => {
           status.textContent = ''
+          const after = div('ed-about-update')
+          status.appendChild(after)
           const ok = div('ed-about-new')
           ok.textContent = t('Updated to v{v} on disk.', { v: release.version })
-          status.appendChild(ok)
+          after.appendChild(ok)
           const note = div('ed-about-notes')
           note.textContent = canUpdateInPlace()
             ? t('This window is still running v{v} — reload to finish. A v{v} backup was downloaded.', { v: APP_VERSION })
             : t("This window is still running v{v}. If you overwrote the file that's open here, reload; otherwise open the file you saved.", { v: APP_VERSION })
-          status.appendChild(note)
+          after.appendChild(note)
           const reloadB = document.createElement('button')
           reloadB.className = 'ed-btn ed-btn-primary'
           reloadB.textContent = t('Reload into new version')
@@ -2560,14 +2566,16 @@ export class Editor {
             try { sessionStorage.setItem(JUST_UPDATED_KEY, release.version) } catch { /* private mode */ }
             location.reload()
           })
-          status.appendChild(reloadB)
+          const row2 = div('ed-about-actions')
+          row2.appendChild(reloadB)
+          after.appendChild(row2)
         }
 
-        // What changed, before deciding whether to take it. The manifest carries
-        // no release notes today, so this points at the per-version release page
-        // — which publish-site.mjs now creates for every release, so the link
-        // cannot dangle. Placed BEFORE the action buttons deliberately: reading
-        // first is the point.
+        // The inline notes above are the signed manifest's summary — the first
+        // five CHANGELOG lead-ins (scripts/release.mjs). This is the rest of
+        // them: the per-version release page, which publish-site.mjs creates
+        // for every release, so the link cannot dangle. First in the action
+        // row deliberately: reading before deciding is the point.
         const notesLink = document.createElement('a')
         notesLink.className = 'ed-btn'
         notesLink.href = `https://github.com/nyblnet/bento/releases/tag/v${release.version}`
@@ -2575,7 +2583,7 @@ export class Editor {
         notesLink.rel = 'noopener'
         notesLink.textContent = t('What’s new →')
         notesLink.title = t('Read the release notes for v{v} (opens in a new tab)', { v: release.version })
-        status.appendChild(notesLink)
+        actions.appendChild(notesLink)
 
         const inPlaceB = document.createElement('button')
         inPlaceB.className = 'ed-btn ed-btn-primary'
@@ -2593,7 +2601,7 @@ export class Editor {
             else { inPlaceB.disabled = false; inPlaceB.textContent = t('Update this file…') }
           } catch (err: any) { fail(err) }
         })
-        status.appendChild(inPlaceB)
+        actions.appendChild(inPlaceB)
 
         const getB = document.createElement('button')
         getB.className = 'ed-btn'
@@ -2608,10 +2616,11 @@ export class Editor {
             getB.textContent = t('Downloaded ✓')
             const note = div('ed-about-notes')
             note.textContent = t('This window keeps running v{v} until you open the downloaded file.', { v: APP_VERSION })
-            status.appendChild(note)
+            card.appendChild(note)
           } catch (err: any) { fail(err) }
         })
-        status.appendChild(getB)
+        actions.appendChild(getB)
+        card.appendChild(actions)
       }
     })
     row.appendChild(checkB)
@@ -2758,6 +2767,31 @@ function syncNoticeText(n: import('../sync/session').SyncNotice): string {
     case 'rate-limited':
       return t('Too many changes at once — live sync is catching up.')
   }
+}
+
+/**
+ * Release notes → a real list.
+ *
+ * The manifest carries them as PLAIN TEXT, one "• " bullet per line, capped at
+ * five plus an "…and N more" tail (scripts/release.mjs). A pre-wrap block gave
+ * every wrapped bullet a flush-left second line, which at 320px was most of
+ * them — so one item read as two and the box looked like a wall. Split per line
+ * and hang the indent instead.
+ *
+ * Always textContent, never innerHTML: the manifest is signed, but a signature
+ * says who wrote a string, not that it is safe to run.
+ */
+function releaseNotes(notes: string): HTMLElement {
+  const box = div('ed-about-release')
+  for (const raw of notes.split('\n')) {
+    const text = raw.trim()
+    if (!text) continue
+    const bullet = /^[•*-]\s+/.test(text)
+    const item = div(bullet ? 'ed-about-note' : 'ed-about-more')
+    item.textContent = bullet ? text.replace(/^[•*-]\s+/, '') : text
+    box.appendChild(item)
+  }
+  return box
 }
 
 /** Deep-clone an element with a fresh id (same-slide duplicates must not share ids). */

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -546,7 +546,10 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   justify-content: center;
 }
 .ed-about {
-  width: 360px;
+  /* 440 rather than 360: release notes ride inline in the manifest now, and a
+     narrower box turned every bullet into two wrapped lines. The calc() keeps
+     a real gutter on a 375px phone, where the editor boots panels-collapsed. */
+  width: min(440px, calc(100vw - 24px));
   background: #fff;
   border-radius: 14px;
   box-shadow: 0 18px 50px rgb(15 23 36 / 0.3);
@@ -604,6 +607,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 }
 .ed-about-new { font-weight: 600; }
 .ed-about-notes {
+  align-self: stretch;
   color: var(--muted);
   background: var(--chrome);
   border-radius: 8px;
@@ -612,6 +616,47 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   max-height: 140px;
   overflow: auto;
 }
+
+/* ————— "an update is available" card —————
+   This is the one moment in the dialog where the user has a decision to make,
+   so it is grouped and given room instead of being five loose children of the
+   status block. Before: the notes sat in a 140px porthole inside a dialog that
+   was itself scrolling, and the three actions stacked vertically underneath —
+   so a five-bullet changelog read as one line plus two scrollbars. */
+.ed-about-update {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-inline-start: 3px solid #FF9E8A;
+  border-radius: 10px;
+}
+.ed-about-release {
+  color: var(--ink-2);
+  background: var(--chrome);
+  border-radius: 8px;
+  padding: 9px 12px;
+  line-height: 1.5;
+  /* Its OWN scroll region, sized off the viewport. release.mjs caps the notes
+     at five bullets plus an "…and N more" line, which fits here whole at any
+     normal window height; anything longer scrolls HERE, not the whole dialog. */
+  max-height: min(300px, 42vh);
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+}
+.ed-about-release > div + div { margin-top: 5px; }
+/* hanging indent: a wrapped bullet lines up under its own text, not the marker */
+.ed-about-note {
+  padding-inline-start: 14px;
+  text-indent: -14px;
+}
+.ed-about-note::before { content: '•\00a0'; }
+.ed-about-more { color: var(--muted); font-style: italic; }
+/* wrap instead of stacking: three actions fit in one or two rows */
+.ed-about-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.ed-about-actions .ed-btn { max-width: 100%; }
 .ed-about-json {
   width: 100%;
   font: 11px/1.4 ui-monospace, Menlo, monospace;


### PR DESCRIPTION
## The problem

When the About dialog finds an update it shows the release notes inline — and
has nowhere to put them. Measured on the built shell at 1280×800, with the
notes `scripts/release.mjs` actually produces for v1.0.11 (the first five bold
CHANGELOG lead-ins plus `…and 13 more`):

| | before | after |
|---|---|---|
| notes box height | 140px, needs 209px | 219px, needs 219px |
| notes scroll to read? | **yes** | no |
| whole update block visible without scrolling the dialog? | **no** | yes |
| dialog width | 360px | 440px |

So: a 140px porthole inside a dialog that was itself scrolling. Two nested
scrollbars to read one decision. The cause is structural — the heading, the
notes and the three action controls were five loose children of
`.ed-about-status`, a column flex with `align-items: flex-start`, so the notes
were squeezed between a heading and a vertical stack of three buttons in a
dialog that also has to hold the two toggles, Document properties and the
licence fine print.

## What changed

- **One card.** `.ed-about-update` groups version → what changed → actions and
  stretches full width. That group is the decision unit, and it is what gets the
  room. The post-update ("Updated to v1.0.12 on disk") state uses the same card.
- **The notes are a real list.** `releaseNotes()` splits the plain-text notes
  per line and hangs the indent, so a wrapped bullet lines up under its own text
  instead of flush-left under the marker — at 320px that was most of them, and
  one item read as two. Still `textContent` per line, never `innerHTML`: the
  manifest is signed, but a signature says who wrote a string, not that it is
  safe to run.
- **Its own scroll region**, `max-height: min(300px, 42vh)` instead of a flat
  140px. release.mjs caps the notes at five bullets plus a tail, which now fits
  whole at any normal window height; anything longer scrolls *there*, not in the
  dialog.
- **Actions wrap** (`.ed-about-actions`) instead of stacking three deep.
- **Dialog widened** to `min(440px, calc(100vw - 24px))` — wide enough that most
  bullets stop wrapping, capped so a 375px phone keeps a 12px gutter (it had
  7.5px before).

`.ed-about { max-height: 88vh; overflow-y: auto }` is untouched, and
`.ed-about-status { flex-shrink: 0 }` stays for the reason recorded in the
comment above it.

## Verified in a real browser

Built `slides/dist-single/Bento_Slides.bento.html`, served it, and drove the
"update found" state with a temporary local stub in the `checkForUpdates()` call
site (reverted before the build that this PR contains) fed the exact notes
`releaseNotes()` emits for the v1.0.11 CHANGELOG section.

- **1280×800** — all six lines visible, `notes.scrollHeight === clientHeight`
  (no inner scroll), the whole card including both buttons sits above the fold
  of the dialog. Actions wrap onto two rows.
- **375×812 phone** — dialog 351px at x=12, no inner scroll, no horizontal page
  overflow (`documentElement.scrollWidth === clientWidth === 375`).
- **320×568** (below anything we claim to support) — degrades the way it should:
  the notes list gets its own scrollbar, still showing ~4½ bullets rather than
  the old porthole.
- **German** (longest button labels of the eight catalogs) — actions wrap, no
  overflow.
- **RTL** (`dir="rtl"` forced) — accent border, bullets and hanging indent all
  mirror correctly; the CSS uses `padding-inline-start` / `border-inline-start`.
- **No update available** (the common case) — the whole dialog now fits without
  scrolling at 800px tall, where before it did not.
- **Not regressed:** Version history with 20 seeded snapshots still scrolls in
  its own 320px list with the dialog itself not scrolling; the help overlay is
  unchanged at 700px and still scrolls; the auto-check and Offline toggles,
  Document properties and the fine print all render as before.

Gates: `tsc -b` clean, `npm run build:single`, `node scripts/shell-gate.mjs …`
passes, `node scripts/build-i18n.mjs --check` current (no new UI strings — this
is layout only, so all eight catalogs are untouched).

## Deliberately not done

- **No new strings**, and no re-wording of the update copy. The complaint was
  space, and every new string is eight catalogs of churn.
- **Did not split the dialog into a fixed head + scrolling body.** The dialog
  scrolling as one unit is fine once the notes stop competing for the same
  pixels, and a sticky head would cost more vertical room than it returns on a
  phone.
- **Did not touch the About dialog's other sections.** They only benefit from
  the extra 80px of width.
- Noticed but out of scope: `editor.ts` still tells the user their work
  auto-saves and to "restore earlier versions from About → Version history" —
  Version history moved to the Save dropdown, so that hint points at the wrong
  place.
