### PR TITLE
A re-layout must not teleport the canvas view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: the slide could open off-centre, pushed to one side and clipped.**
+  Most likely on a deck whose page is larger than the default — a 1600×900 deck
+  outgrows the editing canvas at zoom levels where a 1280×720 one still fits.
+  The canvas gained room to pan past the slide's edges in 1.0.14, and turning
+  that room on moved the slide within the scrollable area without moving the
+  view with it, so you were left looking at the empty margin beside your slide.
+  Clicking the zoom percentage snapped it back, because that was the one action
+  that re-centred. The view now stays put across any re-layout.
+
 ## [1.0.15] — 2026-08-03
 
 - **Fix: removing a formatting option no longer disconnects the people you are

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -332,7 +332,19 @@ export class SlideCanvas {
     // box, so writing padding here cannot disturb the fitScale computed above.
     const padX = width * this.scale > availW ? Math.round(this.scroller.clientWidth / 2) : 0
     const padY = height * this.scale > availH ? Math.round(this.scroller.clientHeight / 2) : 0
+    // Changing the pan room moves the stage within the scroll canvas by exactly
+    // that much, so changing it without compensating TELEPORTS the view. The
+    // first relayout that turns padding on leaves the scroll at 0 — which is now
+    // half a viewport of empty canvas, with the slide shoved off to the side and
+    // clipped. setZoom re-centres afterwards and hid this; every OTHER route in
+    // (opening a deck whose stage already overflows, a window resize, toggling a
+    // panel) does not. Reported on a 1600x900 deck, whose stage outgrows the
+    // canvas at ordinary zooms where the 1280x720 default still fits.
+    const wasX = parseFloat(this.scroller.style.paddingLeft) || 0
+    const wasY = parseFloat(this.scroller.style.paddingTop) || 0
     this.scroller.style.padding = padX || padY ? `${padY}px ${padX}px` : ''
+    if (padX !== wasX) this.scroller.scrollLeft += padX - wasX
+    if (padY !== wasY) this.scroller.scrollTop += padY - wasY
     this.scaleHost.style.transform = `scale(${this.scale})`
     this.moveable.zoom = 1 / this.scale
     this.moveable.updateRect()


### PR DESCRIPTION
**Reported:** an older deck updated to the latest version opened off-centre — slide shoved to one side and clipped, half-width scrollbar thumb. Page size 1600×900, which was the clue but not the cause.

## Cause

The pan room added in #200 (1.0.14) puts half a viewport of padding on each side once the stage outgrows the canvas. **Padding moves the stage within the scrollable area by exactly that much** — so turning it on without moving the scroll offset with it teleports the view, and the offset it teleports *from* is usually 0.

Measured on the reported deck: a 50% empty left gutter, `leftGap 737 / rightGap −988`.

`setZoom` re-centres immediately afterwards, which is exactly why this hid — zooming looks correct. Every other route in does not re-centre: opening a deck whose stage already overflows, a window resize, toggling a panel. And a 1600×900 deck crosses the overflow threshold at zoom levels where the 1280×720 default still fits, so it surfaces there first.

## Fix

When the padding changes, shift `scrollLeft`/`scrollTop` by the same delta, so the same content stays under the viewport.

That's the right rule independently of this bug: **a re-layout is not a navigation.**

## Confirmation

Both directions, by the reporter:

- clicking the zoom percentage — the one path that re-centres — repaired the broken file
- the same document re-shelled onto the fixed build opens centred

I could not construct the transition synthetically (my attempts either didn't trigger a re-layout or didn't change the padding, so pre- and post-fix builds read identically in those runs). The reporter's two confirmations are what establish it.