### PR TITLE
sync: a property removal crashed every replica that received it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,15 @@ jobs:
           slides/node_modules/.bin/esbuild scripts/test-clipboard.ts --bundle --platform=node --format=esm --outfile="$RUNNER_TEMP/test-clipboard.mjs"
           node "$RUNNER_TEMP/test-clipboard.mjs"
 
+      - name: CRDT property-removal rig
+        # Removing a property travels as a `set` op with `v` ABSENT, and the
+        # receiving replica threw on it: JSON.stringify(undefined) is undefined,
+        # and a debug line sliced it. Live in shipped files. The convergence rig
+        # missed it through 300 seeds because its generator assigns properties
+        # and never removes one — a property-based rig only explores the
+        # mutations it was taught.
+        run: node scripts/test-crdt-delprop.ts
+
       - name: CRDT convergence rig
         # 40 seeds locally; deeper on CI where the seconds are free.
         run: SEEDS=300 node scripts/test-sync.ts

--- a/scripts/test-crdt-delprop.ts
+++ b/scripts/test-crdt-delprop.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// CRDT property-REMOVAL rig.
+//
+//   node scripts/test-crdt-delprop.ts
+//
+// WHAT THIS PROVES. Removing a property is an ordinary edit — the editor does
+// it in a dozen places (fill style → solid deletes `colorGradient`, "none"
+// deletes `textStroke`, Unlink deletes a chart's `source`, ⇧⌘G deletes
+// `groupId`) — and it travels as a `set` op whose `v` is ABSENT, which is how
+// the engine spells "delete the key".
+//
+// On the RECEIVING replica that threw:
+//
+//   TypeError: Cannot read properties of undefined (reading 'slice')
+//
+// `JSON.stringify(undefined)` is `undefined`, not `"undefined"`, and the debug
+// line sliced it. A template literal evaluates its expressions eagerly, so the
+// dbg() call being a no-op did not save it — every collaborator applying that
+// op crashed, live, in shipped files.
+//
+// The convergence rig never caught it in 300 seeds because its random mutations
+// assign properties and never REMOVE one. That is the lesson worth keeping: a
+// property-based rig only explores the mutations you taught it, so an operation
+// the UI performs and the generator does not is invisible no matter how many
+// seeds you run.
+
+import { SyncState } from '../slides/src/sync/crdt.ts'
+
+let failures = 0
+let checks = 0
+function ok(cond: boolean, msg: string) {
+  checks++
+  if (!cond) { failures++; console.log(`  FAIL  ${msg}`) }
+  else console.log(`  ok    ${msg}`)
+}
+
+const el = (extra: Record<string, unknown> = {}) => ({
+  id: 'e1', type: 'text', x: 0, y: 0, w: 100, h: 50, rotation: 0, opacity: 1,
+  html: 'hi', fontSize: 20, fontFamily: 'x', fontWeight: 400,
+  color: '#000', align: 'left', valign: 'top', lineHeight: 1.2, ...extra,
+})
+const doc = (els: unknown[]) => ({
+  format: 'bento/slides', version: '1', docId: 'd1', title: 't',
+  size: { width: 1280, height: 720 }, theme: { accent: '#000' }, assets: {}, fonts: null,
+  slides: [{ id: 's1', name: 'one', background: '#fff', transition: 'fade', notes: '', elements: els }],
+}) as any
+
+// Each of these is a real editor action that deletes a key.
+const REMOVALS: Array<[string, Record<string, unknown>]> = [
+  ['shadow (Shadow → none)', { shadow: { blur: 8, color: '#0003' } }],
+  ['colorGradient (Fill style → solid)', { colorGradient: { angle: 90, stops: [{ at: 0, color: '#f00' }] } }],
+  ['textStroke (Outline → none)', { textStroke: { width: 2, color: '#000' } }],
+  ['groupId (⇧⌘G ungroup)', { groupId: 'g1' }],
+  ['link (clear the jump target)', { link: 's2' }],
+]
+
+for (const [label, extra] of REMOVALS) {
+  const before = doc([el(extra)])
+  const after = doc([el()])
+
+  const author = new SyncState('alice')
+  author.adopt(before)
+  const ops = author.diff(before, after)
+
+  const setOps = ops.filter((o: any) => o.op === 'set')
+  ok(setOps.length > 0 && setOps.some((o: any) => o.v === undefined),
+    `${label}: travels as a set op with v absent`)
+
+  // The receiving replica is where it broke.
+  const peer = new SyncState('bob')
+  const target = doc([el(extra)])
+  peer.adopt(target)
+  let threw: string | null = null
+  try { peer.apply(target, ops as any) } catch (e: any) { threw = `${e.constructor.name}: ${e.message}` }
+
+  ok(threw === null, `${label}: a peer applies it without throwing${threw ? ` (got ${threw})` : ''}`)
+  const key = Object.keys(extra)[0]
+  ok(threw !== null || (target.slides[0].elements[0] as any)[key] === undefined,
+    `${label}: the property is actually gone on the peer`)
+}
+
+// The same op arriving for a node the peer has not seen yet parks in `pending`
+// and is replayed later — that path re-applies the op, so it must not throw either.
+{
+  const before = doc([el({ shadow: { blur: 4, color: '#000' } })])
+  const author = new SyncState('alice')
+  author.adopt(before)
+  const ops = author.diff(before, doc([el()]))
+  const peer = new SyncState('bob')
+  const empty = doc([])
+  peer.adopt(empty)
+  let threw: string | null = null
+  try { peer.apply(empty, ops as any) } catch (e: any) { threw = `${e.constructor.name}: ${e.message}` }
+  ok(threw === null, `a removal for an unknown node pends without throwing${threw ? ` (got ${threw})` : ''}`)
+}
+
+console.log(`\n${checks - failures}/${checks} checks passed`)
+if (failures) process.exit(1)

--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -733,7 +733,10 @@ export class SyncState {
       ;(this.pending[nodeId] ??= []).push(op)
       return
     }
-    dbg(nodeId, `set ${op.k}@${op.l},${op.a} APPLY ${JSON.stringify(op.v).slice(0, 40)}`)
+    // NB: v === undefined means "delete the key" (handled below), and
+    // JSON.stringify(undefined) is undefined — String() keeps this debug
+    // line from throwing on every property REMOVAL.
+    dbg(nodeId, `set ${op.k}@${op.l},${op.a} APPLY ${String(JSON.stringify(op.v)).slice(0, 40)}`)
     if (op.el && op.k === 'html') {
       const gen = this.txt[op.el]
       if (gen && cmpReg([op.l, op.a], gen.sd) < 0) {


### PR DESCRIPTION
**Live in shipped files, reachable from ordinary editing.**

Removing a property travels as a `set` op whose `v` is **absent** — that is how the engine spells "delete the key", handled explicitly ten lines further down. The debug line above it did `JSON.stringify(op.v).slice(0, 40)`, and `JSON.stringify(undefined)` is `undefined`, not `"undefined"`. So `applySet` threw:

```
TypeError: Cannot read properties of undefined (reading 'slice')
```

A template literal evaluates its expressions eagerly, so `dbg()` being a no-op unless `__dbgEl` is set did not save it. **The author was fine; every collaborator receiving the op crashed.**

## The trigger is not exotic

| action | deletes |
|---|---|
| Fill style → solid | `colorGradient` ([panels.ts:926](slides/src/editor/panels.ts:926)) |
| Outline → none | `textStroke` ([:994](slides/src/editor/panels.ts:994)) |
| Chart → Unlink | `source` ([:1213](slides/src/editor/panels.ts:1213)) |
| ⇧⌘G ungroup | `groupId` ([:1866](slides/src/editor/panels.ts:1866)) |
| clear a jump target | `link` |

Reproduced for all five against `origin/main` — all five throw, all five pass with the one-line fix.

## Why 300 seeds never caught it

`scripts/test-sync.ts` runs 45,368 checks and has been the safety net for this engine since M0 — CLAUDE.md records it catching 15+ ordering bugs. It never saw this one because **its generator assigns properties and never removes one**, so the op shape simply never occurred.

That's the part worth keeping: a property-based rig explores only the mutations you taught it. An operation the UI performs and the generator doesn't is invisible at any seed count. `scripts/test-crdt-delprop.ts` covers the shape directly — five real editor removals plus the pending/replay path — and **fails 11/16 against the shipped code**.

## Provenance

Found while mapping this engine onto `bento/spaces`, by an agent that then edited my worktree uncommitted. I verified the claim independently against `origin/main` before keeping the fix.
