### PR TITLE
publish: a superseded language pack is a replacement, not a deletion

### DIFF
--- a/scripts/publish-site.mjs
+++ b/scripts/publish-site.mjs
@@ -26,7 +26,7 @@ import { dirname, join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { gatePackIndex } from './sign-packs.mjs'
-import { walk, plannedDeletions, groupDeletions } from './site-inventory.mjs'
+import { walk, plannedDeletions, groupDeletions, supersededPacks } from './site-inventory.mjs'
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const site = join(root, 'site')
@@ -226,7 +226,17 @@ if (!existsSync(join(site, 'guestbook.bento.html'))) {
     // about what we are about to overwrite, so it is the last place to guess.
     die(`cannot inventory the published site at ${dest} — refusing to mirror over it.\n  ${e.message}`)
   }
-  const deletions = plannedDeletions(published, walk(site), excluded)
+  const stagedFiles = walk(site)
+  // A release retires its own previous language packs by design — their names
+  // carry the version. Excusing exactly those keeps the gate meaningful; if it
+  // fired on every release, --allow-deletions would become the habit and the
+  // one run with real deletions would look like all the others.
+  const superseded = supersededPacks(published, stagedFiles)
+  if (superseded.length) {
+    console.log(`• ${superseded.length} superseded language pack(s) replaced by this build — not counted as deletions`)
+  }
+  const deletions = plannedDeletions(published, stagedFiles, excluded)
+    .filter((p) => !superseded.includes(p))
 
   if (deletions.length) {
     if (!args.includes('--allow-deletions')) {

--- a/scripts/site-inventory.mjs
+++ b/scripts/site-inventory.mjs
@@ -41,6 +41,38 @@ export function plannedDeletions(published, staged, excluded = []) {
     .filter((p) => !excluded.some((ex) => p === ex || p.startsWith(`${ex}/`)))
 }
 
+/**
+ * Published language packs this build REPLACES rather than removes.
+ *
+ * Pack filenames carry their version (`bento-slides-1.0.14-ar.pack.json`), so
+ * every release of an app retires all 22 of its predecessors and stages 22
+ * new ones. Being superseded is the entire point of the name; the old file is
+ * unreachable the moment the signed index stops listing it.
+ *
+ * Without this, the deletion gate fires on EVERY release and the only way
+ * through is --allow-deletions. A gate bypassed every single time is not a
+ * gate — it teaches the reflex that defeats it, and the run where the
+ * deletions are real looks exactly like the twenty before it.
+ *
+ * Narrow on purpose: a pack is excused only when THIS build stages a pack for
+ * the same app and the same language at a different version. A release that
+ * dropped a language, or staged no packs at all, still trips the gate.
+ */
+export function supersededPacks(published, staged) {
+  const PACK = /^releases\/([^/]+)\/packs\/bento-([^/]+)-(\d+\.\d+\.\d+)-(.+)\.pack\.json$/
+  const stagedKeys = new Map() // "applang" -> version
+  for (const p of staged) {
+    const m = PACK.exec(p)
+    if (m) stagedKeys.set(`${m[2]}${m[4]}`, m[3])
+  }
+  return published.filter((p) => {
+    const m = PACK.exec(p)
+    if (!m) return false
+    const replacement = stagedKeys.get(`${m[2]}${m[4]}`)
+    return !!replacement && replacement !== m[3]
+  })
+}
+
 /** Deletions grouped by top-level path, so 22 packs read as one line. */
 export function groupDeletions(deletions) {
   const groups = new Map()

--- a/scripts/test-publish-gate.mjs
+++ b/scripts/test-publish-gate.mjs
@@ -23,7 +23,7 @@
 // (2) an excluded path is still not a deletion, or every ordinary publish
 // without a guestbook deck would be blocked.
 
-import { plannedDeletions, groupDeletions, walk } from './site-inventory.mjs'
+import { plannedDeletions, groupDeletions, walk, supersededPacks } from './site-inventory.mjs'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -115,6 +115,40 @@ try {
 } finally {
   rmSync(tmp, { recursive: true, force: true })
 }
+
+// ---- superseded language packs are a REPLACEMENT, not a loss --------------
+// Every slides release retires all 22 of its predecessors — the version is in
+// the filename. If the gate counted those, it would fire on every release and
+// --allow-deletions would become reflex, which is precisely how the run with
+// real deletions gets waved through.
+const SLIDES_1014 = [
+  'index.html', 'CNAME', '.nojekyll', 'agents.md', 'LICENSE',
+  'releases/slides/Bento_Slides.bento.html',
+  'releases/slides/manifest.json',
+  'releases/slides/packs.json',
+  'releases/slides/packs/bento-slides-1.0.14-ko.pack.json',
+  'releases/slides/packs/bento-slides-1.0.14-ru.pack.json',
+  'slides/index.html',
+  'gallery/orbital-dark-immersive.bento.html',
+  'guestbook/index.html',
+  'guestbook.bento.html',
+  'skills/bento-slides/SKILL.md',
+]
+const superseded = supersededPacks(PUBLISHED, SLIDES_1014)
+ok(superseded.length === 2, `both older packs are recognised as superseded (got ${superseded.length})`)
+ok(plannedDeletions(PUBLISHED, SLIDES_1014, ['.git']).filter((p) => !superseded.includes(p)).length === 0,
+  'an ordinary slides release plans no deletions once superseded packs are excused')
+
+// …and the ways it must STILL trip.
+const droppedKorean = SLIDES_1014.filter((p) => !p.includes('-ko.'))
+ok(!supersededPacks(PUBLISHED, droppedKorean).some((p) => p.includes('-ko.')),
+  'a language this build no longer ships is NOT excused — dropping Korean is a real deletion')
+ok(supersededPacks(PUBLISHED, SPACES_STAGED).length === 0,
+  'a spaces release excuses no slides packs — it stages none of them')
+ok(supersededPacks(PUBLISHED, PUBLISHED).length === 0,
+  'a republish of the same versions excuses nothing (same version is not superseded)')
+ok(supersededPacks(PUBLISHED, ['releases/spaces/packs/bento-spaces-1.0.0-ko.pack.json']).length === 0,
+  "another app's pack for the same language does not excuse this app's")
 
 console.log(`\n${checks - failures}/${checks} checks passed`)
 if (failures) process.exit(1)


### PR DESCRIPTION
The deletion gate from #204 blocked the 1.0.15 publish over 22 files that were *supposed* to go — the 1.0.14 language packs, retired by the 22 the build had just staged.

Pack filenames carry their version, so **every release of an app retires all of its predecessors**. As written, the gate fires on every single release.

That's the failure mode worth naming: a gate you clear with the same flag every run isn't a gate. It teaches the reflex that defeats it, and the run where the deletions are real looks exactly like the twenty before it. I used `--allow-deletions` to ship the crash fix, having audited the dry run by hand — but nobody should be making that call routinely.

`supersededPacks()` excuses a published pack **only** when this build stages one for the same app and the same language at a different version.

Everything else still trips, and each is in the rig:

| case | excused? |
|---|---|
| ordinary slides release, 22 packs replaced | yes — zero deletions planned |
| release that drops a language | **no** — dropping Korean is a real deletion |
| spaces release, stages no slides packs | **no** |
| another app's pack for the same language | **no** |
| republish of identical versions | **no** — same version isn't superseded |

19 checks.