### PR TITLE
Budget dash by bytes with consent, not by rows with a refusal

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,53 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-08-02 — dash budgets BYTES with consent, not rows with a refusal
+
+**Supersedes the hard stop proposed in the dash design doc §3.2** (refuse at
+1,000,000 rows or 25 MB, on the importer and every other write path). The two
+guards it sat on top of are unchanged and are not optional.
+
+**What stands, because the failure past the budget is SILENT.** Measured at a
+539 MB file: the `#bento-doc` element still holds exactly one child text node,
+of length **zero**. `textContent` returns `''` — a string, no throw — so the
+workbook opens EMPTY, and self-save then re-splices whatever is in memory over
+the user's file. Unrecoverable loss caused by a successful parse of nothing. So,
+from the first commit that can save:
+
+1. `parseDoc` returns a tagged result, never `null`. Only an **absent or empty**
+   block boots the starter document.
+2. **Refuse to serialize if the boot parse did not succeed** — a hard error
+   surface offering "Save an untouched copy" and "Copy document JSON", with the
+   editor and autosave disabled.
+
+Those two are what prevent the data loss. The row cap was belt-and-braces on
+top of them, and it costs precisely the users who know what they are doing.
+
+**What changes:**
+
+- **Budget in BYTES, not rows.** 1M × 12 is 65 MB; 1M × 2 is ~10 MB and
+  comfortable. A row cap refuses workable files and admits unworkable ones.
+  Excel's 1,048,576 is a *structural* limit users have learned; ours would be a
+  proxy for a quantity we can measure directly.
+- **Warn, then take informed consent — never refuse.** Past the ceiling, say
+  what will actually break, in this browser, with numbers.
+- **The threshold scales with `canWriteInPlace()`** (`kernel/src/save.ts:470`).
+  With the File System Access API a save is an in-place write; without it —
+  Safari, Firefox, every iOS browser — every ⌘S downloads the whole file to
+  `~/Downloads`, so the practical ceiling is far lower. One global constant
+  cannot express that.
+- **Import offers an alternative, not a no**: the first N rows, an aggregate, or
+  the whole thing with the warning accepted.
+
+**The target is unchanged at 100,000 rows × ~12 columns (~6 MB)** — where the
+file emails under attachment limits, downloads in a second, round-trips as JSON
+per PLATFORM §7, and the 2.5 s autosave rewrites it imperceptibly. It is a
+target, not a cap.
+
+Compute is not the constraint and is not close: hand-written columnar JS over
+typed arrays, zero dependencies, single-threaded, measured on **10,000,000
+rows** — scan-sum 5.9 ms, filter+sum 10.6 ms, two-dimension group-by 11.5 ms.
+
 ## 2026-08-02 — `bento/dash` is settled, and it stands for DAta SHeets
 
 **Keep `bento/dash`.** The name contracts **DA**ta **SH**eets — the two halves


### PR DESCRIPTION
Revises the scale rule in the dash design doc before any code depends on it.

## What it was

> Target 100,000 rows × ~12 columns. Warn from 250,000 rows. **Hard-stop the importer at 1,000,000 rows or 25 MB of document JSON**, and apply the same stop to any other write path.

## What it was protecting — this part is real

Past the budget the failure is **silent**. Measured at a 539 MB file: `#bento-doc` still holds exactly one child text node, of length **zero**. `textContent` returns `''` — a string, no throw — so the workbook opens EMPTY, and self-save then re-splices whatever is in memory over the user's file. Unrecoverable loss caused by a successful parse of nothing.

The guards against that are unchanged and not optional:

1. `parseDoc` returns a tagged result, never `null` — only an *absent or empty* block boots the starter
2. **Refuse to serialize if the boot parse didn't succeed** — hard error surface, editor and autosave disabled

Those are what prevent the data loss. The row cap was belt-and-braces on top, and it costs exactly the users who know what they're doing.

## Why the cap goes

**Rows are the wrong unit.** 1M × 12 is 65 MB; 1M × 2 is ~10 MB and comfortable. A row cap refuses workable files and admits unworkable ones. Excel's 1,048,576 is a *structural* limit people have learned; ours would be a proxy for a quantity we can measure directly — so measure it.

**The environment matters more than the data.** With the File System Access API a save is an in-place write. Without it — Safari, Firefox, every iOS browser — every ⌘S downloads the whole file to `~/Downloads`. The same 33 MB workbook is fine in Chrome and miserable in Safari, and `canWriteInPlace()` (`kernel/src/save.ts:470`) already reports which one we're in. One global constant can't express that.

## What replaces it

- Budget in **bytes**, checked before any write that grows the document
- Threshold **scales with `canWriteInPlace()`**
- Past the ceiling: **warn and take informed consent**, naming what will break in this browser, with numbers — never refuse
- Import offers an **alternative, not a no**: first N rows, an aggregate, or the whole thing with the warning accepted

The 100k × 12 target is unchanged — it's where the file still emails under attachment limits, downloads in a second, round-trips as JSON per PLATFORM §7, and autosaves imperceptibly. It is a **target, not a cap**.

For context, compute is nowhere near the constraint: hand-written columnar JS over typed arrays, zero dependencies, single-threaded, on **10,000,000 rows** — scan-sum 5.9 ms, filter+sum 10.6 ms, two-dimension group-by 11.5 ms.

Docs only. `working/dash-design.md` §3.2 is revised in place (gitignored, so not in this diff) so the doc and the log don't disagree.