### PR TITLE
docs: settle the dash name, fix the app roster and the format field

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,45 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-08-02 — `bento/dash` is settled, and it stands for DAta SHeets
+
+**Keep `bento/dash`.** The name contracts **DA**ta **SH**eets — the two halves
+of the app, the typed data model and the grid. It is not short for "dashboard";
+a dashboard is something the app can produce, not what it is.
+
+Recorded because the 2026-07-24 naming entry justifies it as "spreadsheet +
+tables + dashboards", which leads with the output surface and reads as
+mis-scoped. That framing is what caused the name to be re-opened and argued at
+length today. Don't re-open it without a new argument.
+
+This blocked the first commit that writes a `FORMAT` constant — PLATFORM §3
+puts the string into every saved file and there is no server to migrate
+anything — and it is now unblocked.
+
+**Weighed and set aside** (collisions verified live, not recalled):
+
+- `cells` — best suite fit, but it sounds like Ex**cel**. A replacement that
+  echoes the incumbent's name reads as derivative of it.
+- `views` — genuinely dual (a SQL view *and* a visual view), but it names
+  *looking* when the app's own boundary rule is *reckoning* ("does it
+  recalculate → dash").
+- `measures` — the BI term of art, and the convergent pick of two independent
+  root analyses, but "bento measures" parses as a verb clause.
+- `base` — its retirement reason above has **inverted**: it was dropped partly
+  for reading as "database, which this platform does not have", and dash now
+  is one. Set aside as flat rather than wrong; reconsider only if `dash` ever
+  proves to mis-signal in the field.
+- `figures` parses as a verb clause; `grid` collides with "bento grid", an
+  established UI design-trend phrase; `rows` is rows.com, a live "AI Data
+  Analyst" product; `calc` is LibreOffice Calc, and is clipped besides.
+
+**Namespace was deliberately down-weighted.** PyPI `dash` is Plotly's dataviz
+framework and npm `dash` is the cryptocurrency, but the app never ships as a
+bare word — it is `bento/dash`, at `bento.page/dash`, in
+`Bento_Dash.bento.html`. That is the mitigation the 2026-07-24 entry already
+prescribes for the crowded Bento namespace: always carry the `bento/<app>`
+form and the descriptor.
+
 ## 2026-07-28 — Vault is a capability broker; identity is multi-user from commit one
 
 **Refines the 2026-07-27 vault entry rather than superseding it.** Three

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -47,8 +47,10 @@ checks) before any release.
 
 ## 3. Document identity & format
 
-- `doc.type` names the format (`bento/slides`; provisionally `bento/spaces`,
-  `bento/dash`) with an integer format version.
+- `doc.format` names the format (`bento/slides`, `bento/spaces`; `bento/dash`
+  to come) with an integer format version in `doc.version`. The field is
+  `format` — `slides/src/model.ts` exports `FORMAT = 'bento/slides'` and writes
+  it as `format`, and every reader keys off that.
 - **Formats are additive.** Every version opens files from every earlier
   version; unknown fields are preserved, not stripped. Breaking reads of old
   files is not an option — there is no server to migrate them.
@@ -210,7 +212,7 @@ the document model, the renderer, the editor UX, starter documents, panels.
 A new Bento app is on-platform when it:
 
 - [ ] builds to ONE self-contained HTML file passing the §2 conformance gate
-- [ ] declares `doc.type` + format version; opens its own older files
+- [ ] declares `doc.format` + `doc.version`; opens its own older files
 - [ ] mints and preserves `docId` per §3
 - [ ] self-saves (FSA + download) and autosaves per §4
 - [ ] supports the `bento/enc` envelope per §4 (or explicitly documents why not yet)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -5,12 +5,14 @@ guide matches the bento/slides shell of the same version. A deck's `#bento-doc`
 JSON is always the source of truth — if it was written by a newer shell it may
 carry features beyond this guide; unknown keys are ignored, never fatal.
 
-> **Bento is a suite.** Slides is the first app. **Docs** (`bento/docs`) and
-> **Sheets** (`bento/sheets`) follow, each shipping as its own self-contained
-> distributable — `Bento_Slides.bento.html`, `Bento_Docs.bento.html`,
-> `Bento_Sheets.bento.html` — with its own agent guide at
+> **Bento is a suite.** Slides is the first app and the only one shipping
+> today. **Spaces** (`bento/spaces`, notes) and **Dash** (`bento/dash`, data
+> and sheets) are in development, and a word processor is planned. Each ships
+> as its own self-contained distributable — `Bento_Slides.bento.html`,
+> `Bento_Spaces.bento.html`, and so on — with its own agent guide at
 > `bento.page/<app>/agents.md`. **This guide covers Slides only.** Before you
-> edit a file, check its `"format"` and use the matching guide.
+> edit a file, check its `"format"` field and use the matching guide; if the
+> format is one you have no guide for, don't guess at its shape.
 
 *Drop this file into your context (or point your harness at it) and you can
 author and edit Bento presentations directly. Also published at


### PR DESCRIPTION
Three documentation corrections, all found while scoping `bento/dash`.

## 1. Record what `dash` stands for

**DA**ta **SH**eets — the typed data model and the grid, the two halves of the
app. Not short for "dashboard"; a dashboard is something it can produce.

The only justification on file was the 2026-07-24 naming entry's *"spreadsheet
+ tables + dashboards — absorbs what would have been a separate database app"*,
which leads with the output surface and then admits it's absorbing a scope it
doesn't say. That framing is what caused the name to be re-opened and argued at
length today. The new entry records the alternatives and why each was set
aside, so the next person to wonder finds an answer instead of re-running the
analysis.

Two findings worth keeping regardless of the outcome, both verified live rather
than recalled:

- **`cells` sounds like Ex-CEL.** A replacement that echoes the incumbent's name
  reads as derivative of it. This killed the strongest alternative.
- **`rows` is [rows.com](https://rows.com)** — *"Rows — Your new AI Data
  Analyst… analyze data from 50+ sources. No code, SQL, or formulas."* A live
  competitor in the same category, with the same AI-authoring angle. (It was
  previously called *dashdash*.)

The entry also notes that `base`'s retirement reason has **inverted** — it was
dropped partly for reading as "database, which this platform does not have,"
and dash now is one — so if `dash` ever proves to mis-signal in the field,
that's where to look first.

## 2. The published app roster was wrong

`docs/agents.md` — live at `bento.page/agents.md`, the file every AI agent reads
first — announced **`bento/docs`** and **`bento/sheets`** as the apps that
follow. The naming entry says `docs` is *"unusable, being Apple's and
Google's"*, and the real roster is slides / spaces / dash / vault.

So the canonical statement of what Bento *is* advertised an app under a name
the decision log explicitly rules out, a second that isn't in the plan at all
(spreadsheets belong to dash), plus `Bento_Docs.bento.html` and
`Bento_Sheets.bento.html` as distributables and `bento.page/docs/agents.md` as a
guide URL — none of which will ever exist.

Now names the real roster, and stays deliberately vague past `spaces` and
`dash`, since only slides ships today.

## 3. `PLATFORM.md` names a field that doesn't exist

```
model.ts:353    format: typeof FORMAT
model.ts:1004   format: FORMAT,
model.ts:1005   version: FORMAT_VERSION,
```

PLATFORM.md said **`doc.type`** — in the identity section *and* in the new-app
checklist. `agents.md` had it right all along.

The checklist is what makes this worth fixing now rather than eventually: the
next new app is dash, and item two was about to teach the wrong field name to
the single reader who would act on it. Per PLATFORM's own rule — *"when this
doc and the code disagree, the code that shipped wins — fix the doc."*

**Left alone deliberately:** `DECISIONS.md:461` still says `doc.type` in
passing. The log is append-only, and that entry is about lowercase casing, not
field names — its point survives the error. Editing it would break the
convention for no gain.

---

Docs only — no code, no format change, no gates affected.
