### PR TITLE
publish-site: refuse to republish an older release over a newer one

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -112,6 +112,19 @@ verify the manifest signature against the public key embedded in every shell.
    live **guestbook daemon** onto the freshly-published shell as a best-effort
    final step (see below) — no separate command needed.
 
+   > **Publish site-only changes from a tree whose `site/releases/` is current.**
+   > `site/` is local staging, and releases are assembled from a clean checkout
+   > of the tag (step 3) — so an everyday working tree can hold a months-old
+   > manifest while bento.page serves something far newer. Mirroring that would
+   > republish the older signed shell over the newer one and break the update
+   > channel for every deck already in the world.
+   >
+   > `publish-site.mjs` refuses this: it compares the staged manifest version
+   > against the live one and dies if the staged one is older. If you hit that,
+   > you are publishing from the wrong tree — use the release checkout, or
+   > refresh `site/releases/` from the live site first. `--allow-release-downgrade`
+   > exists only for a deliberate rollback.
+
 6. **The GitHub release is created for you** by `publish-site.mjs` — it makes
    the release for the tag, attaches
    `site/releases/slides/Bento_Slides.bento.html`, and takes the notes from

--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -110,6 +110,66 @@ if (existsSync(packIndex)) {
   die(`language packs are staged at ${packsDir.slice(site.length + 1)} but packs.json is MISSING — an unsigned pack must never be published.\n  Fix: node scripts/sign-packs.mjs ${packsDir} --out ${packIndex}`)
 }
 
+// ---- the release channel may never go BACKWARDS ----------------------------
+//
+// `site/` is local staging, and the thing that fills its `releases/` is a
+// DIFFERENT process — release.mjs, run from a clean checkout of the tag, per
+// RELEASING.md. So an everyday working tree can easily hold a months-old
+// manifest while the live site serves something much newer. Mirroring that
+// with --delete republishes the old signed shell and manifest on top of the
+// new one.
+//
+// That is not a cosmetic regression. Every shipped deck checks this manifest
+// and enforces version monotonicity, so a downgrade takes the whole update
+// channel offline for files already in the world, and hands new visitors an
+// older app. It is the same lesson as the guestbook deletion above — "this
+// build didn't produce it" is not evidence it should be replaced — applied to
+// the one artifact nobody can repair from their side.
+//
+// Caught before it happened: a publish from a tree staged at 1.0.11 while
+// bento.page served 1.0.13.
+const manifestVersion = (file) => {
+  try {
+    const outer = JSON.parse(readFileSync(file, 'utf8'))
+    return JSON.parse(outer.payload).version ?? null
+  } catch { return null }
+}
+/** semver-ish compare, matching kernel/src/update.ts compareVersions */
+const cmpVersion = (a, b) => {
+  const pa = String(a).split('.').map(Number)
+  const pb = String(b).split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0)
+    if (d) return d < 0 ? -1 : 1
+  }
+  return 0
+}
+{
+  const localManifest = join(site, 'releases/slides/manifest.json')
+  const liveManifest = join(dest, 'releases/slides/manifest.json')
+  const local = manifestVersion(localManifest)
+  const live = manifestVersion(liveManifest)
+  if (local && live && cmpVersion(local, live) < 0) {
+    if (!args.includes('--allow-release-downgrade')) {
+      die(
+        `this tree would PUBLISH AN OLDER RELEASE than the one already live:\n` +
+        `    staged in site/ : ${local}\n` +
+        `    live on the site: ${live}\n` +
+        `  Every shipped deck checks this manifest and enforces version\n` +
+        `  monotonicity, so publishing ${local} over ${live} breaks updates for\n` +
+        `  files already in the world.\n\n` +
+        `  Releases are assembled from a clean checkout of the tag (RELEASING.md),\n` +
+        `  so this working tree's site/ is simply stale — it is not the release.\n` +
+        `  Publish from the release checkout, or refresh site/releases/ from the\n` +
+        `  live tree first. Deliberate rollback: --allow-release-downgrade.`,
+      )
+    }
+    console.log(`⚠ publishing ${local} OVER live ${live} — downgrade allowed explicitly`)
+  } else if (local && live && cmpVersion(local, live) > 0) {
+    console.log(`• release channel: ${live} → ${local}`)
+  }
+}
+
 // ---- mirror site/ → dest (authoritative; never touches dest/.git) ----------
 // NEVER DELETE WHAT THIS BUILD DID NOT PRODUCE.
 //


### PR DESCRIPTION
Caught in the act while trying to publish the gallery font fix. A publish from my working tree would have mirrored a manifest staged at **1.0.11** over the **1.0.13** live on bento.page:

```
>f.st.... slides/Bento_Slides.bento.html
>f.st.... slides/manifest.json
```

Every shipped deck checks that manifest and enforces version monotonicity, so publishing 1.0.11 over 1.0.13 would take the update channel offline for files already in the world and hand new visitors an older app. Unlike a bad landing page, nobody downstream can repair it.

**The cause is structural.** `site/` is local staging, and the thing that fills its `releases/` is a *different* process — `release.mjs`, run from a clean checkout of the tag per RELEASING.md. So an everyday working tree legitimately holds an old manifest while the site serves something much newer. Nothing connected the two.

Same lesson as the guestbook deletion behind #190 — *"this build didn't produce it" is not evidence it should be replaced* — applied to the one artifact with no recovery path. The gallery shell-consistency gate happened to fire first this time, for an unrelated reason; had the gallery been in sync, the downgrade would have shipped.

Verified all four ways:

| staged | live | result |
|---|---|---|
| 1.0.11 | 1.0.13 | **blocked**, with the remedy spelled out |
| 1.0.14 | 1.0.13 | `• release channel: 1.0.13 → 1.0.14`, proceeds |
| 1.0.13 | 1.0.13 | silent, proceeds |
| 1.0.11 + `--allow-release-downgrade` | 1.0.13 | warns, proceeds |

RELEASING.md gains a note on publishing site-only changes from a tree whose `site/releases/` is current.