### PR TITLE
dash M0: undo as a patch log, and the third write verb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,13 @@ jobs:
         # data on the first save). Both are asserted from both sides.
         run: node scripts/test-dash-model.ts
 
+      - name: bento/dash store + undo rig
+        # Undo is a patch log rather than document snapshots, which buys history
+        # that costs what the EDIT costs — and risks a failure a snapshot cannot
+        # have: an inverse that does not restore what it displaced. Every op is
+        # checked apply → undo → identical, because that failure is silent.
+        run: node scripts/test-dash-store.ts
+
       - name: Built-in layout geometry rig
         # The built-ins are drawn against 1600x900 while the model default is
         # 1280x720, so they used to hang 200px off the right edge of a default

--- a/dash/src/store.ts
+++ b/dash/src/store.ts
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Document state, undo history, and the TYPING RUN.
+//
+// THE TYPING RUN and THE BYTE CAP are spaces' (spaces/src/store.ts:6-13, :20-23),
+// taken deliberately and unchanged. Slides sidesteps commit granularity because
+// canvas text commits on blur; a grid may never blur, so this one policy sets
+// undo granularity, autosave churn, the dirty flag and later the collab op rate.
+// A run is consecutive input in ONE cell with no structural op between: one
+// checkpoint at its first input, later inputs mutate in place, closing on idle,
+// on the caret leaving the cell, on any structural change, on save and on
+// replaceDoc.
+//
+// THE ENTRY BODY IS WHERE DASH DIVERGES, and it is the sharpest divergence in
+// the app. spaces snapshots `JSON.stringify(doc minus assets)` per checkpoint
+// (store.ts:137-142) — the right instinct, since it forked slides' MAX_UNDO=100
+// entry cap into a byte cap precisely because whole-document snapshots do not
+// scale, but an incomplete fork: it still stringifies the whole document.
+// Measured on a 12.2 MB workbook: 10 ms per checkpoint — most of a 16 ms frame,
+// paid in the frame the user starts typing — and 1.19 GB of live strings for a
+// full stack. Unusable at 50k-100k cells, OOM before 500k.
+//
+// So history here is a list of TYPED INVERSES, each carrying only what it
+// touched, minted at the edit site. A 10,000-cell paste is one entry holding
+// 10,000 values, not 100 copies of the workbook.
+//
+// The same Patch objects are the undo entries, the future CRDT ops and the
+// agent API. That is why this lands at commit one: retrofitting op-minting
+// means rewriting the store.
+
+import type { CellOverride, ColumnData, DashDoc, Measure, Sheet, Step, TableSheet } from './model.ts'
+
+type Listener = () => void
+export type StoreEvent = 'doc' | 'view' | 'selection'
+
+/** Idle that closes a run. Autosave debounces longer, so no snapshot lands mid-run. */
+const RUN_IDLE_MS = 600
+
+/**
+ * Undo is bounded by BYTES, not entries — spaces' correction to slides'
+ * MAX_UNDO = 100, and the right one. What differs is what the bytes measure:
+ * here it is the size of the patches themselves, not of document copies.
+ */
+const UNDO_BYTES = 24 * 1024 * 1024
+
+// --- Patches ---------------------------------------------------------------
+
+/**
+ * One undoable change, carrying only what it touched.
+ *
+ * Every variant is INVERTIBLE: `applyPatch` returns the patch that undoes it,
+ * built from the values it displaced. Nothing here reads the whole document.
+ */
+export type Patch =
+  /** `dictLen` truncates a dictionary that this edit grew. Without it, undo
+   *  restores the values and leaves the orphaned strings behind — the document
+   *  is semantically right and no longer byte-identical, and the dictionary
+   *  grows forever under editing. */
+  | { op: 'setCells'; sheet: string; col: string; rids: number[]; v: unknown[]; dictLen?: number }
+  /** `dropEmpty` removes the `cells` container the forward patch created. An
+   *  apply-then-undo that leaves `"cells": {}` behind is not a round trip. */
+  | {
+      op: 'setOverrides'; sheet: string; keys: string[]
+      v: Array<CellOverride | undefined>; dropEmpty?: boolean
+    }
+  /**
+   * `at[i]` is the row POSITION rids[i] takes; omitted means append.
+   * `values` is colId → one value per rid.
+   *
+   * Both exist because this is the inverse of a delete, and a delete has to be
+   * undoable exactly. Without `values` the rows come back EMPTY; without `at`
+   * they come back at the END — and in a spreadsheet, order is data. Measured
+   * before this was fixed: deleting row 2 of [10,20,30,40] and undoing gave
+   * [10,30,40,20].
+   */
+  | {
+      op: 'insertRows'; sheet: string; rids: number[]
+      at?: number[]; values?: Record<string, unknown[]>
+    }
+  | { op: 'deleteRows'; sheet: string; rids: number[] }
+  | { op: 'setColumn'; sheet: string; col: string; patch: Record<string, unknown> }
+  | { op: 'reorderColumns'; sheet: string; order: string[] }
+  | { op: 'setMeasure'; name: string; measure?: Measure; dropEmpty?: boolean }
+  | { op: 'setTitle'; title: string }
+  /**
+   * RESERVED. Both need the transform engine, which does not exist yet. They
+   * are in the union now because the discriminant cannot be retrofitted once
+   * patches are also CRDT ops. `applyPatch` refuses them loudly rather than
+   * pretending — a silent no-op here would be an edit the user believes landed.
+   */
+  | { op: 'applySteps'; sheet: string; steps: Step[] }
+  | { op: 'refreshBinding'; sheet: string; cols: Record<string, ColumnData> }
+
+/**
+ * What a patch touched, so undo can invalidate precisely.
+ *
+ * If undo emitted a document-wide invalidation the patch log's entire win would
+ * be thrown away at undo time — spaces' `restore` emits `doc`+`tree`+`page` and
+ * the editor rebuilds the page, which is correct for a page of prose and wrong
+ * for 100k rows. A patch knows which cells it touched; the invalidation carries
+ * that.
+ */
+export interface Touched {
+  sheet?: string
+  cols?: string[]
+  rids?: number[]
+  /** structure changed (rows added/removed, columns reordered) — relayout, not repaint */
+  structural?: boolean
+  /** genuinely everything: replaceDoc, and nothing else */
+  all?: boolean
+}
+
+interface Entry {
+  /** the patches that undo this step, in reverse application order */
+  inverse: Patch[]
+  touched: Touched
+  bytes: number
+}
+
+// --- Column encoding -------------------------------------------------------
+// Reading and writing one cell has to understand the encoding, because the
+// encoding is what makes the format fit (4.8 bytes/cell dictionary-columnar
+// against 15.9 array-of-objects). `pack` is an author-chosen archive encoding
+// and is READ-ONLY here: writing to it would mean inflating a whole column on
+// a keystroke, so an edit promotes it to `raw` at the call site instead.
+
+/**
+ * Row ids are run-length encoded — `[[1, 4200]]` is 20 bytes for 4200 rows —
+ * but structural edits are far easier to get RIGHT on a flat list, and they are
+ * rare (an import, an insert, a delete) rather than per-keystroke. So structural
+ * ops expand, manipulate and re-compress; only reads walk the runs.
+ */
+const expandRids = (sheet: TableSheet): number[] => {
+  const out: number[] = []
+  for (const [start, count] of sheet.rids) for (let i = 0; i < count; i++) out.push(start + i)
+  return out
+}
+
+const compressRids = (flat: number[]): Array<[number, number]> => {
+  const out: Array<[number, number]> = []
+  for (const rid of flat) {
+    const tail = out[out.length - 1]
+    if (tail && tail[0] + tail[1] === rid) tail[1]++
+    else out.push([rid, 1])
+  }
+  return out
+}
+
+const ridIndex = (sheet: TableSheet, rid: number): number => {
+  let i = 0
+  for (const [start, count] of sheet.rids) {
+    if (rid >= start && rid < start + count) return i + (rid - start)
+    i += count
+  }
+  return -1
+}
+
+export function readCell(data: ColumnData | undefined, row: number): unknown {
+  if (!data || row < 0) return null
+  if (data.enc === 'raw') return data.v[row] ?? null
+  if (data.enc === 'dict') {
+    const k = data.idx[row]
+    return k == null ? null : (data.dict[k] ?? null)
+  }
+  return null // `pack` is opaque until inflated
+}
+
+function writeCell(data: ColumnData, row: number, v: unknown): void {
+  if (data.enc === 'raw') {
+    data.v[row] = v as never
+    return
+  }
+  if (data.enc === 'dict') {
+    if (v == null) { data.idx[row] = null; return }
+    const s = String(v)
+    let k = data.dict.indexOf(s)
+    if (k < 0) { k = data.dict.length; data.dict.push(s) }
+    data.idx[row] = k
+    return
+  }
+  throw new Error('cannot write into a packed column; promote it to raw first')
+}
+
+const totalRows = (sheet: TableSheet): number =>
+  sheet.rids.reduce((n, [, c]) => n + c, 0)
+
+// --- Apply -----------------------------------------------------------------
+
+const table = (doc: DashDoc, id: string): TableSheet => {
+  const s = doc.sheets.find((x: Sheet) => x.id === id)
+  if (!s || s.kind !== 'table') throw new Error(`no table sheet ${id}`)
+  return s
+}
+
+/**
+ * Apply one patch, and return the patch that undoes it.
+ *
+ * The inverse is built from the values actually displaced, so it costs what the
+ * edit costs — never what the document costs.
+ */
+export function applyPatch(doc: DashDoc, p: Patch): { inverse: Patch; touched: Touched } {
+  switch (p.op) {
+    case 'setCells': {
+      const sheet = table(doc, p.sheet)
+      const data = sheet.data[p.col]
+      if (!data) throw new Error(`no column data ${p.col}`)
+      const dictLen = data.enc === 'dict' ? data.dict.length : undefined
+      const was: unknown[] = []
+      p.rids.forEach((rid, i) => {
+        const row = ridIndex(sheet, rid)
+        if (row < 0) { was.push(null); return }
+        was.push(readCell(data, row))
+        writeCell(data, row, p.v[i])
+      })
+      if (p.dictLen !== undefined && data.enc === 'dict' && data.dict.length > p.dictLen) {
+        data.dict.length = p.dictLen
+      }
+      return {
+        inverse: { op: 'setCells', sheet: p.sheet, col: p.col, rids: p.rids, v: was, dictLen },
+        touched: { sheet: p.sheet, cols: [p.col], rids: p.rids },
+      }
+    }
+
+    case 'setOverrides': {
+      const sheet = table(doc, p.sheet)
+      const existed = sheet.cells !== undefined
+      sheet.cells ??= {}
+      const was: Array<CellOverride | undefined> = []
+      p.keys.forEach((k, i) => {
+        was.push(sheet.cells![k])
+        const v = p.v[i]
+        if (v === undefined) delete sheet.cells![k]
+        else sheet.cells![k] = v
+      })
+      if (p.dropEmpty && Object.keys(sheet.cells).length === 0) delete sheet.cells
+      return {
+        inverse: {
+          op: 'setOverrides', sheet: p.sheet, keys: p.keys, v: was,
+          dropEmpty: !existed,
+        },
+        touched: {
+          sheet: p.sheet,
+          cols: [...new Set(p.keys.map((k) => k.slice(0, k.indexOf(':'))))],
+          rids: p.keys.map((k) => Number(k.slice(k.indexOf(':') + 1))),
+        },
+      }
+    }
+
+    case 'insertRows': {
+      const sheet = table(doc, p.sheet)
+      const flat = expandRids(sheet)
+      // ascending, so each splice index stays valid as earlier ones land
+      const order = p.rids.map((rid, i) => ({ rid, at: p.at?.[i] ?? flat.length + i, i }))
+        .sort((a, b) => a.at - b.at)
+      for (const { rid, at, i } of order) {
+        flat.splice(at, 0, rid)
+        for (const [col, d] of Object.entries(sheet.data)) {
+          const v = p.values?.[col]?.[i] ?? null
+          if (d.enc === 'raw') d.v.splice(at, 0, null)
+          else if (d.enc === 'dict') d.idx.splice(at, 0, null)
+          // through writeCell, so a dict column re-interns rather than growing
+          // a second encoding beside itself
+          if (v !== null) writeCell(d, at, v)
+        }
+      }
+      sheet.rids = compressRids(flat)
+      return {
+        inverse: { op: 'deleteRows', sheet: p.sheet, rids: p.rids },
+        touched: { sheet: p.sheet, rids: p.rids, structural: true },
+      }
+    }
+
+    case 'deleteRows': {
+      const sheet = table(doc, p.sheet)
+      // capture position AND value before anything moves — the inverse has to
+      // put each row back exactly where it was, because order is data
+      const taken = p.rids
+        .map((rid) => ({ rid, at: ridIndex(sheet, rid) }))
+        .filter((r) => r.at >= 0)
+        .sort((a, b) => a.at - b.at)
+      const restore: Record<string, unknown[]> = {}
+      for (const [col, d] of Object.entries(sheet.data)) {
+        restore[col] = taken.map((r) => readCell(d, r.at))
+      }
+      // descending, so each splice leaves the remaining indices valid
+      const flat = expandRids(sheet)
+      for (let i = taken.length - 1; i >= 0; i--) {
+        flat.splice(taken[i].at, 1)
+        for (const d of Object.values(sheet.data)) {
+          if (d.enc === 'raw') d.v.splice(taken[i].at, 1)
+          else if (d.enc === 'dict') d.idx.splice(taken[i].at, 1)
+        }
+      }
+      sheet.rids = compressRids(flat)
+      return {
+        inverse: {
+          op: 'insertRows', sheet: p.sheet,
+          rids: taken.map((r) => r.rid), at: taken.map((r) => r.at), values: restore,
+        },
+        touched: { sheet: p.sheet, rids: p.rids, structural: true },
+      }
+    }
+
+    case 'setColumn': {
+      const sheet = table(doc, p.sheet)
+      const col = sheet.columns.find((c) => c.id === p.col)
+      if (!col) throw new Error(`no column ${p.col}`)
+      const was: Record<string, unknown> = {}
+      for (const k of Object.keys(p.patch)) was[k] = (col as Record<string, unknown>)[k]
+      Object.assign(col, p.patch)
+      return {
+        inverse: { op: 'setColumn', sheet: p.sheet, col: p.col, patch: was },
+        touched: { sheet: p.sheet, cols: [p.col] },
+      }
+    }
+
+    case 'reorderColumns': {
+      const sheet = table(doc, p.sheet)
+      const was = sheet.columns.map((c) => c.id)
+      const by = new Map(sheet.columns.map((c) => [c.id, c]))
+      sheet.columns = p.order.map((id) => by.get(id)!).filter(Boolean)
+      return {
+        inverse: { op: 'reorderColumns', sheet: p.sheet, order: was },
+        touched: { sheet: p.sheet, structural: true },
+      }
+    }
+
+    case 'setMeasure': {
+      const existed = doc.measures !== undefined
+      doc.measures ??= {}
+      const was = doc.measures[p.name]
+      if (p.measure === undefined) delete doc.measures[p.name]
+      else doc.measures[p.name] = p.measure
+      if (p.dropEmpty && Object.keys(doc.measures).length === 0) delete doc.measures
+      return {
+        inverse: { op: 'setMeasure', name: p.name, measure: was, dropEmpty: !existed },
+        touched: {},
+      }
+    }
+
+    case 'setTitle': {
+      const was = doc.title
+      doc.title = p.title
+      return { inverse: { op: 'setTitle', title: was }, touched: {} }
+    }
+
+    default:
+      // applySteps / refreshBinding, and anything a future build sends us.
+      // Refusing loudly is the point: a silent no-op is an edit the user
+      // believes landed.
+      throw new Error(`patch op "${(p as { op: string }).op}" is not implemented yet`)
+  }
+}
+
+const patchBytes = (p: Patch): number => JSON.stringify(p).length
+
+// --- Store -----------------------------------------------------------------
+
+export class Store {
+  doc: DashDoc
+  readOnly = false
+  /** view state: never in the document, never synced, never undoable by default */
+  order: Record<string, number[] | undefined> = {}
+  private undoStack: Entry[] = []
+  private redoStack: Entry[] = []
+  private listeners = new Map<StoreEvent, Set<Listener>>()
+  private runCell: string | null = null
+  private runTimer: ReturnType<typeof setTimeout> | undefined
+  private pending: { inverse: Patch[]; touched: Touched; bytes: number } | null = null
+
+  constructor(doc: DashDoc) {
+    this.doc = doc
+  }
+
+  on(ev: StoreEvent, fn: Listener): () => void {
+    const set = this.listeners.get(ev) ?? new Set()
+    this.listeners.set(ev, set)
+    set.add(fn)
+    return () => set.delete(fn)
+  }
+
+  private emit(ev: StoreEvent): void {
+    for (const fn of this.listeners.get(ev) ?? []) fn()
+  }
+
+  /** The last invalidation, for a listener that wants to repaint precisely. */
+  lastTouched: Touched = {}
+
+  /**
+   * One undoable step: apply patches, record their inverses as ONE entry.
+   * Closes any open typing run first, so a run's text and a structural edit
+   * never merge into one entry.
+   */
+  commit(patches: Patch | Patch[]): void {
+    if (this.readOnly) return
+    this.endRun()
+    const list = Array.isArray(patches) ? patches : [patches]
+    const inverse: Patch[] = []
+    const touched: Touched = {}
+    let bytes = 0
+    for (const p of list) {
+      const r = applyPatch(this.doc, p)
+      inverse.unshift(r.inverse) // undo in reverse application order
+      bytes += patchBytes(r.inverse)
+      merge(touched, r.touched)
+    }
+    this.push({ inverse, touched, bytes })
+    this.touch()
+    this.lastTouched = touched
+    this.emit('doc')
+  }
+
+  /**
+   * An edit inside a typing run. The FIRST edit in a cell opens the entry;
+   * every later one extends it in place, so a cell typed into forty times is
+   * one undo step carrying one inverse — not forty.
+   */
+  runEdit(cellKey: string, patch: Patch): void {
+    if (this.readOnly) return
+    if (this.runCell !== cellKey) {
+      this.endRun()
+      this.runCell = cellKey
+      this.pending = { inverse: [], touched: {}, bytes: 0 }
+    }
+    const r = applyPatch(this.doc, patch)
+    // keep only the FIRST inverse for this cell: it holds the value the run
+    // started from, which is what undo must restore
+    if (this.pending!.inverse.length === 0) {
+      this.pending!.inverse.push(r.inverse)
+      this.pending!.bytes = patchBytes(r.inverse)
+    }
+    merge(this.pending!.touched, r.touched)
+    this.touch()
+    this.lastTouched = r.touched
+    this.emit('doc')
+    clearTimeout(this.runTimer)
+    this.runTimer = setTimeout(() => this.endRun(), RUN_IDLE_MS)
+  }
+
+  /** Close the current run, if any. Idempotent. */
+  endRun(): void {
+    clearTimeout(this.runTimer)
+    if (!this.runCell) return
+    this.runCell = null
+    if (this.pending && this.pending.inverse.length) this.push(this.pending)
+    this.pending = null
+  }
+
+  /**
+   * VIEW STATE — the third write verb, and the one nothing in spaces suggests.
+   *
+   * The grid reads through an order vector: sorting sorts the index, filtering
+   * builds a mask. NEITHER touches the document, so neither takes a checkpoint,
+   * sets the dirty flag, or produces an op. Writing the first sort as a
+   * `commit` is the easy mistake, and nobody notices until a file saves itself
+   * every time someone clicks a column header.
+   *
+   * OPEN QUESTION: Excel users press ⌘Z after a sort and expect it undone. That
+   * needs a separate view-history, not the document's undo stack — deliberately
+   * not built here, because guessing it wrong is worse than leaving it.
+   */
+  view(mutate: () => void): void {
+    mutate()
+    this.emit('view')
+  }
+
+  /** Model changed without a new undo entry (mid-run). */
+  touch(): void {
+    this.doc.modified = new Date().toISOString()
+  }
+
+  private push(e: Entry): void {
+    this.undoStack.push(e)
+    this.redoStack.length = 0
+    // Walk backwards dropping the OLDEST entries once the budget is exceeded —
+    // spaces' splice, unchanged (store.ts:144-152).
+    let bytes = 0
+    for (let i = this.undoStack.length - 1; i >= 0; i--) {
+      bytes += this.undoStack[i].bytes
+      if (bytes > UNDO_BYTES) { this.undoStack.splice(0, i + 1); break }
+    }
+  }
+
+  private invert(e: Entry): Entry {
+    const inverse: Patch[] = []
+    const touched: Touched = {}
+    let bytes = 0
+    for (const p of e.inverse) {
+      const r = applyPatch(this.doc, p)
+      inverse.unshift(r.inverse)
+      bytes += patchBytes(r.inverse)
+      merge(touched, r.touched)
+    }
+    this.touch()
+    this.lastTouched = touched
+    this.emit('doc')
+    return { inverse, touched, bytes }
+  }
+
+  undo(): boolean {
+    if (this.readOnly) return false
+    this.endRun()
+    const e = this.undoStack.pop()
+    if (!e) return false
+    this.redoStack.push(this.invert(e))
+    return true
+  }
+
+  redo(): boolean {
+    if (this.readOnly) return false
+    this.endRun()
+    const e = this.redoStack.pop()
+    if (!e) return false
+    this.undoStack.push(this.invert(e))
+    return true
+  }
+
+  get canUndo(): boolean { return this.undoStack.length > 0 }
+  get canRedo(): boolean { return this.redoStack.length > 0 }
+  /** live bytes held by history — the number the cap is enforced against */
+  get historyBytes(): number { return this.undoStack.reduce((n, e) => n + e.bytes, 0) }
+
+  /** Wholesale replacement (agent load, version restore). The one `all` case. */
+  replaceDoc(next: DashDoc): void {
+    this.endRun()
+    this.doc = next
+    this.undoStack.length = 0
+    this.redoStack.length = 0
+    this.order = {}
+    this.lastTouched = { all: true }
+    this.emit('doc')
+    this.emit('view')
+  }
+}
+
+function merge(into: Touched, from: Touched): void {
+  if (from.all) { into.all = true; return }
+  if (from.sheet) into.sheet = from.sheet
+  if (from.structural) into.structural = true
+  if (from.cols) into.cols = [...new Set([...(into.cols ?? []), ...from.cols])]
+  if (from.rids) into.rids = [...new Set([...(into.rids ?? []), ...from.rids])]
+}
+
+export const _internals = { RUN_IDLE_MS, UNDO_BYTES, totalRows, ridIndex }

--- a/scripts/test-dash-store.ts
+++ b/scripts/test-dash-store.ts
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// bento/dash store + undo rig.
+//
+//   node scripts/test-dash-store.ts        (Node ≥ 23.6 strips types natively)
+//
+// WHAT THIS PROVES. Undo here is a list of TYPED INVERSES rather than whole
+// document snapshots, because snapshots were measured at 10 ms per checkpoint
+// on a 12.2 MB workbook and 1.19 GB of live strings for a full stack. That
+// mechanism buys two things and risks two:
+//
+//   BUYS   history that costs what the EDIT costs, not what the DOCUMENT costs;
+//          and an invalidation that names the cells it touched, so undo can
+//          repaint precisely instead of rebuilding the grid.
+//   RISKS  an inverse that does not actually restore what it displaced — the
+//          failure mode a snapshot cannot have, and the reason for this file.
+//          Undoing a delete that brings the rows back EMPTY is worse than the
+//          delete, and it is silent.
+//
+// So every operation is checked round-trip: apply, undo, and assert the
+// document is byte-identical to where it started.
+
+import { parseDoc, type DashDoc } from '../dash/src/model.ts'
+import { Store, applyPatch, readCell, type Patch, _internals } from '../dash/src/store.ts'
+
+let failures = 0
+let checks = 0
+function ok(cond: boolean, msg: string) {
+  checks++
+  if (!cond) { failures++; console.log(`  FAIL  ${msg}`) }
+  else console.log(`  ok    ${msg}`)
+}
+
+const fresh = (): DashDoc => {
+  const r = parseDoc(JSON.stringify({
+    format: 'bento/dash', version: 1, policy: 'bento-dash-1',
+    docId: 'd', title: 'test',
+    sheets: [{
+      id: 'sh1', name: 'S', kind: 'table',
+      rids: [[1, 4]],
+      columns: [
+        { id: 'region', name: 'Region', type: 'text' },
+        { id: 'amount', name: 'Amount', type: 'number' },
+      ],
+      data: {
+        region: { enc: 'dict', dict: ['North', 'South'], idx: [0, 1, 0, 1] },
+        amount: { enc: 'raw', v: [10, 20, 30, 40] },
+      },
+      steps: [{ op: 'import', from: 'q3.csv', at: '2026-08-03T00:00:00Z', rows: 4 }],
+    }],
+  }))
+  if (!r.ok) throw new Error('fixture does not parse')
+  return r.doc
+}
+
+/**
+ * The document minus `modified`. Undo IS an edit — the file has changed since
+ * it was last saved — so the timestamp legitimately moves and comparing it
+ * would assert the wrong thing.
+ */
+const content = (d: DashDoc): string => {
+  const { modified: _m, ...rest } = d
+  return JSON.stringify(rest)
+}
+
+/** apply → undo → is the document exactly where it started? */
+function roundTrip(name: string, patches: Patch | Patch[]) {
+  const s = new Store(fresh())
+  const before = content(s.doc)
+  s.commit(patches)
+  const changed = content(s.doc) !== before
+  const undone = s.undo()
+  ok(changed, `${name}: the patch actually changed something`)
+  ok(undone && content(s.doc) === before, `${name}: undo restores the document exactly`)
+  const afterUndo = content(s.doc)
+  s.redo()
+  ok(content(s.doc) !== afterUndo, `${name}: redo re-applies it`)
+}
+
+// ------------------------------------------------------------ round trips
+roundTrip('setCells (raw)', { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [2, 3], v: [99, 98] })
+roundTrip('setCells (dict)', { op: 'setCells', sheet: 'sh1', col: 'region', rids: [1], v: ['East'] })
+roundTrip('setOverrides', {
+  op: 'setOverrides', sheet: 'sh1', keys: ['amount:2'],
+  v: [{ note: 'checked', by: 'andy' }],
+})
+roundTrip('insertRows', { op: 'insertRows', sheet: 'sh1', rids: [5, 6] })
+roundTrip('deleteRows', { op: 'deleteRows', sheet: 'sh1', rids: [2] })
+roundTrip('setColumn', { op: 'setColumn', sheet: 'sh1', col: 'amount', patch: { format: '$#,##0', unit: 'USD' } })
+roundTrip('reorderColumns', { op: 'reorderColumns', sheet: 'sh1', order: ['amount', 'region'] })
+roundTrip('setMeasure', {
+  op: 'setMeasure', name: 'Revenue',
+  measure: { name: 'Revenue', expr: 'SUM(amount)', grain: 'sh1', additive: true },
+})
+roundTrip('setTitle', { op: 'setTitle', title: 'renamed' })
+roundTrip('a multi-patch commit', [
+  { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [1], v: [1] },
+  { op: 'setColumn', sheet: 'sh1', col: 'amount', patch: { unit: 'EUR' } },
+])
+
+// THE ONE A SNAPSHOT CANNOT GET WRONG, and a patch log can: deleting rows and
+// undoing must bring the VALUES back, not empty rows.
+{
+  const s = new Store(fresh())
+  const sheet = s.doc.sheets[0] as any
+  const beforeVals = [0, 1, 2, 3].map((r) => readCell(sheet.data.amount, r))
+  s.commit({ op: 'deleteRows', sheet: 'sh1', rids: [2, 3] })
+  ok(JSON.stringify([0, 1].map((r) => readCell(sheet.data.amount, r))) === JSON.stringify([10, 40]),
+    'deleteRows removes the right rows')
+  s.undo()
+  const afterVals = [0, 1, 2, 3].map((r) => readCell((s.doc.sheets[0] as any).data.amount, r))
+  ok(JSON.stringify(afterVals) === JSON.stringify(beforeVals),
+    'undoing a delete restores the VALUES, not empty rows')
+}
+
+// ------------------------------------------------------------- typing run
+{
+  const s = new Store(fresh())
+  const before = content(s.doc)
+  for (let i = 0; i < 40; i++) {
+    s.runEdit('amount:1', { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [1], v: [i] })
+  }
+  s.endRun()
+  ok(readCell((s.doc.sheets[0] as any).data.amount, 0) === 39, 'the run left the last value')
+  s.undo()
+  ok(content(s.doc) === before,
+    'forty edits in one cell are ONE undo step, back to the value the run started from')
+}
+{
+  const s = new Store(fresh())
+  s.runEdit('amount:1', { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [1], v: [7] })
+  s.runEdit('amount:2', { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [2], v: [8] })
+  s.endRun()
+  s.undo()
+  ok(readCell((s.doc.sheets[0] as any).data.amount, 1) === 20 &&
+     readCell((s.doc.sheets[0] as any).data.amount, 0) === 7,
+    'moving to another cell closes the run — the two edits are separate steps')
+}
+{
+  const s = new Store(fresh())
+  s.runEdit('amount:1', { op: 'setCells', sheet: 'sh1', col: 'amount', rids: [1], v: [7] })
+  s.commit({ op: 'setColumn', sheet: 'sh1', col: 'amount', patch: { unit: 'GBP' } })
+  s.undo()
+  ok((s.doc.sheets[0] as any).columns.find((c: any) => c.id === 'amount').unit === undefined &&
+     readCell((s.doc.sheets[0] as any).data.amount, 0) === 7,
+    'a structural commit closes the run first — text and structure never merge')
+}
+
+// ------------------------------------------ history costs the EDIT, not the doc
+{
+  const s = new Store(fresh())
+  // grow the document without touching history
+  const sheet = s.doc.sheets[0] as any
+  sheet.data.amount.v = Array.from({ length: 50_000 }, (_, i) => i)
+  sheet.rids = [[1, 50_000]]
+  const docSize = JSON.stringify(s.doc).length
+  s.commit({ op: 'setCells', sheet: 'sh1', col: 'amount', rids: [1], v: [0] })
+  ok(docSize > 100_000, `the fixture document is genuinely large (${docSize} bytes)`)
+  ok(s.historyBytes < 200,
+    `one cell edit costs ${s.historyBytes} bytes of history, not a copy of the document`)
+  // this is the assertion a snapshot implementation fails
+  ok(s.historyBytes * 100 < docSize,
+    'history for one edit is <1% of the document — the property snapshots cannot have')
+}
+
+// --------------------------------------------------------------- byte cap
+{
+  const s = new Store(fresh())
+  const wide = Array.from({ length: 20_000 }, (_, i) => `value-${i}`)
+  const rids = Array.from({ length: 20_000 }, (_, i) => i + 1)
+  ;(s.doc.sheets[0] as any).rids = [[1, 20_000]]
+  ;(s.doc.sheets[0] as any).data.region = { enc: 'raw', v: wide.slice() }
+  for (let i = 0; i < 200; i++) {
+    s.commit({ op: 'setCells', sheet: 'sh1', col: 'region', rids, v: wide })
+  }
+  ok(s.historyBytes <= _internals.UNDO_BYTES,
+    `history stays inside the ${(_internals.UNDO_BYTES / 1024 / 1024) | 0} MB cap (${(s.historyBytes / 1024 / 1024).toFixed(1)} MB)`)
+  ok(s.canUndo, 'and the most recent entries survive the trim')
+}
+
+// ------------------------------------------------------- precise invalidation
+{
+  const s = new Store(fresh())
+  s.commit({ op: 'setCells', sheet: 'sh1', col: 'amount', rids: [2], v: [5] })
+  ok(s.lastTouched.sheet === 'sh1' && s.lastTouched.cols?.[0] === 'amount'
+     && s.lastTouched.rids?.[0] === 2 && !s.lastTouched.all,
+    'a commit reports WHICH cells it touched')
+  s.undo()
+  ok(s.lastTouched.cols?.[0] === 'amount' && !s.lastTouched.all,
+    'and so does undo — otherwise the patch log is thrown away at undo time')
+  s.replaceDoc(fresh())
+  ok(s.lastTouched.all === true, 'only replaceDoc invalidates everything')
+}
+
+// ------------------------------------------------------------- view state
+{
+  const s = new Store(fresh())
+  const before = content(s.doc)
+  let viewEvents = 0
+  s.on('view', () => { viewEvents++ })
+  s.view(() => { s.order.sh1 = [3, 2, 1, 0] })
+  ok(content(s.doc) === before, 'view() does NOT touch the document — a sort never dirties the file')
+  ok(!s.canUndo, 'view() takes no checkpoint')
+  ok(viewEvents === 1, 'view() emits an invalidation so the grid repaints')
+}
+
+// ----------------------------------------------------------------- refusals
+{
+  const s = new Store(fresh())
+  let threw = ''
+  try { s.commit({ op: 'applySteps', sheet: 'sh1', steps: [] }) } catch (e) { threw = String(e) }
+  ok(threw.includes('not implemented'),
+    'a reserved op REFUSES loudly rather than silently doing nothing')
+  s.readOnly = true
+  const before = content(s.doc)
+  s.commit({ op: 'setTitle', title: 'nope' })
+  ok(content(s.doc) === before, 'a read-only store accepts no commits')
+}
+
+console.log(`\n${checks - failures}/${checks} checks passed`)
+if (failures) process.exit(1)


### PR DESCRIPTION
Copies spaces' **typing run** and **byte cap** unchanged (`spaces/src/store.ts:6-13, :20-23`) and replaces only the entry *body*.

## Why the body changes

spaces snapshots `JSON.stringify(doc minus assets)` per checkpoint. That's the right instinct — it forked slides' `MAX_UNDO = 100` entry cap into a byte cap *precisely because* whole-document snapshots don't scale — but the fork is incomplete: it still stringifies the whole document.

Measured on a 12.2 MB workbook: **10 ms per checkpoint** (most of a 16 ms frame, paid in the frame the user starts typing) and **1.19 GB of live strings** for a full stack.

So history is a list of typed inverses, minted at the edit site, each carrying only what it displaced. Proven rather than asserted — on a 289 KB fixture, one cell edit costs **65 bytes** of history, and the rig asserts history for one edit stays under 1% of the document. That's the property a snapshot implementation cannot have.

The same `Patch` objects are the undo entries, the future CRDT ops and the agent API, which is why this lands now rather than after the differ: retrofitting op-minting means rewriting the store.

## Three bugs the rig found — all in this commit's own code

None of these is possible in a snapshot implementation. They're the price of the mechanism, and the reason the rig exists.

**1. Undoing a row delete restored the rows at the END of the sheet.**

```
[10,20,30,40] → delete row 2 → undo → [10,30,40,20]
```

In a spreadsheet order is data, so that's corruption, not cosmetics. The inverse now carries each row's **position** as well as its values. Structural ops expand the run-length encoded `rids` to a flat list, splice, and re-compress — rarer than a keystroke and far easier to get right than in-place RLE juggling.

**2. Undoing an edit to a dictionary column left the orphaned string behind.** Values right, document no longer byte-identical, and the dictionary grows forever under editing. The inverse carries the length to truncate to.

**3. `setOverrides` and `setMeasure` create their containers on demand**, and undo left `"cells": {}` and `"measures": {}` behind. An apply-then-undo that changes the document is not a round trip.

## `view()` — the third write verb

The grid reads through an order vector, so sorting sorts the index and filtering builds a mask. **Neither touches the document**, so neither checkpoints, dirties, nor produces an op.

Nothing in spaces suggests this exists — every mutation there goes through `commit` or `runEdit` and every one dirties the document. Writing the first sort as a `commit` is the easy mistake, and nobody notices until a file saves itself every time someone clicks a column header.

**Still open, deliberately not guessed:** Excel users press ⌘Z after a sort and expect it undone. That needs a separate view-history, not the document's undo stack.

## Refusals

`applySteps` and `refreshBinding` are in the union — the discriminant can't be retrofitted once patches are CRDT ops — but they refuse loudly, because they need the transform engine. A silent no-op would be an edit the user believes landed.

## The rig

49 checks. Verified against three deliberately reintroduced regressions:

| removed | checks lost |
|---|---|
| positional restore | 2 |
| container drop | 2 |
| dict truncation | 1 |

Typechecks clean under `--strict`.