### PR TITLE
fix(slides): preserve embedded fonts on paste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
         # file carrying a script tag.
         run: node scripts/test-preview.ts
 
+      - name: Clipboard embedded-font rig
+        run: |
+          slides/node_modules/.bin/esbuild scripts/test-clipboard.ts --bundle --platform=node --format=esm --outfile="$RUNNER_TEMP/test-clipboard.mjs"
+          node "$RUNNER_TEMP/test-clipboard.mjs"
+
       - name: CRDT convergence rig
         # 40 seeds locally; deeper on CI where the seconds are free.
         run: SEEDS=300 node scripts/test-sync.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ pre-1.0.
   the adjacent slides mounted while moving between them; morph transitions
   were unaffected.
 
+- **Copy and paste keeps embedded typefaces intact.** Pasting elements or
+  slides into another deck now carries the fonts they actually use — and only
+  those — remapping a colliding font asset without replacing the recipient's
+  bytes, so the pasted text keeps its face immediately.
+
 ## [1.0.12] — 2026-08-01
 
 - **A laser pointer while you present.** Press **L** in the slideshow and the

--- a/scripts/test-clipboard.ts
+++ b/scripts/test-clipboard.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Clipboard transport is plain JSON, so this regression rig runs without a DOM.
+
+import { insertElements, insertSlides, parseClip, serializeElements, serializeSlides } from '../slides/src/editor/clipboard.ts'
+import { defaultText, newDoc, type BentoDoc } from '../slides/src/model.ts'
+
+let checks = 0
+let failures = 0
+
+function ok(condition: boolean, message: string) {
+  checks++
+  if (condition) console.log(`  ✓ ${message}`)
+  else {
+    failures++
+    console.error(`  ✗ ${message}`)
+  }
+}
+
+function sourceDoc(): BentoDoc {
+  const doc = newDoc()
+  doc.assets = { 'font-acme': 'data:font/woff2;base64,U09VUkNF', unused: 'data:font/woff2;base64,VU5VU0VE' }
+  doc.fonts = [
+    { family: 'Acme', asset: 'font-acme' },
+    { family: 'Unused', asset: 'unused' },
+  ]
+  doc.slides[0].elements = [defaultText({ id: 'text-acme', html: 'A', fontFamily: "'Acme', sans-serif" })]
+  return doc
+}
+
+function targetDoc(): BentoDoc {
+  const doc = newDoc()
+  doc.assets = { 'font-acme': 'data:font/woff2;base64,VEFSR0VU' }
+  return doc
+}
+
+function remappedFont(doc: BentoDoc) {
+  return doc.fonts?.find((font) => font.family === 'Acme')
+}
+
+console.log('\nelement clipboard')
+{
+  const source = sourceDoc()
+  const payload = parseClip(serializeElements(source.slides[0].elements, source))!
+  ok(payload.fonts?.length === 1 && payload.fonts[0].family === 'Acme', 'copies only the embedded face used by pasted elements')
+  ok(payload.assets?.['font-acme'] === source.assets!['font-acme'], 'copies bytes for an embedded element font')
+
+  const target = targetDoc()
+  insertElements(payload, target, target.slides[0])
+  const font = remappedFont(target)
+  ok(font?.asset !== 'font-acme', 'remaps a colliding font asset for pasted elements')
+  ok(target.assets!['font-acme'] === 'data:font/woff2;base64,VEFSR0VU', 'keeps target asset bytes on collision')
+  ok(font != null && target.assets![font.asset] === source.assets!['font-acme'], 'pasted element font points at its source bytes')
+}
+
+console.log('\nslide clipboard')
+{
+  const source = sourceDoc()
+  const payload = parseClip(serializeSlides(source.slides, source))!
+  ok(payload.fonts?.length === 1 && payload.fonts[0].family === 'Acme', 'copies only the embedded face used by pasted slides')
+  ok(payload.assets?.['font-acme'] === source.assets!['font-acme'], 'copies bytes for an embedded slide font')
+
+  const target = targetDoc()
+  insertSlides(payload, target, 1)
+  const font = remappedFont(target)
+  ok(font?.asset !== 'font-acme', 'remaps a colliding font asset for pasted slides')
+  ok(target.assets!['font-acme'] === 'data:font/woff2;base64,VEFSR0VU', 'keeps target slide asset bytes on collision')
+  ok(font != null && target.assets![font.asset] === source.assets!['font-acme'], 'pasted slide font points at its source bytes')
+}
+
+console.log(`\n${checks - failures}/${checks} checks passed`)
+if (failures) process.exit(1)

--- a/slides/src/editor/clipboard.ts
+++ b/slides/src/editor/clipboard.ts
@@ -9,8 +9,9 @@
 // pixels and typefaces along; asset-key collisions with different content are
 // remapped so nothing clobbers the target deck.
 
-import type { BentoDoc, Slide, SlideElement } from '../model'
+import type { BentoDoc, Slide, SlideElement, TextElement } from '../model'
 import { uid } from '../model'
+import { firstFamily } from '../fonts'
 
 export interface ClipPayload {
   __bento: 'clip'
@@ -32,28 +33,42 @@ function assetKeysOf(els: SlideElement[]): Set<string> {
   return keys
 }
 
-function collectAssets(els: SlideElement[], doc: BentoDoc): Record<string, string> {
+function fontsFor(els: SlideElement[], doc: BentoDoc): NonNullable<BentoDoc['fonts']> {
+  const families = new Set(
+    els
+      .filter((el): el is TextElement => el.type === 'text')
+      .map((el) => firstFamily(el.fontFamily)),
+  )
+  return (doc.fonts ?? []).filter((font) => families.has(firstFamily(font.family)))
+}
+
+function collectAssets(els: SlideElement[], fonts: NonNullable<BentoDoc['fonts']>, doc: BentoDoc): Record<string, string> {
   const out: Record<string, string> = {}
-  for (const k of assetKeysOf(els)) if (doc.assets?.[k] != null) out[k] = doc.assets[k]
+  const keys = assetKeysOf(els)
+  for (const font of fonts) keys.add(font.asset)
+  for (const k of keys) if (doc.assets?.[k] != null) out[k] = doc.assets[k]
   return out
 }
 
 export function serializeElements(els: SlideElement[], doc: BentoDoc): string {
+  const fonts = fontsFor(els, doc)
   const payload: ClipPayload = {
     __bento: 'clip', kind: 'elements',
     elements: JSON.parse(JSON.stringify(els)),
-    assets: collectAssets(els, doc),
+    assets: collectAssets(els, fonts, doc),
+    fonts,
   }
   return JSON.stringify(payload)
 }
 
 export function serializeSlides(slides: Slide[], doc: BentoDoc): string {
   const els = slides.flatMap((s) => s.elements)
+  const fonts = fontsFor(els, doc)
   const payload: ClipPayload = {
     __bento: 'clip', kind: 'slides',
     slides: JSON.parse(JSON.stringify(slides)),
-    assets: collectAssets(els, doc),
-    fonts: doc.fonts, // carry typefaces so pasted slides keep their look
+    assets: collectAssets(els, fonts, doc),
+    fonts,
   }
   return JSON.stringify(payload)
 }
@@ -75,6 +90,16 @@ function mergeAssets(payload: ClipPayload, doc: BentoDoc): Map<string, string> {
   return remap
 }
 
+/** Merge embedded-font records after their asset keys have been remapped. */
+function mergeFonts(payload: ClipPayload, doc: BentoDoc, remap: Map<string, string>) {
+  if (!payload.fonts?.length) return
+  doc.fonts = doc.fonts ?? []
+  for (const source of payload.fonts) {
+    if (doc.fonts.some((font) => font.family === source.family)) continue
+    doc.fonts.push({ ...source, asset: remap.get(source.asset) ?? source.asset })
+  }
+}
+
 function rewriteRefs(els: SlideElement[], remap: Map<string, string>) {
   if (!remap.size) return
   for (const el of els) {
@@ -89,6 +114,7 @@ function rewriteRefs(els: SlideElement[], remap: Map<string, string>) {
 /** Insert pasted elements onto a slide with fresh ids, nudged so they're visible. */
 export function insertElements(payload: ClipPayload, doc: BentoDoc, slide: Slide): SlideElement[] {
   const remap = mergeAssets(payload, doc)
+  mergeFonts(payload, doc, remap)
   const els: SlideElement[] = (payload.elements ?? []).map((e) => ({
     ...(JSON.parse(JSON.stringify(e)) as SlideElement),
     id: uid(e.type[0]),
@@ -102,10 +128,7 @@ export function insertElements(payload: ClipPayload, doc: BentoDoc, slide: Slide
 /** Insert pasted slides at `at` with fresh slide ids; merge assets + fonts. */
 export function insertSlides(payload: ClipPayload, doc: BentoDoc, at: number): Slide[] {
   const remap = mergeAssets(payload, doc)
-  if (payload.fonts?.length) {
-    doc.fonts = doc.fonts ?? []
-    for (const f of payload.fonts) if (!doc.fonts.some((g) => g.family === f.family)) doc.fonts.push(f)
-  }
+  mergeFonts(payload, doc, remap)
   const slides: Slide[] = (payload.slides ?? []).map((s) => {
     const copy = JSON.parse(JSON.stringify(s)) as Slide
     copy.id = uid('slide')

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -25,6 +25,7 @@ import { borderPoint, boxCenter, lineEndpoints, setLineEndpoints, sideMidpoint }
 import { ICONS } from '../icons'
 import { t, setLocale, locale, localeChoices, LOCALE_CHOICES, applyDirection, isRtl } from '../i18n'
 import { availablePacks, fetchPack, markFileSaved, packCoverage, packsInFile, stageForFile, unstageFromFile } from '../packs'
+import { injectFonts } from '../fonts'
 import { appConfig } from '../../../kernel/src/app.ts'
 import { disconnectOnline, joinFromDoc, mintCollab, mintInvite, onlineTransport, rotateKeys, sharingOn, startSharing, stopSharing } from '../sync/online'
 
@@ -1895,6 +1896,7 @@ export class Editor {
         ev.preventDefault()
         let added: SlideElement[] = []
         this.store.commit(() => { added = insertElements(clip, this.store.doc, this.store.slide) })
+        if (clip.fonts?.length) injectFonts(this.store.doc)
         this.store.select(added.map((e) => e.id))
         this.toast(added.length === 1 ? t('Pasted 1 item') : t('Pasted {n} items', { n: added.length }))
         return
@@ -1904,6 +1906,7 @@ export class Editor {
         const at = this.store.currentIndex + 1
         let made: Slide[] = []
         this.store.commit(() => { made = insertSlides(clip, this.store.doc, at) }, 'slides')
+        if (clip.fonts?.length) injectFonts(this.store.doc)
         this.rebuildSidebar()
         this.store.goTo(at)
         this.toast(made.length === 1 ? t('Pasted 1 slide') : t('Pasted {n} slides', { n: made.length }))


### PR DESCRIPTION
## Summary

- Preserve embedded fonts when copying selected elements or slides between decks.
- Remap colliding font asset keys and register pasted faces in the open target deck.
- Add a regression rig for element and slide clipboard paths.

## Root cause

Clipboard payloads either omitted embedded font metadata entirely or included a font record without its asset bytes. A target deck could therefore fall back to a system font or resolve a same-named asset key to unrelated bytes.

## Validation

- Typecheck and production single-file build succeeded.
- Clipboard embedded-font rig: 10 of 10 checks passed.
- Preview rig: 18 of 18 checks passed.
- Splice conformance gate passed.
