### PR TITLE
docs: tk is on main, and a pack republish can regress the shipped shell

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -173,6 +173,33 @@ node scripts/publish-site.mjs "packs: fix the Korean plural forms"
 signed hash, if an indexed pack is missing, or if packs are staged with no
 index at all — an unsigned pack must never reach the CDN.
 
+**Between releases, re-emit only the packs you mean to change.** Packs are keyed
+on the ENGLISH SOURCE STRING, so a pack rebuilt from `main` is keyed to `main` —
+not to the shell people are actually running. Rename a UI string after a release
+and every rebuilt pack silently swaps the old key for the new one, while the
+shipped shell still asks for the old. The pack verifies, installs, and drops
+that string to English in every language at once.
+
+This is not hypothetical: adding Turkmen on 2026-08-01 rebuilt all 22 packs, and
+the diff against the published set was exactly one key per pack — `#168` had
+renamed "restore earlier versions from **About** → Version history" to
+"**Save** → Version history". Publishing the rebuilt set would have regressed
+that string across 21 languages in exchange for adding one.
+
+So the safe republish is surgical: copy in only the pack(s) that changed, leave
+the rest byte-identical, and re-sign the index over all of them (the index pins
+each pack's own sha256, so a mixed set is fine). Confirm it before pushing:
+
+```sh
+node scripts/publish-site.mjs --dry "packs: …"   # change set must be ONLY what you intend
+```
+
+Check which key the LIVE shell actually uses before assuming a rename is safe —
+inflate the `bento-rt` payload of the published shell and grep for the string.
+A pack added this way carries the newer key and lacks the older one, so its own
+first release shows that one string in English until the shell catches up. That
+is the right trade for a NEW language and the wrong one for an existing pack.
+
 ### Testing the pack UI locally
 
 Point a shell at a local pack channel with the `bento-packs-url` localStorage

--- a/docs/i18n-packs.md
+++ b/docs/i18n-packs.md
@@ -434,7 +434,7 @@ but not yet on `main` — do not describe it as shipped.
 - [x] Removing a file's LAST pack now actually sticks — #96
 - [x] Hebrew (he) — the first RTL language — #100, completed and its four
       directional arrows flipped for RTL in #111
-- [x] **22 packs — 21 on `main`, `tk` on *branch* `turkmen-lang-translation`**
+- [x] **22 packs, all on `main`**
       — #102–#120 added nineteen in one batch (`id` and `ms` share #109),
       joining `he` and the original `ko`; Turkmen followed. With the 9 bundled
       catalogs that is 31 languages:


### PR DESCRIPTION
Two related doc fixes, both from publishing Turkmen today.

## 1. The pack status line was self-contradicting

`docs/i18n-packs.md` still read *"22 packs — 21 on `main`, `tk` on **branch** `turkmen-lang-translation`"*. Accurate when written, stale the moment #164 merged. It is the checklist people read to know what has shipped.

## 2. A pack republish between releases can regress translations

This one cost real work to find and is worth writing down.

**Packs are keyed on the English source string**, so a pack rebuilt from `main` is keyed to `main` — not to the shell people are actually running. Rename a UI string after a release and every rebuilt pack silently swaps the old key for the new one, while the shipped shell still asks for the old. The pack verifies, installs, and drops that string to English **in every language at once**.

Not hypothetical. Rebuilding all 22 packs to add Turkmen produced a diff against the published set of exactly **one key per pack** — #168 had renamed `About → Version history` to `Save → Version history`. I confirmed the live 1.0.11 shell still asks for the old key by inflating its `bento-rt` payload. Publishing the rebuilt set would have **regressed one string across 21 languages in order to add one language**.

What shipped instead: `tk` only, with the other 21 left byte-identical, and the index re-signed over all 22 (the index pins each pack's own sha256, so a mixed set is fine). `publish-site.mjs --dry` confirmed the change set was exactly two files.

The runbook now says: re-emit only the packs you mean to change, check which key the live shell uses before assuming a rename is safe, and dry-run the publish. It also records the accepted trade — a newly added pack carries the newer key and shows that one string in English until the shell catches up, which is right for a **new** language and wrong for an existing one.

Docs only.