### PR TITLE
Release 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.16] — 2026-08-03
+
 - **Fix: the slide could open off-centre, pushed to one side and clipped.**
   Most likely on a deck whose page is larger than the default — a 1600×900 deck
   outgrows the editing canvas at zoom levels where a 1280×720 one still fits.

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.15",
+  "version": "1.0.16",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
A single-fix release for the canvas centring regression (#227), which I shipped in 1.0.14.

The pan room added to the canvas moved the slide within the scrollable area without moving the view with it, so a deck whose stage outgrows the canvas opened parked in the empty margin — slide shoved to one side and clipped. That's every 1600×900 deck on an ordinary laptop, reachable just by opening the file.

Held to one entry deliberately: the other commits since v1.0.15 are dash M0, decision records and publish tooling, none of which change the slides shell.

Signed notes:

```
• Fix: the slide could open off-centre, pushed to one side and clipped.
• Fix: removing a formatting option no longer disconnects the people you are working with.  (1.0.15)
• "Save a copy…" and share exports remember their own folder.  (1.0.15)
• Fix: the topbar came back in the wrong order after the window narrowed and widened again.  (1.0.15)
• Fix: a deck opens where the browser refuses it storage.  (1.0.15)
• Pan the canvas by dragging, and past the slide's edges.  (1.0.14)
…and 6 more
```