### PR TITLE
Release 1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,25 @@ pre-1.0.
 
 ## [Unreleased]
 
-- **Fix: Fade, slide, and zoom transitions animate again.** Present mode now keeps
-  the adjacent slides mounted while moving between them; morph transitions
-  were unaffected.
+## [1.0.13] — 2026-08-02
 
-- **Copy and paste keeps embedded typefaces intact.** Pasting elements or
-  slides into another deck now carries the fonts they actually use — and only
-  those — remapping a colliding font asset without replacing the recipient's
-  bytes, so the pasted text keeps its face immediately.
+- **Fix: fade, slide and zoom transitions animate again.** They had been
+  instant cuts. Reveal only mounts slides within `viewDistance`, which was set
+  to 1 — so the slide being moved *to* was not in the page, and a CSS
+  transition had nothing to animate into. Morph was unaffected, because that
+  is Bento's own animation rather than Reveal's. Found and fixed by James
+  London.
+
+- **Copy and paste keeps embedded typefaces intact.** Pasting elements into
+  another deck used to lose their embedded font entirely, and pasting slides
+  carried every face in the source deck while omitting the bytes they pointed
+  at. Both now carry exactly the faces in use, and a name collision keeps the
+  recipient's own bytes. Fixed by Kushida.
+
+- **Update notes now cover every version you skipped.** The About dialog
+  described only the newest release, so upgrading across two versions told you
+  nothing about the one in between — and 1.0.12 was barely a day old when this
+  release became necessary. It now spans the releases you missed.
 
 ## [1.0.12] — 2026-08-01
 

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Two contributed fixes and one of ours.

## What ships

**Fade, slide and zoom transitions animate again** — they had been instant cuts. Reveal's `viewDistance` was `1`, so the slide being moved *to* was never mounted and the CSS transition had nothing to animate into. Morph was unaffected, being Bento's own animation. Broken since `c6ca5a4`, long before 1.0.11. Found and fixed by **James London** (#177).

**Copy and paste keeps embedded typefaces** — elements carried no fonts at all; slides carried every face in the source deck while omitting the bytes they pointed at. Now exactly the faces in use, with collisions keeping the recipient's bytes. Fixed by **Kushida** (#175), with a rig that reports 3/10 against the unfixed code and 10/10 with it.

**Update notes span the versions you skipped** (#185) — needed immediately here: 1.0.12 was a day old, so almost everyone updating would otherwise never learn what it contained.

## The notes a frozen 1.0.11 file will see

```
• Fix: fade, slide and zoom transitions animate again.
• Copy and paste keeps embedded typefaces intact.
• Update notes now cover every version you skipped.
• A laser pointer while you present.  (1.0.12)
• Decks thumbnail properly on iPhone and iPad.  (1.0.12)
• Count-up numbers keep their thousands separators.  (1.0.12)
…and 28 more
```

That's the point of #185 — the 1.0.12 headlines reach people who skipped straight past it, with no CHANGELOG duplication.

## Gates

`tsc` · language coverage (8 core + 22 packs, all 100%) · packed-table check · shell-gate.