### PR TITLE
Release 1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.15] — 2026-08-03
+
+- **Fix: one collaborator's edit could crash everyone else in the room.**
+  Removing a property from an element travels as an op the receiving side
+  could not read, and every other participant's editor threw on arrival. The
+  person making the edit saw nothing wrong at all.
+
+  Nothing exotic triggers it: ungrouping (⇧⌘G), switching a fill from gradient
+  back to solid, turning an outline off, unlinking a chart from its table, or
+  clearing a jump target. All five reproduced, all five fixed by one line.
+
+  The convergence rig never caught it because its generator only ever *assigns*
+  properties, so an op that removes one had simply never occurred in 45,000
+  checks. It generates removals now.
+
 - **"Save a copy…" and share exports remember their own folder.** The save
   picker used one identity for every kind of save, so it opened wherever you
   last put a view-only copy even when you were saving your working file.

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cut for the collab crash in #219.

Removing a property from an element travelled as an op every **other** participant's editor threw on, while the author saw nothing wrong. Ungroup (⇧⌘G), fill style back to solid, outline off, chart unlink and clearing a jump target all reach it — a shared room could be taken down by ordinary editing. It leads the changelog section and therefore the signed manifest notes.

Riding along, all merged and each with its own rig:

- topbar restore-order fix (#212)
- "Save a copy…" and share exports remember their own folder
- a deck opens where the browser refuses it storage
- the kernel work behind those: per-app autosave database with the data carried over (#211), preference storage that cannot take the app down (#205), save intent visible to a host (#213)

Signed notes preview:

```
• Fix: one collaborator's edit could crash everyone else in the room.
• "Save a copy…" and share exports remember their own folder.
• Fix: the topbar came back in the wrong order after the window narrowed and widened again.
• Fix: a deck opens where the browser refuses it storage.
• Pan the canvas by dragging, and past the slide's edges.  (1.0.14)
• Fit a text box to its text, in one click.  (1.0.14)
…and 8 more
```