### PR TITLE
Fix: Restore fade, slide and zoom transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: Fade, slide, and zoom transitions animate again.** Present mode now keeps
+  the adjacent slides mounted while moving between them; morph transitions
+  were unaffected.
+
 ## [1.0.12] — 2026-08-01
 
 - **A laser pointer while you present.** Press **L** in the slideshow and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,10 +579,12 @@ names provisional.
 4. **Never let a literal `</script>` into the bundle** — `save.ts` builds it by
    concatenation; the data block JSON escapes `<`.
 5. Reveal's `.reveal-viewport` paints white; the present overlay CSS overrides it black.
-6. **svg-element CSS must be scoped** (`render.ts scopeCss`) — svg `<style>` applies
+6. **Reveal uses `distance < viewDistance`** — `1` mounts only the current section.
+   Keep it at least `2` so fade, slide, and zoom have adjacent sections to animate.
+7. **svg-element CSS must be scoped** (`render.ts scopeCss`) — svg `<style>` applies
    document-wide, so one diagram's animation/dim rules would leak into every other
    svg on the page (CSS animations with fill modes even beat later static rules).
-7. Tiny text labels make unusable click targets when scaled down — interactive
+8. Tiny text labels make unusable click targets when scaled down — interactive
    controls get padded transparent `link` overlay rects, not links on the text itself.
 
 - **Compressed shell (Phase 1)**: `scripts/postbuild-compress.mjs` (runs in

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -470,8 +470,9 @@ export function startPresentation(
       : false,
     // touch is handled by our own swipe logic below (state-aware + ends exit)
     touch: false,
-    // heavy decks: paint only the neighbourhood of the current slide
-    viewDistance: 1,
+    // Reveal uses distance < viewDistance; 2 is the minimum that keeps adjacent
+    // sections mounted so fade/slide/zoom transitions can animate.
+    viewDistance: 2,
     keyboardCondition: null,
     plugins: [],
   })


### PR DESCRIPTION
**What & why**
Resolves issue #176. Fade, slide and zoom transitions do not work. This is because Reveal’s viewDistance option is set to 1. This causes the slide needed for the transition to be unloaded instantly, preventing Reveal’s CSS transition from completing.
[Before PR.bento.html](https://github.com/user-attachments/files/30620892/Before.PR.bento.html)
[After PR.bento.html](https://github.com/user-attachments/files/30620897/After.PR.bento.html)

**How I verified it**
- Ran the full `npm run build:single` pipeline manually: TypeScript typecheck, single-file Vite build, and post-build compression.
- Ran `node scripts/shell-gate.mjs slides/dist-single/Bento_Slides.bento.html`.
- Browser-tested fade, slide, zoom, and morph transitions; all behaved as expected with no console errors.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/`
- [x] New UI strings added to every catalog in `slides/src/i18n/`
- [x] Document format changes are additive and backward-compatible
- [x] Did not bump the version or cut a release (maintainers sign releases)