### PR TITLE
release: restore the guestbook landing page, and stop deleting what a build didn't produce

### DIFF
--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -111,7 +111,22 @@ if (existsSync(packIndex)) {
 }
 
 // ---- mirror site/ → dest (authoritative; never touches dest/.git) ----------
+// NEVER DELETE WHAT THIS BUILD DID NOT PRODUCE.
+//
+// The mirror is authoritative, which is right for generated output — but the
+// guestbook DECK is generated only when the gitignored epoch file exists
+// (working/guestbook-live/), and releases are built from a clean checkout of
+// the tag where it never does. Without this exclusion, every such release
+// silently deletes the published deck. That is how the v1.0.12 publish removed
+// the live guestbook from bento-site.
+//
+// The landing page is now written unconditionally (release.mjs), so only the
+// deck needs protecting, and only when this build has none to offer.
 const rsyncFlags = ['-a', '--delete', '--exclude', '.git']
+if (!existsSync(join(site, 'guestbook.bento.html'))) {
+  rsyncFlags.push('--exclude', 'guestbook.bento.html')
+  console.log('• no guestbook deck in this build (no local epoch) — leaving the published one untouched')
+}
 if (dry) rsyncFlags.push('-n', '-v', '--itemize-changes')
 console.log(`• ${dry ? 'DRY-RUN ' : ''}mirroring ${site}/ → ${dest}/`)
 run('rsync', [...rsyncFlags, `${site}/`, `${dest}/`])

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -224,7 +224,18 @@ execFileSync('node', [join(root, 'scripts/build-qr-page.mjs'), join(site, 'q/ind
 // loaded as a live, editable template deck.
 execFileSync('node', [join(root, 'scripts/build-announcement-deck.mjs'), join(site, 'hello.bento.html')], { stdio: 'inherit' })
 
-// The Guestbook (U2) — ships only once an epoch has been minted into
+// The guestbook LANDING page is an authored source (site-src/guestbook.html),
+// tracked in this repo, so it ships on every release. It used to be written
+// only inside the `existsSync(guestbook)` branch below, which depends on a
+// GITIGNORED epoch file — so a release built from a clean checkout of the tag
+// (which is what RELEASING.md now tells you to do) produced a site/ with no
+// guestbook/index.html, and publish-site.mjs mirrors with `rsync --delete`.
+// That deleted the live landing page during the v1.0.12 publish. The deck below
+// genuinely needs the epoch; this page never did.
+mkdirSync(join(site, 'guestbook'), { recursive: true })
+cpSync(join(root, 'site-src/guestbook.html'), join(site, 'guestbook/index.html'))
+
+// The Guestbook DECK (U2) — ships only once an epoch has been minted into
 // working/guestbook-live/ (scripts/build-guestbook.mjs). Kill switch:
 // delete that file and re-release.
 const guestbook = join(root, 'working/guestbook-live/guestbook.bento.html')
@@ -243,8 +254,6 @@ if (existsSync(guestbook)) {
   const reshelled = spliceDoc(freshShell, gbDoc)
   writeFileSync(guestbook, reshelled) // keep the working epoch file on the fresh shell too
   cpSync(guestbook, join(site, 'guestbook.bento.html'))
-  mkdirSync(join(site, 'guestbook'), { recursive: true })
-  cpSync(join(root, 'site-src/guestbook.html'), join(site, 'guestbook/index.html'))
   console.log(`guestbook: re-shelled current epoch onto the fresh shell (room ${gbDoc.collab?.room?.split('/').pop() ?? '?'})`)
 } else {
   console.log('guestbook: not armed (working/guestbook-live/ empty) — skipped')


### PR DESCRIPTION
Fixes #190, reported by @7jameslondon — whose diagnosis was exactly right.

## What happened

The v1.0.12 publish deleted `guestbook/index.html` from `bento-site`, and https://bento.page/guestbook/ has returned 404 since. The path from the landing page — *"Join the public Guestbook"* — has been broken for a day.

## Why

`site-src/guestbook.html` is **tracked in this repo**, but `release.mjs` only copied it to `site/guestbook/index.html` *inside* the `existsSync(working/guestbook-live/…)` branch. `working/` is gitignored, so it doesn't exist in the clean tag checkout that `RELEASING.md` now tells you to build from. The assembled `site/` had no guestbook page, and `publish-site.mjs` mirrors with `rsync --delete`.

**I introduced the build-from-a-clean-checkout rule in #153.** This is its second consequence — the first was the guestbook re-seed warning, which I looked at earlier today and explained away as harmless. It was the same missing directory, and I didn't connect them.

## Two changes

**The landing page ships unconditionally.** It never needed the epoch file; only the deck does.

**`publish-site.mjs` will not delete a guestbook deck this build didn't produce.** An authoritative mirror is right for generated output, but a clean-checkout release generates no deck, and deleting the published one on that basis is wrong. That static deck is the fallback for when the Cloudflare daemon isn't serving from KV — precisely when losing it would matter.

## Verified under the failing condition

Built from a checkout with no `working/`:

```
guestbook: not armed (working/guestbook-live/ empty) — skipped
/private/tmp/gbfix/site/guestbook/index.html          ← emitted anyway
```

Dry-run publish:

```
• no guestbook deck in this build (no local epoch) — leaving the published one untouched
cd+++++++ guestbook/
>f+++++++ guestbook/index.html
```

The page is **added back**, the deck is **left alone**, and no guestbook path is deleted.

I also checked whether other outputs have the same shape — `existsSync` gates exactly one block in `release.mjs`, so the blast radius is just this.
