### PR TITLE
publish: an unchanged mirror must not skip the GitHub release

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,13 +62,34 @@ verify the manifest signature against the public key embedded in every shell.
    ```sh
    git worktree add /tmp/rel vX.Y.Z --detach
    ```
-3. `node scripts/release.mjs` — builds, signs, assembles `./site/`
+3. **Push the tag now, before publishing.** The GitHub release is created *for*
+   a tag, so the tag must exist on the remote before step 5 can run — publishing
+   first leaves the site live with no release, which is what happened cutting
+   v1.0.12:
+
+   ```sh
+   git push origin vX.Y.Z
+   ```
+
+   Do NOT use `git push origin main --tags`: it also pushes every local tag,
+   including scratch ones (a `backup/…` tag from a history rewrite escaped this
+   way and had to be deleted from the remote).
+
+4. `node scripts/release.mjs` — builds, signs, assembles `./site/`
    (CNAME, landing page, live demo, download, signed manifest, language packs
    + their signed index).
-4. Publish `./site/` to the public site repo — one step:
+5. Publish `./site/` to the public site repo — one step:
 
    ```sh
    node scripts/publish-site.mjs "release vX.Y.Z"
+   ```
+
+   **From a `/tmp` build worktree, set the destination explicitly.** The script
+   resolves `../bento-site` relative to the repo root, so from `/tmp/rel` it
+   looks for `/private/tmp/bento-site` and stops:
+
+   ```sh
+   BENTO_SITE_DIR=~/devel/bento-site node scripts/publish-site.mjs "release vX.Y.Z"
    ```
 
    This mirrors the assembled `site/` tree into `../bento-site` (or
@@ -91,7 +112,7 @@ verify the manifest signature against the public key embedded in every shell.
    live **guestbook daemon** onto the freshly-published shell as a best-effort
    final step (see below) — no separate command needed.
 
-5. **The GitHub release is created for you** by `publish-site.mjs` — it makes
+6. **The GitHub release is created for you** by `publish-site.mjs` — it makes
    the release for the tag, attaches
    `site/releases/slides/Bento_Slides.bento.html`, and takes the notes from
    this version's CHANGELOG section (so the two can't drift). It is idempotent:
@@ -103,17 +124,6 @@ verify the manifest signature against the public key embedded in every shell.
    command to run. This used to be a manual step, and it was silently missed
    for v1.0.10 — the site was live and self-updating while the repo showed no
    release at all. Documentation didn't prevent that, so the check now does.
-6. **Push the tag.** `main` itself is usually already on the remote — merging
-   PRs through `gh` pushes as it goes — so the tag is the only ref outstanding:
-
-   ```sh
-   git push origin vX.Y.Z
-   ```
-
-   Do NOT use `git push origin main --tags`: it also pushes every local tag,
-   including scratch ones (a `backup/…` tag from a history rewrite escaped this
-   way and had to be deleted from the remote).
-
 7. **Verify against the LIVE channel, not the local build.** These are the
    things no local gate can prove, and some are only exercisable once published:
 

--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -120,10 +120,19 @@ if (dry) { console.log('\n(dry run — the itemized list above is the pending ch
 // ---- commit + push ---------------------------------------------------------
 run('git', ['-C', dest, 'add', '-A'])
 const status = capture('git', ['-C', dest, 'status', '--porcelain'])
-if (!status) { console.log('✓ nothing changed — bento-site already up to date'); process.exit(0) }
 
-run('git', ['-C', dest, 'commit', '-q', '-m', message])
-run('git', ['-C', dest, 'push', '-q', 'origin', 'HEAD'])
+// An unchanged mirror must NOT end the run. Publishing has two halves — mirror
+// the site, then create the GitHub release — and they can fail independently.
+// v1.0.12 mirrored and pushed, then `gh release create` failed because the tag
+// was not on the remote yet; re-running was supposed to repair that, and could
+// not, because this exited here first. The documented "idempotent, safe to
+// re-run" property was false in exactly the case anyone would rely on it.
+if (!status) {
+  console.log('✓ site unchanged — bento-site already up to date')
+} else {
+  run('git', ['-C', dest, 'commit', '-q', '-m', message])
+  run('git', ['-C', dest, 'push', '-q', 'origin', 'HEAD'])
+}
 const head = capture('git', ['-C', dest, 'rev-parse', '--short', 'HEAD'])
 const ver = (() => {
   try {
@@ -159,10 +168,20 @@ const ghAvailable = (() => {
   catch { return false }
 })()
 
+// The GitHub release is created FOR a tag, so the tag must already be on the
+// remote. `git push origin vX.Y.Z` comes BEFORE this, not after — the runbook
+// used to say otherwise and v1.0.12 hit it.
+const tagOnRemote = (() => {
+  try { return capture('git', ['ls-remote', '--tags', 'origin', tag]).trim().length > 0 }
+  catch { return false }
+})()
+
 if (ver === '?') {
   console.warn('⚠ could not read the published version — skipping the GitHub release step')
 } else if (!ghAvailable) {
   die(`site is published, but gh is unavailable or unauthenticated — the GitHub release for ${tag} was NOT created.\n  Fix: gh auth login, then:  gh release create ${tag} ${releaseShell} --title ${releaseTitle} --notes-file <notes>`)
+} else if (!tagOnRemote) {
+  die(`site is published, but ${tag} is not on the remote — the GitHub release cannot be created for a tag that does not exist there.\n  Fix:  git push origin ${tag}\n  then re-run this script; it is safe to re-run.`)
 } else {
   const exists = (() => {
     try { capture('gh', ['release', 'view', tag], { stdio: ['ignore', 'pipe', 'pipe'] }); return true }


### PR DESCRIPTION
Two defects that cutting v1.0.12 exposed — one in the script, one in the runbook I wrote this morning.

## The script: re-running couldn't repair a half-finished publish

Publishing has two halves — mirror the site, then create the GitHub release — and they fail independently.

v1.0.12 mirrored and pushed successfully, then `gh release create` failed because the tag wasn't on the remote yet. Re-running should have repaired that. It couldn't: with the mirror now a no-op, the script hit `✓ nothing changed` and called `process.exit(0)` **before** the release step.

So the documented *"idempotent: re-running publish is always safe"* property was false in precisely the situation where you'd depend on it. I had to create the release by hand.

Now the unchanged branch falls through instead of exiting, and a missing remote tag is caught up front with the fix printed:

```
site is published, but v1.0.12 is not on the remote — the GitHub release
cannot be created for a tag that does not exist there.
  Fix:  git push origin v1.0.12
  then re-run this script; it is safe to re-run.
```

## The runbook: the tag was pushed too late

It said publish first, push the tag afterwards. That can't work — a GitHub release is created **for** a tag, so the tag must exist on the remote before publish runs. Pushing is now **step 3**, before the build, and the old step 6 that repeated it is gone.

## And a contradiction I introduced

Step 2 says build from a clean worktree at `/tmp/rel`. `publish-site.mjs` resolves `../bento-site` relative to the repo root — so from `/tmp` it looks for `/private/tmp/bento-site` and stops. Both instructions landed in the same PR (#153) and contradicted each other. `BENTO_SITE_DIR` is now documented in step 5.

---

That's the third defect found in this script by using it, after the silent notes fallback (#158) and the bare release title (#159). All three were invisible until a release actually went through them.