### PR TITLE
update: release notes cover every version the reader skipped

### DIFF
--- a/kernel/src/update.ts
+++ b/kernel/src/update.ts
@@ -83,6 +83,13 @@ export interface ReleaseInfo {
   /** absolute URL of the release shell */
   url: string
   notes?: string
+  /**
+   * Per-version lead-ins, newest first, e.g. { '1.0.13': ['…'], '1.0.12': ['…'] }.
+   * Lets a client show exactly the versions it skipped rather than only the
+   * newest. ADDITIVE — `notes` remains the string every already-shipped file
+   * reads, because their update code is frozen and cannot learn this field.
+   */
+  notesFrom?: Record<string, string[]>
   at?: string
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -77,28 +77,76 @@ const key = opt('key', null)
  * so the whole changelog section would be a needless payload. Bold lead-ins
  * only — the headline of each entry — with the full text a link away.
  */
-function releaseNotes() {
-  try {
-    const cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8')
-    const start = cl.indexOf(`## [${version}]`)
-    if (start < 0) return null
-    const next = cl.indexOf('\n## [', start + 1)
-    const body = cl.slice(cl.indexOf('\n', start) + 1, next > 0 ? next : undefined)
-    // the bold lead-in of each bullet: "- **Something changed.** detail…"
-    const heads = [...body.matchAll(/^- \*\*(.+?)\*\*/gms)].map((m) => m[1].replace(/\s+/g, ' ').trim())
-    if (!heads.length) return null
-    const MAX = 5
-    const shown = heads.slice(0, MAX).map((h) => `• ${h}`)
-    if (heads.length > MAX) shown.push(`…and ${heads.length - MAX} more`)
-    return shown.join('\n')
-  } catch {
-    return null // notes are a nicety; never fail a release over them
-  }
+function changelogSections() {
+  // Every released section, newest first: [{ version, heads }]
+  const cl = readFileSync(join(root, 'CHANGELOG.md'), 'utf8')
+  const out = []
+  const re = /^## \[(\d+\.\d+\.\d+)\][^\n]*$/gm
+  const marks = [...cl.matchAll(re)]
+  marks.forEach((m, i) => {
+    const body = cl.slice(m.index + m[0].length, i + 1 < marks.length ? marks[i + 1].index : undefined)
+    const heads = [...body.matchAll(/^- \*\*(.+?)\*\*/gms)].map((h) => h[1].replace(/\s+/g, ' ').trim())
+    if (heads.length) out.push({ version: m[1], heads })
+  })
+  return out
 }
 
-// Sign the manifest against the staged bytes.
-const notes = releaseNotes()
-if (notes) console.log(`  notes   ${notes.split('\n').length} line(s) from CHANGELOG`)
+const cmpVer = (a, b) => {
+  const pa = a.split('.').map(Number), pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  return 0
+}
+
+/**
+ * Release notes for the manifest, in two forms — because shipped files are
+ * FROZEN CODE and can only read what they were written to read.
+ *
+ * `notes` (string) is what every existing file reads: `notes?: string`,
+ * rendered with textContent. It cannot be made reader-aware after the fact, so
+ * it SPANS the last few releases rather than only this one. Releases land days
+ * apart; someone on 1.0.11 who updates to 1.0.13 would otherwise never see
+ * what 1.0.12 contained, because the manifest only ever described the newest
+ * version. A reader who is merely one version behind sees a little they have
+ * seen before — the cheaper of the two errors.
+ *
+ * `notesFrom` (object, version → lead-ins) is for clients new enough to filter
+ * it against their own APP_VERSION and show exactly the versions they skipped.
+ * Purely additive: an older file ignores the field entirely.
+ */
+function releaseNotesString(sections) {
+  const SPAN = 3   // this release plus the two before it
+  const recent = sections.filter((s) => cmpVer(s.version, version) <= 0).slice(0, SPAN)
+  if (!recent.length) return null
+  const lines = []
+  let total = 0
+  const MAX = 6
+  for (const sec of recent) {
+    for (const h of sec.heads) {
+      if (total >= MAX) break
+      lines.push(`• ${h}${sec.version === version ? '' : `  (${sec.version})`}`)
+      total++
+    }
+    if (total >= MAX) break
+  }
+  const all = recent.reduce((n, s) => n + s.heads.length, 0)
+  if (all > total) lines.push(`…and ${all - total} more`)
+  return lines.join('\n')
+}
+
+function releaseNotesByVersion(sections) {
+  const SPAN = 6
+  const out = {}
+  for (const sec of sections.filter((s) => cmpVer(s.version, version) <= 0).slice(0, SPAN)) {
+    out[sec.version] = sec.heads.slice(0, 8)
+  }
+  return Object.keys(out).length ? out : null
+}
+
+let sections = []
+try { sections = changelogSections() } catch { /* notes are a nicety; never fail a release over them */ }
+const notes = sections.length ? releaseNotesString(sections) : null
+const notesFrom = sections.length ? releaseNotesByVersion(sections) : null
+if (notes) console.log(`  notes   ${notes.split('\n').length} line(s), spanning ${Object.keys(notesFrom ?? {}).slice(0, 3).join(', ')}`)
 else console.log('  notes   none — no CHANGELOG entry for this version')
 const signArgs = [
   join(root, 'scripts/sign-release.mjs'),
@@ -106,6 +154,7 @@ const signArgs = [
   '--out', join(site, 'releases/slides/manifest.json'),
 ]
 if (notes) signArgs.push('--notes', notes)
+if (notesFrom) signArgs.push('--notes-from', JSON.stringify(notesFrom))
 if (key) signArgs.push('--key', key)
 execFileSync('node', signArgs, { stdio: 'inherit' })
 

--- a/scripts/sign-release.mjs
+++ b/scripts/sign-release.mjs
@@ -6,7 +6,7 @@
 //
 //   node scripts/sign-release.mjs slides/dist-single/Bento_Slides.bento.html \
 //     [--url https://bento.page/releases/slides/Bento_Slides.bento.html] \
-//     [--version 0.2.0] [--notes "What changed"] [--key ~/.bento/release-key.json] \
+//     [--version 0.2.0] [--notes "What changed"] [--notes-from '{"1.0.13":[…]}'] [--key ~/.bento/release-key.json] \
 //     [--out manifest.json]
 //
 // The manifest is { payload: "<json string>", sig: "<base64>" } — the
@@ -44,6 +44,15 @@ const opt = (name, fallback) => {
 const version = opt('version', JSON.parse(readFileSync(join(root, 'slides/package.json'), 'utf8')).version)
 const url = opt('url', 'https://bento.page/releases/slides/Bento_Slides.bento.html')
 const notes = opt('notes', '')
+// Per-version lead-ins, so a client can show exactly the versions it skipped.
+// ADDITIVE: `notes` stays a plain string for every already-shipped file, whose
+// update code is frozen and reads only that.
+const notesFromRaw = opt('notes-from', '')
+let notesFrom = null
+if (notesFromRaw) {
+  try { notesFrom = JSON.parse(notesFromRaw) }
+  catch { console.error('sign-release: --notes-from is not valid JSON'); process.exit(1) }
+}
 const keyPath = opt('key', defaultKeyPath())
 const outPath = opt('out', join(dirname(shellPath), 'manifest.json'))
 
@@ -56,6 +65,7 @@ const payload = JSON.stringify({
   sha256,
   url,
   ...(notes ? { notes } : {}),
+  ...(notesFrom ? { notesFrom } : {}),
   at: new Date().toISOString(),
 })
 

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -11,7 +11,7 @@ import {
   instantiateLayout, isLightBg, layoutElementIds, newDocId, parseDoc, readableInk, syncLinkedChart, uid,
   type ChartElement, type ShapeKind, type Slide, type SlideElement, type TableElement,
 } from '../model'
-import { APP_VERSION, applyUpdate, applyUpdateInPlace, autoCheckEnabled, canUpdateInPlace, checkForUpdates, offlineEnabled, setAutoCheck, setOffline } from '../update'
+import { APP_VERSION, applyUpdate, applyUpdateInPlace, autoCheckEnabled, canUpdateInPlace, checkForUpdates, compareVersions, offlineEnabled, setAutoCheck, setOffline } from '../update'
 import { CHART_PRESETS } from '../charts'
 import { renderSlide, renderThumbnail } from '../render'
 import { SlideCanvas } from './canvas'
@@ -2670,7 +2670,22 @@ export class Editor {
         const line = div('ed-about-new')
         line.textContent = t('Version {v} is available.', { v: release.version })
         card.appendChild(line)
-        if (release.notes) card.appendChild(releaseNotes(release.notes))
+        // Prefer per-version notes filtered to what THIS file actually skipped:
+        // releases land days apart, so a reader two versions behind should see
+        // both, and a reader one version behind should not see the older one
+        // again. `notes` is the fallback for a manifest that predates the field.
+        const skipped = release.notesFrom
+          ? Object.keys(release.notesFrom)
+              .filter((v) => compareVersions(v, APP_VERSION) > 0)
+              .sort((a, b) => compareVersions(b, a))
+          : []
+        if (skipped.length) {
+          const lines = skipped.flatMap((v) =>
+            (release.notesFrom![v] ?? []).map((h) => (skipped.length > 1 ? `• ${h}  (${v})` : `• ${h}`)))
+          card.appendChild(releaseNotes(lines.join('\n')))
+        } else if (release.notes) {
+          card.appendChild(releaseNotes(release.notes))
+        }
         const actions = div('ed-about-actions')
         const fail = (err: any) => { status.textContent = t('Update failed: {m}', { m: String(err?.message ?? err) }) }
         const done = () => {


### PR DESCRIPTION
The manifest described only the newest version, so a file two releases behind saw nothing about the one in between. With 1.0.12 live barely an hour before 1.0.13 became necessary, almost nobody updating would learn what 1.0.12 contained.

## Two halves, because shipped files are frozen code

An existing deck reads `notes?: string` and renders it with `textContent`. **No richer field can ever reach it.** That constraint shapes the whole fix:

| field | shape | who it serves |
|---|---|---|
| `notes` | string *(unchanged)* | **every already-shipped file.** Now spans the last 3 releases, capped at 6 lead-ins, tagging older entries with their version |
| `notesFrom` | `{ version: [lead-ins] }` *(new)* | clients from 1.0.13 on — filtered against their own `APP_VERSION`, showing **exactly** the versions they skipped |

`notes` is reader-*agnostic* by necessity, so a reader one version behind sees one line they've seen before. That's the cheaper of the two errors. `notesFrom` is reader-*aware* and purely additive — an older file ignores it.

## What a frozen 1.0.11 file will now see

```
• Fix: Fade, slide and zoom transitions animate again.
• Fix: embedded fonts survive copy-paste.
• A laser pointer while you present.  (1.0.12)
• Decks thumbnail properly on iPhone and iPad.  (1.0.12)
• Count-up numbers keep their thousands separators.  (1.0.12)
• The tab tells you which file you are editing.  (1.0.12)
…and 27 more
```

No CHANGELOG duplication — history stays accurate, and the 1.0.12 section is untouched.

## Verified end to end

- `notesFrom` rides **inside the signed payload**, so it's as tamper-proof as the shell hash
- signature still verifies with the field present
- a client reading `.notes` still gets a string

## Sizing

The string is capped because **every shipped file fetches this manifest at launch**. `notesFrom` keeps 6 versions × 8 lead-ins (~1.5 KB), which is where the fidelity lives.

## One thing it deliberately does not do

It does **not** retroactively fix the 1.0.11 → 1.0.13 jump via `notesFrom` — those files can't read it. The spanning string is what serves them, and that's precisely why the string changed rather than only the structure.

`tsc` · packed-table check · language coverage · shell-gate — all pass.