### PR TITLE
Let fx.enter run for elements new to a morph slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Entrance animations work on morph slides.** Setting an element to sweep in
+  from the right on a morph slide gave you a small upward nudge instead: the
+  morph supplied one fixed entrance for everything new on the slide, and
+  `fx.enter`'s direction, duration and order were discarded. An element that is
+  new to a morph slide now enters the way you asked. One that morphs in from
+  the previous slide still ignores `fx.enter` — it is already in motion, and an
+  entrance would fight the tween — and elements with no `fx.enter` keep the
+  automatic fade-and-rise, so nothing changes in a deck that did not ask for it.
+
 - **`window.bento.validate()` — see what the runtime silently swallows.**
   Almost everything that goes wrong in a generated deck fails quietly: a typo'd
   property is ignored, a `dash-march` loop on a solid stroke animates nothing,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -296,12 +296,16 @@ without them — and elements should carry the full field set shown.
   must be unique **within** a slide. Plain shared `id` still works and is still
   the simplest thing when you control both slides.
 - **Entrances**: `fx: { enter: "fade-up", order: 0 }` — equal `order` =
-  simultaneous. **Entrance staggers do not run on a morph arrival** — a
-  morphing element is already in motion and an entrance tween would fight it.
-  Count-ups are different: on a morph arrival they run for elements that have
-  **no** morph partner on the previous slide (a new statistic counts; one that
-  flew in already showing its number does not restart from zero). So a headline
-  number on a morph slide is fine as long as it is new to that slide.
+  simultaneous. On a **morph arrival** the rule is per element, and it turns on
+  whether that element has a morph partner on the previous slide:
+  - **has a partner** → it morphs, and `fx.enter` and `fx.countUp` are both
+    skipped. It is already in motion and already showing its number; an
+    entrance would fight the tween and a count-up would restart from zero.
+  - **no partner** → it is new to the slide, so both run normally. Without an
+    `fx.enter` it gets an automatic fade-and-rise so nothing ever just pops in.
+
+  So a headline number, or a panel that sweeps in from the right, is fine on a
+  morph slide — just make sure it is new to that slide.
 - **Ken-burns**: `fx: { ambient: "kenburns", ken: { dir: "drift|out|in",
   scale: 1.08, duration: 20 } }` — `drift` loops, `out`/`in` settle once on
   slide entry. For full-bleed photos: image at 0,0,1280,720 + a scrim rect

--- a/scripts/test-validate.ts
+++ b/scripts/test-validate.ts
@@ -89,10 +89,19 @@ const broken: BentoDoc = {
     {
       id: 's2', name: 'two', background: '#FFF', transition: 'morph', notes: '', elements: [
         // entrance on a morph arrival; also an unknown fx key
-        { id: 'e', type: 'text', x: 96, y: 100, w: 400, h: 80, rotation: 0, opacity: 1,
+        // an entrance on an element that MORPHS in (it shares 'dup' with the
+        // previous slide) — already in motion, so fx.enter is skipped. Also
+        // carries an unknown fx key.
+        { id: 'dup', type: 'text', x: 96, y: 100, w: 400, h: 80, rotation: 0, opacity: 1,
           html: 'x', fontSize: 20, fontFamily: 'system-ui', fontWeight: 400,
           color: '#111', align: 'left', valign: 'middle', lineHeight: 1.2,
           fx: { enter: 'fade-up', wobble: true } } as any,
+        // an entrance on an element that is NEW to this slide — nothing to
+        // fight, so it runs and must NOT be reported
+        { id: 'fresh', type: 'text', x: 96, y: 220, w: 400, h: 80, rotation: 0, opacity: 1,
+          html: 'y', fontSize: 20, fontFamily: 'system-ui', fontWeight: 400,
+          color: '#111', align: 'left', valign: 'middle', lineHeight: 1.2,
+          fx: { enter: 'slide-left' } } as any,
         // a chart with options charts-lite does not implement
         { id: 'c', type: 'chart', x: 600, y: 100, w: 400, h: 300, rotation: 0, opacity: 1,
           preset: 'bar',
@@ -120,6 +129,10 @@ ok(r.findings.some((f) => f.code === 'chart-key-ignored' && f.path === 'option.s
   'a label on a bar series is reported (it is read for pie only)')
 ok(r.findings.some((f) => f.code === 'unknown-key' && f.path === 'fx.wobble'),
   'an unknown key nested under fx is reported with its path')
+ok(!r.findings.some((f) => f.code === 'overridden-enter-fx' && f.element === 'fresh'),
+  'an entrance on an element NEW to a morph slide is not reported — it runs')
+ok(r.findings.some((f) => f.code === 'overridden-enter-fx' && f.element === 'dup'),
+  'an entrance on an element that morphs in IS reported')
 
 // ------------------------------------------------- chart false-positive guard
 // The shape the starter deck's own charts use. Every key here IS implemented,

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1077,6 +1077,36 @@ function fxNodes(slide: Slide, section: HTMLElement): Array<[SlideElement, HTMLE
   return pairs
 }
 
+type EnterKind = NonNullable<NonNullable<SlideElement['fx']>['enter']>
+
+/**
+ * The starting frame, duration and ease an `fx.enter` kind implies.
+ *
+ * Shared by the two places an element can enter — the plain entrance runner and
+ * the morph path, which gives elements with no morph partner an entrance of
+ * their own. Keeping ONE table means a new direction cannot work on ordinary
+ * slides and quietly do nothing on morph arrivals.
+ *
+ * fade-* nudge 16px; slide-* sweep 120px in from an edge (slide-left starts to
+ * the RIGHT and travels leftward). x needs the x transform channel in anim.ts.
+ */
+function enterSpec(kind: EnterKind, enterDur?: number) {
+  const D = 120
+  const from = { opacity: 0, x: 0, y: 0 }
+  if (kind === 'fade-up') from.y = 16
+  else if (kind === 'fade-down') from.y = -16
+  else if (kind === 'slide-left') from.x = D
+  else if (kind === 'slide-right') from.x = -D
+  else if (kind === 'slide-up') from.y = D
+  else if (kind === 'slide-down') from.y = -D
+  const sliding = kind.startsWith('slide-')
+  return {
+    from,
+    duration: enterDur ?? (sliding ? 0.75 : 0.55),
+    ease: sliding ? 'power3.out' : 'power2.out',
+  }
+}
+
 /** Staggered entrance animations + count-ups for the incoming slide. */
 function runEnterFx(slide: Slide, section: HTMLElement) {
   const entering = fxNodes(slide, section)
@@ -1092,27 +1122,17 @@ function runEnterFx(slide: Slide, section: HTMLElement) {
     // node would fight it and freeze the dot off its path
     if (fx.loop?.type === 'motion-path') return
     if (fx.enter) {
-      // directional entrances: fade-* nudge 16px, slide-* sweep 120px from an
-      // edge. x needs the x transform channel (added to anim.ts).
-      const D = 120
-      const from = { opacity: 0, x: 0, y: 0 }
-      if (fx.enter === 'fade-up') from.y = 16
-      else if (fx.enter === 'fade-down') from.y = -16
-      else if (fx.enter === 'slide-left') from.x = D // starts to the right, slides in leftward
-      else if (fx.enter === 'slide-right') from.x = -D
-      else if (fx.enter === 'slide-up') from.y = D
-      else if (fx.enter === 'slide-down') from.y = -D
-      const slide = fx.enter.startsWith('slide-')
+      const spec = enterSpec(fx.enter, fx.enterDur)
       anim.fromTo(
         node,
-        from,
+        spec.from,
         {
           opacity: el.opacity,
           x: 0,
           y: 0,
-          duration: fx.enterDur ?? (slide ? 0.75 : 0.55),
+          duration: spec.duration,
           delay: 0.12 + Math.min(step, 24) * 0.05,
-          ease: slide ? 'power3.out' : 'power2.out',
+          ease: spec.ease,
         },
       )
     }
@@ -1546,12 +1566,25 @@ function runMorph(
       // motion-path loops own the transform — entrance limited to opacity
       const m = toModel.get(n.dataset.flipId!)
       const owns = m?.fx?.loop?.type === 'motion-path'
+      // An explicit fx.enter WINS over the default rise. This element has no
+      // morph partner — it is new to this slide, so there is no morph tween for
+      // an entrance to fight, and the author named a direction. Elements with a
+      // partner are excluded above and keep morphing; elements with no fx.enter
+      // keep the default, so no existing deck changes unless it asked to.
+      const kind = owns ? undefined : m?.fx?.enter
+      const spec = kind ? enterSpec(kind, m?.fx?.enterDur) : null
+      const step = m?.fx?.order ?? i
       anim.fromTo(n,
-        owns ? { opacity: 0 } : { opacity: 0, y: 14 },
+        spec ? { ...spec.from } : owns ? { opacity: 0 } : { opacity: 0, y: 14 },
         {
-          opacity, ...(owns ? {} : { y: 0 }), duration: 0.45,
-          delay: MORPH_DURATION * 0.4 + (spread * i) / entering.length,
-          ease: 'power2.out',
+          opacity,
+          ...(spec ? { x: 0, y: 0 } : owns ? {} : { y: 0 }),
+          duration: spec?.duration ?? 0.45,
+          // Both stagger from the same base — the morph is 40% done before
+          // anything new arrives, so the two motions read as one beat.
+          delay: MORPH_DURATION * 0.4 +
+            (spec ? Math.min(step, 24) * 0.05 : (spread * i) / entering.length),
+          ease: spec?.ease ?? 'power2.out',
         })
     })
     settleGuarantee(entering.map(([n]) => {

--- a/slides/src/validate.ts
+++ b/slides/src/validate.ts
@@ -204,9 +204,13 @@ export function validateDoc(doc: BentoDoc, opts: ValidateOpts = {}): ValidateRes
       }
 
       // effects that will not run -------------------------------------------
-      if (el.fx?.enter && isMorphArrival) {
+      // Only a MORPHING element loses its entrance: it is already travelling
+      // from its previous-slide frame, and an entrance tween would fight that.
+      // An element with no partner on the previous slide runs its fx.enter
+      // normally, so there is nothing to report.
+      if (el.fx?.enter && isMorphArrival && partners.has(mk)) {
         add({ ...at, code: 'overridden-enter-fx', severity: 'warning', path: 'fx.enter',
-          message: `On a morph arrival the morph supplies its own entrance — new elements fade and rise 14px — so fx.enter's direction, duration and order are all ignored here.` })
+          message: `This element morphs in from the previous slide, so it is already in motion and fx.enter is skipped. Give it a morph key that is new to this slide if you want it to enter instead.` })
       }
       if (el.fx?.enter && el.fx?.loop?.type === 'motion-path') {
         add({ ...at, code: 'entrance-on-motion-path', severity: 'warning', path: 'fx.enter',


### PR DESCRIPTION
> Replaces #196, which GitHub closed when its base branch (`validate-api`) was
> deleted on merging #195. Same commit, rebased onto `main`.

Setting an element to sweep in from the right on a morph slide gave you a small
upward nudge instead.

Not because entrances were dead there — that was my first reading and it was
wrong. `runMorph` already gives every unpartnered incoming element an entrance
of its own. The problem is that the entrance is **fixed**: `fx.enter`'s
direction, `enterDur` and `order` were all discarded in favour of a 14px rise.

## The split

The same one the count-up fix used, applied per element:

| on a morph arrival | behaviour |
|---|---|
| **has a morph partner** | travelling from its previous-slide frame, so an entrance would fight the morph — `fx.enter` stays skipped |
| **no partner** | new to this slide, nothing to fight, and the author named a direction — it runs, honouring `enterDur` and staggering by `fx.order` |
| **no partner, no `fx.enter`** | keeps the automatic fade-and-rise |

## Blast radius

Exactly the decks that already wrote `fx.enter` on a morph arrival — where it
currently does nothing. **A deck that never asked for an entrance cannot
change.**

Measured in present mode against the manual animation clock:

| element | starts at | |
|---|---|---|
| `carried` — has a partner | opacity 1, x −36 | morphs from its old position, entrance skipped |
| `plain` — new, no `fx` | opacity 0, y 14 | **unchanged** — the regression control |
| `left` — new, `slide-left` | opacity 0, **x 120** | sweeps in from the right (was y 14) |
| `down` — new, `slide-down` | opacity 0, **y −120** | drops in |

## Also

The direction table now lives in one place (`enterSpec`) rather than being
duplicated across the two entrance paths, so a new direction cannot work on
ordinary slides and quietly do nothing on morph arrivals.

`validate()`'s check narrows to match — only a *partnered* element loses its
entrance — and the rig asserts both directions: a new element is not reported,
a morphing one is. 21 checks.

Closes the last of the entrance half of #194's neighbourhood; `h: "auto"` and
layout containers are still open there.
