### PR TITLE
webext: a package that can be uploaded, and the answers a reviewer asks for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,14 @@ jobs:
         # file carrying a script tag.
         run: node scripts/test-preview.ts
 
+      - name: WebExtension package rig
+        # Validates the store package without writing it: every file the
+        # manifest names exists, every icon is the size it claims, no unexpected
+        # file is about to ship (probe/ is four capability probes — harmless to
+        # us, alarming to a reviewer), and no permission is declared but unused.
+        # A listing rejected for a missing 128px icon costs days of review.
+        run: node scripts/pack-webext.mjs --check
+
       - name: WebExtension background rig
         # The half that WRITES, and previously the untested half. Two properties
         # it must hold: the target file comes from sender.url (browser-stamped)

--- a/scripts/pack-webext.mjs
+++ b/scripts/pack-webext.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+//
+// Builds the store-uploadable package for tray/webext.
+//
+//   node scripts/pack-webext.mjs            → dist/bento-tray-<version>.zip
+//   node scripts/pack-webext.mjs --check    → validate only, write nothing (CI)
+//
+// WHY THIS EXISTS RATHER THAN `zip -r`.
+//
+// **It refuses to ship the wrong files.** `tray/webext/` contains things that
+// must NOT reach a listing: `probe/` is four capability probes that open local
+// files and talk across origins — harmless to us, alarming to a reviewer, and
+// nothing to do with the product — and `README.md` is 200 lines of internal
+// reasoning. A recursive zip takes the lot. Here the payload is an explicit
+// allow-list and anything unexpected in the tree is an error, not a silent
+// inclusion.
+//
+// **It checks the manifest against the tree.** Every file the manifest names —
+// service worker, both content scripts, options page, popup, every icon — must
+// exist, and every icon must be the size it claims. A listing rejected for a
+// missing 128px icon costs a review round trip measured in days.
+//
+// **It is byte-reproducible.** Entries are sorted, timestamps fixed, no
+// filesystem metadata. The same tree always produces the same zip, so "is the
+// uploaded package the reviewed package?" is answerable by hashing it. This
+// repo already holds that line for the document shell (docs/RELEASING.md:
+// signed locally, the signed bytes are the served bytes); an extension going to
+// a store cannot be signed by us, so reproducibility is what is left.
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { deflateRawSync, crc32 } from 'node:zlib'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = join(root, 'tray/webext')
+const OUT = join(root, 'dist')
+
+/** What ships. Anything in the tree and not matched here is an error. */
+const INCLUDE = [/^manifest\.json$/, /^icons\/[^/]+\.png$/, /^src\/[^/]+\.(js|html)$/]
+/** Present on purpose, deliberately NOT shipped. */
+const EXCLUDE = [/^probe\//, /^README\.md$/, /^STORE\.md$/]
+
+const problems = []
+const fail = (m) => problems.push(m)
+
+// ---- walk the tree ---------------------------------------------------------
+function walk(dir, base = '') {
+  const out = []
+  for (const name of readdirSync(dir).sort()) {
+    const abs = join(dir, name)
+    const rel = base ? `${base}/${name}` : name
+    if (statSync(abs).isDirectory()) out.push(...walk(abs, rel))
+    else out.push(rel)
+  }
+  return out
+}
+
+const all = walk(SRC)
+const payload = []
+for (const rel of all) {
+  if (EXCLUDE.some((r) => r.test(rel))) continue
+  if (INCLUDE.some((r) => r.test(rel))) { payload.push(rel); continue }
+  fail(`unexpected file in tray/webext — add it to INCLUDE or EXCLUDE deliberately: ${rel}`)
+}
+
+// ---- the manifest must match the tree --------------------------------------
+let manifest = null
+try {
+  manifest = JSON.parse(readFileSync(join(SRC, 'manifest.json'), 'utf8'))
+} catch (e) {
+  fail(`manifest.json does not parse: ${e.message}`)
+}
+
+if (manifest) {
+  if (manifest.manifest_version !== 3) fail('manifest_version must be 3')
+  for (const k of ['name', 'version', 'description']) {
+    if (!manifest[k]) fail(`manifest is missing "${k}" — the store requires it`)
+  }
+  if (manifest.version === '0.0.1') fail('manifest version is still the scaffold placeholder 0.0.1')
+  if ((manifest.description ?? '').length > 132) {
+    fail(`description is ${manifest.description.length} chars; the store truncates at 132`)
+  }
+
+  const named = new Set()
+  const claim = (p) => { if (p) named.add(p.replace(/^\//, '')) }
+  claim(manifest.background?.service_worker)
+  claim(manifest.options_page)
+  claim(manifest.action?.default_popup)
+  for (const cs of manifest.content_scripts ?? []) (cs.js ?? []).forEach(claim)
+  for (const size of ['16', '32', '48', '128']) {
+    const p = manifest.icons?.[size]
+    if (!p) fail(`manifest.icons is missing the ${size}px entry — the store requires 128 and uses the rest`)
+    else claim(p)
+  }
+  for (const p of named) {
+    if (!payload.includes(p)) fail(`manifest names "${p}" but it is not in the package`)
+  }
+
+  // Icons must actually BE the size they claim. A store rejection for this is
+  // days of review latency for a one-line mistake.
+  for (const [size, p] of Object.entries(manifest.icons ?? {})) {
+    try {
+      const b = readFileSync(join(SRC, p))
+      // PNG: width/height are big-endian u32 at byte 16 and 20 of the IHDR.
+      const w = b.readUInt32BE(16)
+      const h = b.readUInt32BE(20)
+      if (w !== Number(size) || h !== Number(size)) {
+        fail(`${p} is ${w}x${h} but is declared as the ${size}px icon`)
+      }
+    } catch (e) {
+      fail(`cannot read icon ${p}: ${e.message}`)
+    }
+  }
+
+  // A permission that is declared and unused is a question a reviewer asks and
+  // the listing cannot answer.
+  const srcText = payload.filter((p) => p.endsWith('.js'))
+    .map((p) => readFileSync(join(SRC, p), 'utf8')).join('\n')
+  for (const perm of manifest.permissions ?? []) {
+    if (!new RegExp(`chrome\\.${perm}\\b`).test(srcText) && perm !== 'storage') {
+      fail(`permission "${perm}" is declared but never used in the shipped code`)
+    }
+  }
+}
+
+// ---- a minimal, deterministic zip ------------------------------------------
+// Written by hand rather than shelled out to `zip` so the output is fixed by
+// construction: sorted entries, one timestamp, no filesystem metadata.
+const DOS_TIME = 0x0000 // 00:00:00
+const DOS_DATE = 0x2821 // 2020-01-01 — a constant, so the bytes never drift
+
+function zip(files) {
+  const locals = []
+  const central = []
+  let offset = 0
+  for (const { name, data } of files) {
+    const body = deflateRawSync(data, { level: 9 })
+    const nameBuf = Buffer.from(name, 'utf8')
+    const sum = crc32(data)
+
+    const lh = Buffer.alloc(30)
+    lh.writeUInt32LE(0x04034b50, 0); lh.writeUInt16LE(20, 4); lh.writeUInt16LE(0, 6)
+    lh.writeUInt16LE(8, 8); lh.writeUInt16LE(DOS_TIME, 10); lh.writeUInt16LE(DOS_DATE, 12)
+    lh.writeUInt32LE(sum, 14); lh.writeUInt32LE(body.length, 18); lh.writeUInt32LE(data.length, 22)
+    lh.writeUInt16LE(nameBuf.length, 26); lh.writeUInt16LE(0, 28)
+    locals.push(lh, nameBuf, body)
+
+    const cd = Buffer.alloc(46)
+    cd.writeUInt32LE(0x02014b50, 0); cd.writeUInt16LE(20, 4); cd.writeUInt16LE(20, 6)
+    cd.writeUInt16LE(0, 8); cd.writeUInt16LE(8, 10); cd.writeUInt16LE(DOS_TIME, 12)
+    cd.writeUInt16LE(DOS_DATE, 14); cd.writeUInt32LE(sum, 16)
+    cd.writeUInt32LE(body.length, 20); cd.writeUInt32LE(data.length, 24)
+    cd.writeUInt16LE(nameBuf.length, 28); cd.writeUInt16LE(0, 30); cd.writeUInt16LE(0, 32)
+    cd.writeUInt16LE(0, 34); cd.writeUInt16LE(0, 36); cd.writeUInt32LE(0, 38)
+    cd.writeUInt32LE(offset, 42)
+    central.push(cd, nameBuf)
+
+    offset += lh.length + nameBuf.length + body.length
+  }
+  const cdBuf = Buffer.concat(central)
+  const end = Buffer.alloc(22)
+  end.writeUInt32LE(0x06054b50, 0); end.writeUInt16LE(0, 4); end.writeUInt16LE(0, 6)
+  end.writeUInt16LE(files.length, 8); end.writeUInt16LE(files.length, 10)
+  end.writeUInt32LE(cdBuf.length, 12); end.writeUInt32LE(offset, 16); end.writeUInt16LE(0, 20)
+  return Buffer.concat([...locals, cdBuf, end])
+}
+
+// ---- report ----------------------------------------------------------------
+console.log(`tray/webext → ${payload.length} files`)
+for (const p of payload) console.log(`  ${p}`)
+
+if (problems.length) {
+  console.error(`\n${problems.length} problem${problems.length > 1 ? 's' : ''}:`)
+  for (const p of problems) console.error(`  ✗ ${p}`)
+  process.exit(1)
+}
+
+if (process.argv.includes('--check')) {
+  console.log('\npackage is valid (nothing written)')
+  process.exit(0)
+}
+
+const bytes = zip(payload.map((name) => ({ name, data: readFileSync(join(SRC, name)) })))
+mkdirSync(OUT, { recursive: true })
+const out = join(OUT, `bento-tray-${manifest.version}.zip`)
+writeFileSync(out, bytes)
+console.log(`\nwrote ${relative(root, out)} — ${(bytes.length / 1024).toFixed(1)}KB`)
+console.log('deterministic: the same tree always produces these bytes')

--- a/tray/webext/README.md
+++ b/tray/webext/README.md
@@ -18,6 +18,24 @@ The last row is the one that matters: the copy and the export went elsewhere
 rather than overwriting the document being edited. An earlier build got that
 wrong and silently destroyed it.
 
+## Packaging
+
+```bash
+node scripts/pack-webext.mjs          # → dist/bento-tray-<version>.zip
+node scripts/pack-webext.mjs --check  # validate only (CI runs this)
+```
+
+It is an allow-list, not a recursive zip: `probe/`, `README.md` and `STORE.md`
+are in this directory and must not reach a listing — the probes especially,
+being four pages that open local files and talk across origins, which is
+harmless to us and alarming to a reviewer. It also checks every file the
+manifest names exists, every icon is the size it claims, and no permission is
+declared but unused. The output is byte-reproducible, so the uploaded package
+can be shown to be the reviewed one.
+
+Listing copy, permission justifications and the data-usage answers live in
+`STORE.md`.
+
 ## Distribution
 
 **The app stores are the main channel** — Chrome Web Store, Edge Add-ons, and

--- a/tray/webext/STORE.md
+++ b/tray/webext/STORE.md
@@ -1,0 +1,143 @@
+# Store listing — Bento Tray
+
+Copy for the Chrome Web Store developer dashboard, and the same text serves Edge
+Add-ons. Kept in the repo so the answers a reviewer gets are the answers the code
+actually supports, and so the next submission does not reinvent them.
+
+Build the upload with `node scripts/pack-webext.mjs` → `dist/bento-tray-<v>.zip`.
+
+---
+
+## Name
+
+```
+Bento Tray
+```
+
+## Summary (132 characters max)
+
+```
+Save a Bento document back to the file you opened, with no destination prompt.
+```
+
+## Category
+
+Productivity → Workflow & Planning
+
+## Description
+
+```
+Bento documents are single HTML files — the document, the viewer and the editor
+in one. Open one by double-clicking it and the browser will let it read itself,
+but not write itself: the first time you press Cmd-S, you get a "save as" dialog
+asking where to put a file that already has a home.
+
+Bento Tray fixes that. Point it at the folder your documents live in, once. From
+then on, Cmd-S writes straight back to the file you opened. No dialog, no second
+copy appearing beside the original, no wondering which one is current.
+
+WHAT IT DOES NOT DO
+
+"Save a copy", read-only copies, presentation packages and templates all still
+ask you where to put the new file — because those are new files, and choosing
+where they go is the point. The extension only ever writes the document you
+already had open.
+
+It sends nothing anywhere. There is no account, no sync and no server. It reads
+and writes files inside the one folder you choose, and nothing else on your
+computer.
+
+REQUIREMENTS
+
+After installing, turn on "Allow access to file URLs" on this extension's card
+in chrome://extensions. Chrome requires you to enable that by hand — no
+extension can do it for you — and nothing works until it is on. The toolbar icon
+tells you whether it is, along with whether your folder is still granted.
+
+Bento is open source: https://github.com/nyblnet/bento
+```
+
+## Single purpose
+
+```
+Bento Tray lets a locally-opened Bento document save back to its own file
+instead of prompting for a destination. That is its only function.
+```
+
+## Permission justifications
+
+**`storage`**
+
+```
+Stores the handle for the one folder the user grants, so the folder does not
+have to be chosen again on every browser restart. No document content is stored.
+```
+
+**File access (`file:///*.bento.html` content scripts)**
+
+```
+Bento documents are opened from disk, so the extension has to run on file:// to
+do anything at all. The match pattern is limited to *.bento.html rather than all
+local HTML, so it never touches unrelated local files. Two scripts are needed
+because Chrome separates the worlds: one runs in the page to provide the save
+entry point, and one relays to the extension, which is the only part that
+touches the filesystem.
+```
+
+**Why no host permissions**
+
+```
+The extension makes no network requests and needs no access to any website.
+```
+
+## Data usage disclosures
+
+| Question | Answer |
+|---|---|
+| Personally identifiable information | No |
+| Health information | No |
+| Financial information | No |
+| Authentication information | No |
+| Personal communications | No |
+| Location | No |
+| Web history | No |
+| User activity | No |
+| **Website content** | **No** — file contents are read and written locally and never transmitted |
+
+Certifications: does not sell or transfer data to third parties; does not use or
+transfer data for purposes unrelated to the single purpose; does not use or
+transfer data to determine creditworthiness or for lending.
+
+**Privacy policy URL** — required once any data question is answered yes. All
+are no here, so a policy should not be required; if the dashboard insists,
+`https://bento.page/privacy` is the address to publish one at.
+
+---
+
+## Screenshots — NOT YET MADE
+
+1280×800 or 640×400, at least one, up to five. What to capture:
+
+1. A deck open from disk with the toolbar popup showing green on both rows —
+   the state a working install is in.
+2. The options page with a folder granted.
+3. The moment that motivates the extension: the "save as" dialog you get
+   *without* it, beside a document that already has a filename.
+
+A small promo tile (440×280) is optional but improves placement.
+
+---
+
+## Before submitting
+
+- [ ] `node scripts/pack-webext.mjs` produces the zip with no problems reported
+- [ ] Load that exact zip unpacked and run the three save paths — in-place
+      silent, "Save a copy…" prompts, an export prompts
+- [ ] Test on a **clean browser profile**, which is the only way to see what a
+      new user sees: no grant, file access off, nothing primed
+- [ ] Confirm the popup reports file access correctly rather than falling to
+      "unknown" (`chrome.extension.isAllowedFileSchemeAccess()` behaviour under
+      MV3 is still unverified — the code handles the null case, but a real
+      reading is better than a handled unknown)
+- [ ] Screenshots
+- [ ] Developer account (one-off fee)

--- a/tray/webext/manifest.json
+++ b/tray/webext/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bento Tray",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Save a Bento document back to the file you opened, without a destination prompt.",
   "minimum_chrome_version": "116",
   "permissions": [

--- a/tray/webext/src/options.js
+++ b/tray/webext/src/options.js
@@ -32,7 +32,12 @@ async function report() {
   if (!s.folder) {
     lines.push('<b>No folder granted yet.</b> Choose the folder your decks live in.')
   } else if (s.permission === 'granted') {
-    lines.push(`<b class="ok">Folder: ${esc(s.folder)}</b> — decks in here save in place, with no dialog.`)
+    // Do not promise in-place saving while file access is off — that promise is
+    // false, and printing it under "nothing works until it is on" is worse than
+    // saying nothing.
+    lines.push(s.files === false
+      ? `<b>Folder: ${esc(s.folder)}</b> — ready, but nothing saves in place until file access is on.`
+      : `<b class="ok">Folder: ${esc(s.folder)}</b> — decks in here save in place, with no dialog.`)
   } else {
     lines.push(`<b class="bad">Folder: ${esc(s.folder)} — needs renewing.</b> ` +
       'The grant lapses whenever the extension restarts. Choose it again to restore it.')

--- a/tray/webext/src/page-bridge.js
+++ b/tray/webext/src/page-bridge.js
@@ -81,10 +81,12 @@
    */
   /**
    * The release that first sent a distinct picker `id` per purpose (#213).
-   * A deck whose embedded runtime predates it sends `bento-doc` for EVERY save
-   * — including "Save a copy…" — so the id carries no information there and
-   * this bridge must not act on it. If #213 ships under a different number,
-   * this constant is the one thing to change.
+   *
+   * CONFIRMED: `pickerIdFor` is absent from v1.0.14 and present in v1.0.15, so
+   * 1.0.15 is the floor. A deck whose embedded runtime predates it sends
+   * `bento-doc` for EVERY save — including "Save a copy…" — so the id carries
+   * no information there and this bridge must not act on it. Those decks get
+   * the browser's own picker, exactly as they do with no extension installed.
    */
   const ID_SINCE = [1, 0, 15]
 

--- a/tray/webext/src/popup.js
+++ b/tray/webext/src/popup.js
@@ -23,8 +23,15 @@ const files = s.files === true
     : row('meh', 'Local files — unknown',
         'This browser will not say. If saves still prompt, check <b>Allow access to file URLs</b>.')
 
+// The folder row must not promise in-place saving while the OTHER precondition
+// is failing. Seeing "decks in here save in place, with no dialog" directly
+// under "nothing works until file access is on" is two green-ish signals
+// contradicting each other, and the reassuring one is the false one.
 const folder = s.permission === 'granted'
-  ? row('ok', `Folder: ${esc(s.folder)}`, 'Decks in here save in place, with no dialog.')
+  ? row(s.files === false ? 'meh' : 'ok', `Folder: ${esc(s.folder)}`,
+      s.files === false
+        ? 'Ready, but nothing saves in place until local file access is on.'
+        : 'Decks in here save in place, with no dialog.')
   : s.folder
     ? row('bad', `Folder: ${esc(s.folder)} — needs renewing`,
         'The grant lapses whenever the extension restarts. One click in Settings restores it.')


### PR DESCRIPTION
> Stacked on #220 (icons/popup live there). Merge #220 first and this retargets.

The extension worked but there was **no way to ship it**: nothing produced an
upload, the version was still the scaffold's `0.0.1`, and none of the listing
answers existed.

## `scripts/pack-webext.mjs`, deliberately not `zip -r`

**It refuses to ship the wrong files.** `tray/webext/` holds `probe/` — four
capability probes that open local files and talk across origins, harmless to us
and alarming to a reviewer — plus `README.md` and now `STORE.md`. A recursive
zip takes the lot. The payload is an allow-list; anything unexpected in the tree
is an error.

**It checks the manifest against the tree.** Every named file exists, every icon
is really the size it claims, no permission is declared but unused. Verified by
breaking it:

```
✗ icons/icon-16.png is 128x128 but is declared as the 16px icon
```

**It is byte-reproducible.** Sorted entries, fixed timestamps, no filesystem
metadata — built twice, identical sha256. This repo holds that line for the
document shell; an extension going through a store can't be signed by us, so
reproducibility is what's left, and *"is the uploaded package the reviewed
package?"* stays answerable.

The zip is hand-written, so I checked it's a real one rather than a plausible
one: `unzip -t` passes, `unzip -l` lists 13 files, and extracted
`manifest.json`, `background.js` and `icon-128.png` each compare identical to
source.

## `STORE.md`

Listing copy, single-purpose statement, a justification per permission, and the
data-usage answers — **all No**, because the extension makes no network requests
at all. Kept in the repo so a reviewer's answers are the ones the code supports,
and the next submission doesn't reinvent them.

Screenshots are the one item still missing, and are marked as such.

## `ID_SINCE` is closed

v1.0.14 carries no `pickerIdFor`; v1.0.15 does. **1.0.15 confirmed as the
floor**, not assumed. Older decks get the browser's own picker, exactly as with
no extension installed.

## Still needs a human

- Screenshots
- A clean-profile run — the only way to see what a new user sees
- Whether the popup reports file access or falls to "unknown"