### PR TITLE
release: clear our own superseded packs from the seeded tree

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -34,7 +34,7 @@
 // rebuild producing different bytes than what was signed.)
 
 import { execFileSync } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spliceDoc } from './guestbook-deck.mjs'
@@ -232,6 +232,20 @@ if (app.packs) {
   // what "Add language…" reads; nothing is trusted without it.
   // Both steps are no-ops until a pack catalog exists (docs/i18n-packs.md).
   const packsOut = join(site, 'releases/slides/packs')
+  // Seeding restored the PREVIOUS release's packs, and this build is about to
+  // write its own beside them — leaving two files claiming the same language,
+  // which sign-packs refuses outright ("two packs claim \"ar\""). Their whole
+  // job is to be superseded, so clear this app's older ones first. Nothing
+  // else in the seeded tree is touched: the point of seeding is to preserve
+  // what THIS release does not build, and a stale pack of our own is not that.
+  if (existsSync(packsOut)) {
+    let dropped = 0
+    for (const f of readdirSync(packsOut)) {
+      const m = /^bento-slides-(\d+\.\d+\.\d+)-.+\.pack\.json$/.exec(f)
+      if (m && m[1] !== version) { rmSync(join(packsOut, f)); dropped++ }
+    }
+    if (dropped) console.log(`• cleared ${dropped} superseded language pack(s) from the seeded tree`)
+  }
   execFileSync('node', [join(root, 'scripts/build-i18n.mjs'), '--packs', packsOut], { stdio: 'inherit' })
   const packArgs = [
     join(root, 'scripts/sign-packs.mjs'), packsOut,


### PR DESCRIPTION
Found cutting 1.0.15 — **the release refused to build at all**:

```
Error: two packs claim "ar":
  bento-slides-1.0.14-ar.pack.json and bento-slides-1.0.15-ar.pack.json
```

Seeding `site/` from the published tree (#216) is what stops a one-app release deleting another app's artifacts. It also restores the *previous* release's language packs, and the build then writes its own beside them — so the pack directory holds two files claiming every language.

That's the signer doing its job: a channel where two files answer to "ar" is precisely what it exists to prevent. The seeding just needs to be narrower.

Superseded packs **of the app being built** are the one thing in the seeded tree not worth preserving — being replaced is their whole purpose, and publish mirrors with `--delete`, so they were never going to survive the publish either. Everything else the seed restored is untouched.