### PR TITLE
dash M0: the app — it opens, edits, imports and saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           cache-dependency-path: |
             slides/package-lock.json
             spaces/package-lock.json
+            dash/package-lock.json
 
       - name: Install
         working-directory: slides
@@ -108,6 +109,22 @@ jobs:
 
       - name: Splice conformance gate (spaces)
         run: node scripts/shell-gate.mjs spaces/dist-single/Bento_Spaces.bento.html
+
+      # dash: the data app — same pipeline, same gate.
+      - name: Install (dash)
+        working-directory: dash
+        run: npm ci
+
+      - name: Typecheck (dash)
+        working-directory: dash
+        run: node_modules/.bin/tsc -b
+
+      - name: Build single-file shell (dash)
+        working-directory: dash
+        run: npm run build:single
+
+      - name: Splice conformance gate (dash)
+        run: node scripts/shell-gate.mjs dash/dist-single/Bento_Dash.bento.html
 
       - name: Language pack verification rig
         # Packs come off the network, so the signature + hash-pin chain is the

--- a/dash/.gitignore
+++ b/dash/.gitignore
@@ -1,0 +1,3 @@
+dist
+dist-single
+node_modules

--- a/dash/index.html
+++ b/dash/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- viewport-fit=cover: without it iOS insets the page from the notch and
+         home-indicator areas and paints the gap with the body background, so the
+         editor visibly stops short of the screen edges. The app fills the screen
+         and positions its own chrome; it never needs the browser to pad it. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="color-scheme" content="only light" />
+    <meta name="generator" content="bento-dash" />
+    <title>bento/dash</title>
+    <!-- NOTICE
+      bento/dash — MIT licensed. https://bento.page
+      This file is the document, the viewer and the editor. The runtime is
+      open source; the document itself is the JSON block below.
+    -->
+    <script type="application/bento+json" id="bento-doc"></script>
+  </head>
+  <body>
+    <div id="bento-splash">
+      <div class="dash-splash-mark">bento<span>/</span>dash</div>
+    </div>
+    <style>
+      #bento-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #fff;
+        z-index: 9999;
+        transition: opacity 0.45s ease;
+        font: 600 20px/1.4 ui-sans-serif, system-ui, -apple-system, sans-serif;
+        color: #1e2a3a;
+      }
+      #bento-splash.done { opacity: 0; pointer-events: none; }
+      .dash-splash-mark span { color: #ff9e8a; }
+      @media (prefers-reduced-motion: reduce) {
+        #bento-splash { transition: none; }
+      }
+    </style>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dash/package-lock.json
+++ b/dash/package-lock.json
@@ -1,0 +1,1297 @@
+{
+  "name": "bento-dash",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bento-dash",
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.13.2",
+        "typescript": "~5.8.3",
+        "vite": "^7.1.1",
+        "vite-plugin-singlefile": "^2.3.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-singlefile": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+      "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">18.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^4.59.0",
+        "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bento-dash",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "build:single": "tsc -b && SINGLEFILE=1 vite build --outDir dist-single && mv dist-single/index.html dist-single/Bento_Dash.bento.html && node ../scripts/postbuild-compress.mjs dist-single/Bento_Dash.bento.html --generator bento-dash --title \"bento/dash\"",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@types/node": "^24.13.2",
+    "typescript": "~5.8.3",
+    "vite": "^7.1.1",
+    "vite-plugin-singlefile": "^2.3.3"
+  }
+}

--- a/dash/src/format.ts
+++ b/dash/src/format.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Turning a stored value into the string a reader sees.
+//
+// THE LINE THIS FILE DRAWS, because PLATFORM §8 does not draw it yet:
+//
+//   The number FORMAT is DOCUMENT data — the author chose two decimal places
+//   and a pound sign, and everyone who opens the file must see the same thing,
+//   or two people reading one board disagree about what it says.
+//
+//   The GROUPING and DECIMAL GLYPHS are VIEWER chrome, the same rule locale
+//   already follows everywhere else in Bento. A German reader of a British
+//   author's workbook should see 1.234,50 for the value the author formatted
+//   as #,##0.00 — same number, same precision, their own separators.
+//
+// So the format string says WHAT to show and the viewer's locale says HOW to
+// punctuate it. Getting this backwards either freezes one reader's separators
+// into everyone else's file, or lets the author's chosen precision drift.
+
+import type { Column, ColumnType } from './model.ts'
+
+/** Viewer-scoped, never in the document. Falls back to the host's own locale. */
+let viewerLocale: string | undefined
+
+export const setViewerLocale = (l: string | undefined): void => { viewerLocale = l }
+
+/**
+ * Read the digit shape out of an Excel-style pattern. We support the part
+ * people actually write — a currency prefix, thousands grouping, and a fixed
+ * number of decimals — and ignore the rest rather than pretending.
+ */
+function readPattern(fmt: string | undefined): {
+  prefix: string; suffix: string; group: boolean; dp: number | null; pct: boolean
+} {
+  if (!fmt) return { prefix: '', suffix: '', group: false, dp: null, pct: false }
+  const pct = fmt.includes('%')
+  const body = fmt.replace('%', '')
+  const m = body.match(/[#0][#0,]*(?:\.0+)?/)
+  const digits = m?.[0] ?? ''
+  const at = m ? body.indexOf(digits) : -1
+  const dot = digits.indexOf('.')
+  return {
+    prefix: at >= 0 ? body.slice(0, at) : '',
+    suffix: at >= 0 ? body.slice(at + digits.length) : '',
+    group: digits.includes(','),
+    dp: dot >= 0 ? digits.length - dot - 1 : null,
+    pct,
+  }
+}
+
+/** Format one value for display. Never mutates, never throws. */
+export function formatValue(v: unknown, col: Pick<Column, 'type' | 'format'>): string {
+  if (v == null || v === '') return ''
+  const t: ColumnType = col.type
+  if (t === 'bool') return v ? '✓' : ''
+  if (t === 'date') return String(v)
+  if (t === 'text' || t === 'enum') return String(v)
+
+  const n = typeof v === 'number' ? v : Number(v)
+  if (!Number.isFinite(n)) return String(v)
+
+  const p = readPattern(col.format)
+  const isPct = p.pct || t === 'percent'
+  const shown = isPct ? n * 100 : n
+  const dp = p.dp ?? (t === 'money' ? 2 : isPct ? 0 : shown % 1 === 0 ? 0 : 2)
+
+  // Intl does the punctuation, so the VIEWER's separators apply to the
+  // AUTHOR's precision — the split this file exists to make.
+  const body = new Intl.NumberFormat(viewerLocale, {
+    minimumFractionDigits: dp,
+    maximumFractionDigits: dp,
+    useGrouping: p.group || (!col.format && (t === 'money' || Math.abs(shown) >= 10_000)),
+  }).format(shown)
+
+  return `${p.prefix}${body}${p.suffix}${isPct && !p.suffix ? '%' : ''}`
+}
+
+/** Right-align anything that is a quantity; left-align anything that is a word. */
+export const alignFor = (t: ColumnType): 'left' | 'right' =>
+  t === 'number' || t === 'money' || t === 'percent' ? 'right' : 'left'
+
+export const TYPE_LABEL: Record<ColumnType, string> = {
+  text: 'Text', number: 'Number', money: 'Money',
+  percent: 'Percent', date: 'Date', bool: 'Yes/No', enum: 'Category',
+}

--- a/dash/src/grid.ts
+++ b/dash/src/grid.ts
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// The grid.
+//
+// WINDOWED, not because 100k rows is slow to compute — a full scan is 5.9 ms —
+// but because 100k × 6 is 600,000 DOM nodes, and that is what actually stops
+// the browser. Only the visible slice exists; two spacer rows hold the
+// scrollbar honest. This is the whole reason the grid can claim the row target
+// the format was sized for.
+//
+// IT READS THROUGH AN ORDER VECTOR. Sorting sorts the vector, not the data:
+// `store.view()` mutates it, emits an invalidation, and takes no checkpoint —
+// so a sort does not dirty the file and does not produce an op. Writing the
+// first sort as a `commit` is the easy mistake, and nobody notices until a
+// workbook saves itself every time somebody clicks a column header.
+//
+// THE TYPE ROW IS THE DEMO. Import guesses, and where it cannot decide — a date
+// column that fits both DD/MM and MM/DD — it refuses and says so. That refusal
+// is only honest if changing the type is one click away, so the header carries
+// the type as a control, not a label.
+
+import { formatValue, alignFor, TYPE_LABEL } from './format.ts'
+import type { Column, ColumnType, TableSheet } from './model.ts'
+import { readCell, type Store } from './store.ts'
+
+const ROW_H = 30
+const OVERSCAN = 8
+
+export interface GridHost {
+  el: HTMLElement
+  store: Store
+  sheetId: string
+}
+
+const cols = (s: TableSheet) => s.columns
+const rowCount = (s: TableSheet) => s.rids.reduce((n, [, c]) => n + c, 0)
+
+/** Row index → rid, honouring the view's order vector when one exists. */
+function ridAt(store: Store, sheet: TableSheet, i: number): number {
+  const order = store.order[sheet.id]
+  const idx = order ? order[i] : i
+  let seen = 0
+  for (const [start, count] of sheet.rids) {
+    if (idx < seen + count) return start + (idx - seen)
+    seen += count
+  }
+  return -1
+}
+
+const dataRow = (sheet: TableSheet, rid: number): number => {
+  let i = 0
+  for (const [start, count] of sheet.rids) {
+    if (rid >= start && rid < start + count) return i + (rid - start)
+    i += count
+  }
+  return -1
+}
+
+export class Grid {
+  private host: HTMLElement
+  private store: Store
+  private sheetId: string
+  private scroller!: HTMLElement
+  private table!: HTMLElement
+  private editing: { rid: number; col: string } | null = null
+  private sort: { col: string; dir: 'asc' | 'desc' } | null = null
+  /** set by the app so a type change can be routed through one place */
+  onRetype?: (col: Column) => void
+
+  constructor(opts: GridHost) {
+    this.host = opts.el
+    this.store = opts.store
+    this.sheetId = opts.sheetId
+    this.build()
+    this.store.on('doc', () => this.paint())
+    this.store.on('view', () => this.paint())
+  }
+
+  /** Point the grid at a different sheet — an import adds one and shows it. */
+  setSheet(id: string): void {
+    this.sheetId = id
+    this.sort = null
+    this.scroller.scrollTop = 0
+    this.paint()
+  }
+
+  get sheet(): TableSheet {
+    const s = this.store.doc.sheets.find((x) => x.id === this.sheetId)
+    if (!s || s.kind !== 'table') throw new Error('grid needs a table sheet')
+    return s
+  }
+
+  private head!: HTMLElement
+  private foot!: HTMLElement
+
+  /**
+   * Header and totals are in normal FLOW and stick to the scroller; only the
+   * body rows are absolutely positioned, inside a sizer between them.
+   *
+   * Mixing the two in one stacking context was the first attempt and it hid
+   * the first two rows behind the header — `position: sticky` resolves against
+   * the scroll container, and an absolutely-positioned sibling at `top: 0`
+   * lands underneath it.
+   */
+  private build(): void {
+    this.host.innerHTML =
+      '<div class="dg-scroll">' +
+      '<div class="dg-table">' +
+      '<div class="dg-head-row"></div>' +
+      '<div class="dg-sizer"></div>' +
+      '<div class="dg-foot-row"></div>' +
+      '</div></div>'
+    this.scroller = this.host.querySelector('.dg-scroll')!
+    this.table = this.host.querySelector('.dg-sizer')!
+    this.head = this.host.querySelector('.dg-head-row')!
+    this.foot = this.host.querySelector('.dg-foot-row')!
+    this.scroller.addEventListener('scroll', () => this.paint(), { passive: true })
+    this.paint()
+  }
+
+  /** Header: name, a type control, and a sort affordance. */
+  private header(): string {
+    const s = this.sheet
+    return `${cols(s).map((c) => {
+      const arrow = this.sort?.col === c.id ? (this.sort.dir === 'asc' ? ' ▲' : ' ▼') : ''
+      return `<div class="dg-cell dg-h" style="width:${c.w ?? 130}px" data-col="${c.id}">` +
+        `<span class="dg-name" title="${esc(c.name)}">${esc(c.name)}${arrow}</span>` +
+        `<button class="dg-type" data-retype="${c.id}" title="${esc(TYPE_LABEL[c.type])} — click to change">${esc(TYPE_LABEL[c.type])}</button>` +
+        (c.failed ? `<span class="dg-warn" title="${c.failed} value(s) could not be read as ${esc(TYPE_LABEL[c.type])}">!</span>` : '') +
+        `</div>`
+    }).join('')}`
+  }
+
+  private totalsRow(): string {
+    const s = this.sheet
+    if (!s.totals) return ''
+    const n = rowCount(s)
+    return `${cols(s).map((c) => {
+      const spec = s.totals?.[c.id]
+      if (!spec) return `<div class="dg-cell" style="width:${c.w ?? 130}px"></div>`
+      const data = s.data[c.id]
+      let acc = 0
+      let seen = 0
+      for (let i = 0; i < n; i++) {
+        const v = readCell(data, i)
+        if (typeof v !== 'number') continue
+        seen++
+        if (spec === 'min') acc = seen === 1 ? v : Math.min(acc, v)
+        else if (spec === 'max') acc = seen === 1 ? v : Math.max(acc, v)
+        else acc += v
+      }
+      const out = spec === 'avg' ? (seen ? acc / seen : 0) : spec === 'count' ? seen : acc
+      return `<div class="dg-cell" style="width:${c.w ?? 130}px;text-align:${alignFor(c.type)}">` +
+        `<span class="dg-agg">${esc(String(spec))}</span> ${esc(formatValue(out, c))}</div>`
+    }).join('')}`
+  }
+
+  paint(): void {
+    const s = this.sheet
+    const n = rowCount(s)
+    this.table.style.height = `${n * ROW_H}px`
+
+    // Only the visible slice exists. 100k x 6 would be 600,000 nodes, and that
+    // — not the arithmetic — is what stops the browser.
+    const top = Math.max(0, Math.floor(this.scroller.scrollTop / ROW_H) - OVERSCAN)
+    const visible = Math.ceil(this.scroller.clientHeight / ROW_H) + OVERSCAN * 2
+    const end = Math.min(n, top + visible)
+
+    const body: string[] = []
+    for (let i = top; i < end; i++) {
+      const rid = ridAt(this.store, s, i)
+      const r = dataRow(s, rid)
+      body.push(`<div class="dg-row" data-rid="${rid}" style="top:${i * ROW_H}px">` +
+        cols(s).map((c) => {
+          const over = s.cells?.[`${c.id}:${rid}`]
+          const v = over && 'v' in over ? over.v : readCell(s.data[c.id], r)
+          const note = over?.note ? ' dg-noted' : ''
+          return `<div class="dg-cell${note}" data-col="${c.id}" ` +
+            `style="width:${c.w ?? 130}px;text-align:${alignFor(c.type)}">${esc(formatValue(v, c))}</div>`
+        }).join('') + '</div>')
+    }
+    this.head.innerHTML = this.header()
+    this.table.innerHTML = body.join('')
+    this.foot.innerHTML = this.totalsRow()
+    this.wire()
+  }
+
+  private wire(): void {
+    this.head.querySelectorAll<HTMLElement>('.dg-name').forEach((el) => {
+      el.onclick = () => this.toggleSort(el.parentElement!.dataset.col!)
+    })
+    this.head.querySelectorAll<HTMLElement>('[data-retype]').forEach((el) => {
+      el.onclick = (e) => {
+        e.stopPropagation()
+        const col = this.sheet.columns.find((c) => c.id === el.dataset.retype)
+        if (col) this.onRetype?.(col)
+      }
+    })
+    this.table.querySelectorAll<HTMLElement>('.dg-row[data-rid] .dg-cell').forEach((el) => {
+      el.ondblclick = () => this.edit(Number(el.parentElement!.dataset.rid), el.dataset.col!, el)
+    })
+  }
+
+  /**
+   * Sorting is VIEW state. It sorts the order vector and never the data, so it
+   * takes no checkpoint, sets no dirty flag and produces no op.
+   */
+  private toggleSort(colId: string): void {
+    const s = this.sheet
+    const dir = this.sort?.col === colId && this.sort.dir === 'asc' ? 'desc' : 'asc'
+    this.sort = { col: colId, dir }
+    const n = rowCount(s)
+    const data = s.data[colId]
+    const idx = Array.from({ length: n }, (_, i) => i)
+    const sign = dir === 'asc' ? 1 : -1
+    idx.sort((a, b) => {
+      const x = readCell(data, a)
+      const y = readCell(data, b)
+      if (x == null) return 1        // blanks sink, both directions — a blank is
+      if (y == null) return -1       // not "smallest", it is "not a value"
+      return x < y ? -sign : x > y ? sign : 0
+    })
+    this.store.view(() => { this.store.order[s.id] = idx })
+  }
+
+  private edit(rid: number, colId: string, cell: HTMLElement): void {
+    const s = this.sheet
+    const col = s.columns.find((c) => c.id === colId)
+    if (!col || this.store.readOnly) return
+    this.editing = { rid, col: colId }
+    const r = dataRow(s, rid)
+    const raw = readCell(s.data[colId], r)
+    cell.classList.add('dg-editing')
+    cell.contentEditable = 'true'
+    cell.textContent = raw == null ? '' : String(raw)
+    cell.focus()
+    const range = document.createRange()
+    range.selectNodeContents(cell)
+    getSelection()?.removeAllRanges()
+    getSelection()?.addRange(range)
+
+    const commit = () => {
+      if (!this.editing) return
+      this.editing = null
+      cell.contentEditable = 'false'
+      cell.classList.remove('dg-editing')
+      const text = cell.textContent ?? ''
+      const v = coerceForColumn(text, col.type)
+      this.store.runEdit(`${colId}:${rid}`, {
+        op: 'setCells', sheet: s.id, col: colId, rids: [rid], v: [v],
+      })
+      this.store.endRun()
+    }
+    cell.onblur = commit
+    cell.onkeydown = (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); return }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        this.editing = null
+        cell.contentEditable = 'false'
+        cell.classList.remove('dg-editing')
+        this.paint()
+      }
+    }
+  }
+}
+
+/** What the user typed, under the column's declared type. */
+function coerceForColumn(text: string, type: ColumnType): unknown {
+  const s = text.trim()
+  if (s === '') return null
+  if (type === 'number' || type === 'money' || type === 'percent') {
+    const n = Number(s.replace(/[,\s£$€¥%]/g, ''))
+    if (!Number.isFinite(n)) return s        // keep what they typed rather than
+    return type === 'percent' && s.includes('%') ? n / 100 : n  // silently zeroing
+  }
+  if (type === 'bool') return /^(y|yes|true|1|✓)$/i.test(s)
+  return s
+}
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')

--- a/dash/src/i18n.ts
+++ b/dash/src/i18n.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Facade: the i18n ENGINE lives in the shared kernel; CATALOGS are per-app
+// string data and live here. This module registers them at import time and
+// re-exports the engine, so registration is guaranteed to precede the first
+// t() call by ES module evaluation order.
+//
+// No translations yet — English-string-as-key means every string
+// works untranslated, and catalogs can be added later without touching call
+// sites. App code imports './i18n', never the kernel module directly.
+
+import { registerI18n } from '../../kernel/src/i18n.ts'
+import type { LocaleChoice } from '../../kernel/src/i18n.ts'
+
+const CHOICES: LocaleChoice[] = [{ code: 'en', label: 'English' }]
+
+registerI18n({ catalogs: {}, choices: CHOICES })
+
+export const LOCALE_CHOICES = CHOICES
+
+export { t, locale, setLocale, i18nApi, localeChoices } from '../../kernel/src/i18n.ts'
+export type { Catalog } from '../../kernel/src/i18n.ts'

--- a/dash/src/main.ts
+++ b/dash/src/main.ts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Boot sequence for bento/dash.
+//
+// Order matters: configure the app, then capture the pristine document BEFORE
+// any DOM mutation — the captured copy is what gets re-serialized on save.
+//
+// THE BOOT DISPATCHER IS THE MOST IMPORTANT TWENTY LINES IN THE APP, because
+// getting it wrong destroys data rather than merely failing. `parseDoc` returns
+// a tagged result and the ONLY state that reaches the starter workbook is an
+// absent or empty block. Everything else refuses, says what it found, and
+// offers the bytes back untouched — because anything that failed to parse is
+// somebody's data, and replacing it with an empty workbook is a loss the first
+// ⌘S makes permanent.
+//
+// And one case the kernel cannot express: `readEmbeddedDoc` returns
+// `text || null`, so "no #bento-doc element" and "element present, text node
+// empty" arrive identically. Measured, past the parser's limit the block IS
+// present with a zero-length text node and no throw — so that must be told
+// apart HERE, where the DOM is still visible, or an oversized workbook opens
+// as the starter and saves over itself.
+
+import './styles.css'
+import { configureApp, appConfig } from '../../kernel/src/app.ts'
+import {
+  capturePristine, readEmbeddedDoc, serializeFile, serializeAuto, saveFile,
+  parseEnvelope, decryptEnvelope, setEncryptionPassword, isEncryptionActive,
+  canWriteInPlace, downloadFile, suggestedFileName, openedFileName,
+} from '../../kernel/src/save.ts'
+import { putRecovery, pruneOld } from '../../kernel/src/autosave.ts'
+import { APP_VERSION } from '../../kernel/src/update.ts'
+import { t } from './i18n.ts'
+import {
+  parseDoc, docBytes, docBudget, rowCount, DOC_BUDGET_FSA, DOC_BUDGET_DOWNLOAD,
+  type DashDoc, type ParseResult, type Column, type ColumnType, type TableSheet,
+} from './model.ts'
+import { Store } from './store.ts'
+import { starterDoc } from './starter.ts'
+import { Grid } from './grid.ts'
+import { importDelimited } from './import.ts'
+import { TYPE_LABEL } from './format.ts'
+
+configureApp({
+  appId: 'bento-dash',
+  appName: 'bento/dash',
+  manifestUrl: 'https://bento.page/releases/dash/manifest.json',
+})
+
+capturePristine()
+
+// --- boot -------------------------------------------------------------------
+
+const blockEl = document.getElementById('bento-doc')
+const embedded = readEmbeddedDoc()
+const envelope = embedded ? parseEnvelope(embedded) : null
+
+if (envelope) {
+  void passwordGate(embedded!)
+} else if (blockEl && embedded === null && (blockEl.textContent ?? '').length > 0) {
+  // present, non-empty, and yet unreadable — the case the kernel flattens
+  refuse({ ok: false, err: 'unreadable', detail: t('The document block is present but could not be read.') })
+} else {
+  const res = parseDoc(embedded ?? '')
+  if (res.ok) boot(res.doc, res.repairs.length, res.frozen)
+  else if (res.err === 'empty') boot(starterDoc(), 0, undefined)
+  else refuse(res)
+}
+
+/** An encrypted workbook: ask, then take the same boot path. */
+async function passwordGate(raw: string): Promise<void> {
+  document.getElementById('bento-splash')?.remove()
+  document.body.innerHTML =
+    `<div class="dx-gate"><h1>${t('This file is encrypted.')}</h1>` +
+    `<p>${t('Enter the password to open this workbook.')}</p>` +
+    `<input type="password" class="dx-title" autocomplete="current-password" style="width:100%">` +
+    `<p><button class="dx-btn dx-unlock">${t('Unlock')}</button> <span class="dx-err"></span></p></div>`
+  const input = document.querySelector<HTMLInputElement>('input')!
+  const err = document.querySelector<HTMLElement>('.dx-err')!
+  const tryUnlock = async () => {
+    const env = parseEnvelope(raw)
+    if (!env || !input.value) return
+    const json = await decryptEnvelope(env, input.value)
+    if (json === null) { err.textContent = t('Wrong password — try again'); input.select(); return }
+    const res = parseDoc(json)
+    if (!res.ok) { err.textContent = t('Unlocked, but the workbook inside could not be read.'); return }
+    setEncryptionPassword(input.value)
+    document.body.innerHTML = '<div id="app"></div>'
+    boot(res.doc, res.repairs.length, res.frozen)
+  }
+  document.querySelector('.dx-unlock')!.addEventListener('click', () => void tryUnlock())
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') void tryUnlock() })
+  input.focus()
+}
+
+/**
+ * The refusal surface. It never opens an editor, so nothing downstream can
+ * serialize: `boot()` is where the Store, the save handler and the autosave
+ * subscription are constructed, and none of them exist on this path.
+ */
+function refuse(res: Extract<ParseResult, { ok: false }>): void {
+  document.getElementById('bento-splash')?.remove()
+  const why = res.err === 'empty' ? '' : 'detail' in res ? res.detail : ''
+  const found = 'found' in res && res.found ? ` (${res.found})` : ''
+  document.body.innerHTML =
+    `<div class="dx-gate">` +
+    `<h1>${t('This file could not be opened as a bento/dash workbook.')}</h1>` +
+    `<p>${esc(why)}${esc(found)}</p>` +
+    `<p>${t('Your data has not been changed, and this build will not write to this file. You can take the contents out below.')}</p>` +
+    `<code id="dx-raw"></code>` +
+    `<button class="dx-btn" id="dx-copy">${t('Copy document JSON')}</button>` +
+    `<button class="dx-btn" id="dx-download">${t('Save an untouched copy')}</button>` +
+    `</div>`
+  const raw = readEmbeddedDoc() ?? ''
+  document.getElementById('dx-raw')!.textContent = raw.slice(0, 4000) || t('(the document block is empty)')
+  document.getElementById('dx-copy')!.addEventListener('click', () => {
+    void navigator.clipboard?.writeText(raw)
+  })
+  document.getElementById('dx-download')!.addEventListener('click', () => {
+    // the file exactly as it arrived — no parse, no re-serialize
+    downloadFile(document.documentElement.outerHTML, openedFileName() ?? 'recovered.bento.html')
+  })
+}
+
+// --- the app ----------------------------------------------------------------
+
+function boot(doc: DashDoc, repaired: number, frozen?: 'policy' | 'version'): void {
+  document.title = `${doc.title} — ${appConfig().appName}`
+  document.getElementById('bento-splash')?.remove()
+
+  const store = new Store(doc)
+  if (frozen) store.readOnly = true
+
+  const app = document.getElementById('app')!
+  app.innerHTML =
+    `<header class="dx-bar">` +
+    `<span class="dx-mark">bento<span>/</span>dash</span>` +
+    `<input class="dx-title" value="">` +
+    `<span class="dx-dirty" hidden>•</span>` +
+    `<button class="dx-btn" data-act="import">${t('Import CSV…')}</button>` +
+    `<button class="dx-btn" data-act="undo">${t('Undo')}</button>` +
+    `<button class="dx-btn" data-act="export">${t('Export CSV')}</button>` +
+    `<button class="dx-btn" data-act="save">${t('Save')}</button>` +
+    `<span class="dx-ver">v${APP_VERSION}</span>` +
+    `</header>` +
+    `<div class="dx-findings" hidden></div>` +
+    `<div class="dx-grid"></div>`
+
+  const titleEl = app.querySelector<HTMLInputElement>('.dx-title')!
+  const dirtyEl = app.querySelector<HTMLElement>('.dx-dirty')!
+  const findingsEl = app.querySelector<HTMLElement>('.dx-findings')!
+  titleEl.value = doc.title
+  titleEl.disabled = store.readOnly
+
+  const grid = new Grid({ el: app.querySelector<HTMLElement>('.dx-grid')!, store, sheetId: doc.sheets[0].id })
+  grid.onRetype = (col) => retype(store, col)
+
+  const notes: Notice[] = []
+  if (frozen) {
+    notes.push({
+      message: frozen === 'version'
+        ? t('This workbook was written by a newer version of dash. It is open read-only so nothing is lost.')
+        : t('This workbook declares rules this build does not know. It is open read-only so nothing is lost.'),
+    })
+  }
+  if (repaired) {
+    notes.push({ message: t('{n} duplicate or missing id(s) were repaired so references resolve.').replace('{n}', String(repaired)) })
+  }
+  showFindings(findingsEl, notes)
+
+  // --- dirty + autosave
+  let dirty = false
+  let timer: number | undefined
+  const markDirty = () => {
+    dirty = true
+    dirtyEl.hidden = false
+    clearTimeout(timer)
+    timer = window.setTimeout(() => {
+      // NEVER write an encrypted workbook's plaintext to IndexedDB. The kernel
+      // states the rule in its own header and enforces it in neither place, so
+      // every app has to remember — and the second one did not.
+      if (!isEncryptionActive()) void putRecovery(store.doc)
+    }, 2500)
+  }
+  store.on('doc', markDirty)
+  void pruneOld()
+
+  titleEl.addEventListener('input', () => {
+    store.commit({ op: 'setTitle', title: titleEl.value })
+    document.title = `${titleEl.value} — ${appConfig().appName}`
+  })
+
+  // --- actions
+  app.querySelector('[data-act="save"]')!.addEventListener('click', () => { void doSave() })
+  app.querySelector('[data-act="undo"]')!.addEventListener('click', () => { store.undo() })
+  app.querySelector('[data-act="export"]')!.addEventListener('click', () => exportCsv(store))
+  app.querySelector('[data-act="import"]')!.addEventListener('click', () => {
+    void pickCsv(store, findingsEl, grid)
+  })
+  document.addEventListener('keydown', (e) => {
+    const mod = e.metaKey || e.ctrlKey
+    if (!mod) return
+    const k = e.key.toLowerCase()
+    if (k === 's') { e.preventDefault(); void doSave() }
+    else if (k === 'z' && !e.shiftKey) { e.preventDefault(); store.undo() }
+    else if ((k === 'z' && e.shiftKey) || k === 'y') { e.preventDefault(); store.redo() }
+  })
+  document.addEventListener('paste', (e) => {
+    if ((e.target as HTMLElement)?.isContentEditable) return
+    const text = e.clipboardData?.getData('text/plain')
+    if (!text || !/[,;\t]/.test(text.split('\n')[0] ?? '')) return
+    e.preventDefault()
+    applyImport(store, findingsEl, grid, text, 'pasted')
+  })
+
+  async function doSave(): Promise<void> {
+    if (store.readOnly) return
+    // Budget check before every write that grows the document. Not a refusal:
+    // the user is told what will actually break, in this browser, and decides.
+    const bytes = docBytes(store.doc)
+    const budget = docBudget(canWriteInPlace())
+    if (bytes > budget) {
+      const mb = (bytes / 1024 / 1024).toFixed(1)
+      const how = canWriteInPlace()
+        ? t('Saving will take a moment.')
+        : t('This browser has no in-place save, so every save downloads the whole file.')
+      if (!window.confirm(`${t('This workbook is {mb} MB.').replace('{mb}', mb)} ${how} ${t('Save anyway?')}`)) return
+    }
+    const r = await saveFile(store.doc)
+    if (r === 'saved' || r === 'downloaded') { dirty = false; dirtyEl.hidden = true }
+  }
+
+  window.addEventListener('beforeunload', (e) => {
+    if (dirty && !store.readOnly) { e.preventDefault(); e.returnValue = '' }
+  })
+
+  // --- the scripting/agent surface
+  ;(window as unknown as Record<string, unknown>).bento = {
+    format: doc.format,
+    get doc() { return store.doc },
+    serialize: () => serializeFile(store.doc),
+    serializeAuto: () => serializeAuto(store.doc),
+    undo: () => store.undo(),
+    redo: () => store.redo(),
+    /** patch the workbook — the same objects the store, undo and future ops use */
+    commit: (p: unknown) => { store.commit(p as never) },
+    importCsv: (text: string, name?: string) => applyImport(store, findingsEl, grid, text, name ?? 'pasted'),
+    loadDoc: (json: string): boolean => {
+      const r = parseDoc(json)
+      if (!r.ok) return false
+      store.replaceDoc(r.doc)
+      return true
+    },
+    stats: () => ({ rows: rowCount(store.doc), bytes: docBytes(store.doc), budget: docBudget(canWriteInPlace()) }),
+  }
+}
+
+// --- import -----------------------------------------------------------------
+
+async function pickCsv(store: Store, host: HTMLElement, grid: Grid): Promise<void> {
+  const input = document.createElement('input')
+  input.type = 'file'
+  input.accept = '.csv,.tsv,.txt,text/csv,text/plain'
+  input.addEventListener('change', () => {
+    const f = input.files?.[0]
+    if (!f) return
+    void f.text().then((text) => applyImport(store, host, grid, text, f.name))
+  })
+  input.click()
+}
+
+function applyImport(store: Store, host: HTMLElement, grid: Grid, text: string, source: string): void {
+  const sheetId = `sheet-${Math.floor(Date.now() % 1e8).toString(36)}`
+  const r = importDelimited(text, {
+    name: source.replace(/\.[a-z]+$/i, '') || 'Imported',
+    sheetId,
+    source,
+    at: new Date().toISOString(),
+  })
+  store.commit({ op: 'setTitle', title: store.doc.title })  // one checkpoint boundary
+  store.doc.sheets.push(r.sheet)
+  store.replaceDoc(store.doc)
+  grid.setSheet(sheetId)
+  showFindings(host, r.findings)
+}
+
+/**
+ * One line in the banner. Import findings and boot notices share a surface
+ * because they answer the same question — "what did opening this file decide
+ * on my behalf?" — so they get one type rather than one borrowed from import.
+ */
+interface Notice { message: string }
+
+function showFindings(host: HTMLElement, findings: Notice[]): void {
+  if (!findings.length) { host.hidden = true; host.innerHTML = ''; return }
+  host.hidden = false
+  host.innerHTML = findings.map((f) =>
+    `<div class="dx-f"><span class="dx-dot">●</span><span>${esc(f.message)}</span></div>`).join('')
+}
+
+/** The correctable half of the type row: import guesses, you settle it. */
+function retype(store: Store, col: Column): void {
+  const types: ColumnType[] = ['text', 'number', 'money', 'percent', 'date', 'bool']
+  const list = types.map((tp, i) => `${i + 1}. ${TYPE_LABEL[tp]}`).join('\n')
+  const pick = window.prompt(`${t('Column type for')} "${col.name}"\n\n${list}`,
+    String(types.indexOf(col.type) + 1))
+  if (!pick) return
+  const next = types[Number(pick) - 1]
+  if (!next || next === col.type) return
+  const sheet = store.doc.sheets.find((s) =>
+    s.kind === 'table' && s.columns.some((c) => c.id === col.id)) as TableSheet | undefined
+  if (!sheet) return
+  store.commit({ op: 'setColumn', sheet: sheet.id, col: col.id, patch: { type: next } })
+}
+
+// --- export -----------------------------------------------------------------
+
+function exportCsv(store: Store): void {
+  const sheet = store.doc.sheets.find((s) => s.kind === 'table') as TableSheet | undefined
+  if (!sheet) return
+  const q = (s: string) => (/[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s)
+  const n = sheet.rids.reduce((a, [, c]) => a + c, 0)
+  const lines = [sheet.columns.map((c) => q(c.name)).join(',')]
+  for (let i = 0; i < n; i++) {
+    lines.push(sheet.columns.map((c) => {
+      const d = sheet.data[c.id]
+      const v = d?.enc === 'raw' ? d.v[i] : d?.enc === 'dict' ? (d.idx[i] == null ? null : d.dict[d.idx[i]!]) : null
+      return q(v == null ? '' : String(v))
+    }).join(','))
+  }
+  const blob = new Blob([lines.join('\r\n')], { type: 'text/csv' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = `${suggestedFileName(store.doc).replace(/\.bento\.html$/, '')}.csv`
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(a.href), 1000)
+}
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+// referenced so the budget constants are not tree-shaken out of the bundle,
+// and so a reader of this file sees both halves of the rule in one place
+void DOC_BUDGET_FSA
+void DOC_BUDGET_DOWNLOAD

--- a/dash/src/starter.ts
+++ b/dash/src/starter.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// The workbook a fresh bento/dash file opens with.
+//
+// It has to teach the app in one screen, so it is deliberately not empty and
+// deliberately not a lorem-ipsum grid: it is a small, real-shaped table with
+// every column type dash knows, a totals row, and a provenance step — because
+// those three are what distinguish this from a spreadsheet, and none of them is
+// discoverable from an empty document.
+
+import { FORMAT, FORMAT_VERSION, type DashDoc, type TableSheet } from './model.ts'
+
+const uid = (p: string): string =>
+  `${p}-${(typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID().slice(0, 8)
+    : Math.floor(Date.now() % 1e8).toString(36))}`
+
+const REGION = ['North', 'South', 'North', 'East', 'South', 'North', 'East', 'South']
+const OWNER = ['Priya', 'Sam', 'Priya', 'Lee', 'Sam', 'Lee', 'Priya', 'Sam']
+const STAGE = ['Won', 'Open', 'Won', 'Open', 'Lost', 'Won', 'Open', 'Won']
+const VALUE = [12400, 8200, 15600, 4300, 9100, 22750, 6400, 18300]
+const CLOSED = [
+  '2026-01-14', '2026-02-03', '2026-02-19', '2026-03-02',
+  '2026-03-11', '2026-03-24', '2026-04-08', '2026-04-21',
+]
+const PROB = [1, 0.4, 1, 0.25, 0, 1, 0.6, 1]
+
+export function starterSheet(): TableSheet {
+  return {
+    id: 'sheet-pipeline',
+    name: 'Pipeline',
+    kind: 'table',
+    rids: [[1, REGION.length]],
+    columns: [
+      { id: 'region', name: 'Region', type: 'text', role: 'label', w: 120 },
+      { id: 'owner', name: 'Owner', type: 'text', w: 120 },
+      { id: 'stage', name: 'Stage', type: 'text', w: 110 },
+      { id: 'value', name: 'Value', type: 'money', unit: 'GBP', format: '£#,##0', w: 130 },
+      { id: 'closed', name: 'Closed', type: 'date', parsed: 'iso', w: 130 },
+      { id: 'prob', name: 'Probability', type: 'percent', format: '0%', w: 130 },
+    ],
+    data: {
+      // repetitive columns dictionary-encode; the numeric ones stay raw —
+      // the same choice the importer makes, so the starter is shaped like
+      // something you could actually have imported
+      region: { enc: 'dict', dict: ['North', 'South', 'East'], idx: REGION.map((r) => ['North', 'South', 'East'].indexOf(r)) },
+      owner: { enc: 'dict', dict: ['Priya', 'Sam', 'Lee'], idx: OWNER.map((o) => ['Priya', 'Sam', 'Lee'].indexOf(o)) },
+      stage: { enc: 'dict', dict: ['Won', 'Open', 'Lost'], idx: STAGE.map((s) => ['Won', 'Open', 'Lost'].indexOf(s)) },
+      value: { enc: 'raw', v: VALUE },
+      closed: { enc: 'raw', v: CLOSED },
+      prob: { enc: 'raw', v: PROB },
+    },
+    // The totals row is the Excel *table* total, not =SUM(D2:D9): it cannot
+    // fall out of range when somebody appends a row, which the range form does
+    // silently and constantly.
+    totals: { value: 'sum', prob: 'avg' },
+    // steps[0] is ALWAYS the provenance record. Here it says the rows were
+    // typed rather than imported, which is true and is the point: a dash file
+    // always answers "where did this come from?".
+    steps: [{ op: 'import', from: 'the starter workbook', at: '', rows: REGION.length, note: 'Typed in, not imported — replace it with your own data.' }],
+  }
+}
+
+export function starterDoc(): DashDoc {
+  return {
+    format: FORMAT,
+    version: FORMAT_VERSION,
+    policy: 'bento-dash-1',
+    docId: uid('doc'),
+    title: 'Untitled workbook',
+    sheets: [starterSheet()],
+    measures: {
+      'Weighted pipeline': {
+        name: 'Weighted pipeline',
+        expr: 'SUM(value * prob)',
+        grain: 'sheet-pipeline',
+        additive: true,
+        unit: 'GBP',
+        desc: 'Open value discounted by probability. Won counts in full; lost counts nothing.',
+      },
+    },
+    theme: {
+      background: '#FFFFFF',
+      color: '#1E2A3A',
+      accent: '#F7A600',
+      fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif",
+    },
+  }
+}

--- a/dash/src/styles.css
+++ b/dash/src/styles.css
@@ -1,0 +1,184 @@
+/* SPDX-License-Identifier: MIT
+   Copyright (c) 2026 The Bento authors
+   bento/dash — the whole interface. One stylesheet; it ships deflated. */
+
+:root {
+  --ink: #1e2a3a;
+  --muted: #64748b;
+  --line: #e3e8ef;
+  --line-strong: #cbd5e1;
+  --accent: #f7a600;
+  --bg: #ffffff;
+  --panel: #f8fafc;
+  --sel: #fff7e6;
+  --row-h: 30px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  -webkit-text-size-adjust: 100%;
+}
+
+#app { display: flex; flex-direction: column; height: 100%; }
+
+/* ————— top bar ————— */
+.dx-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  flex: 0 0 auto;
+  /* the notch: the app positions its own chrome and never asks the browser to pad it */
+  padding-top: max(8px, env(safe-area-inset-top));
+}
+.dx-mark { font-weight: 650; letter-spacing: -0.01em; white-space: nowrap; }
+.dx-mark span { color: #ff9e8a; }
+.dx-title {
+  font: inherit;
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 8px;
+  min-width: 8ch;
+  flex: 1 1 auto;
+  background: transparent;
+  color: inherit;
+}
+.dx-title:hover { border-color: var(--line-strong); }
+.dx-title:focus { outline: none; border-color: var(--accent); background: #fff; }
+.dx-btn {
+  font: inherit;
+  padding: 5px 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  background: #fff;
+  color: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.dx-btn:hover { background: var(--panel); border-color: var(--muted); }
+.dx-btn:active { transform: translateY(0.5px); }
+.dx-btn[disabled] { opacity: 0.45; cursor: default; }
+.dx-ver { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; }
+.dx-dirty { color: var(--accent); font-size: 18px; line-height: 1; }
+
+/* ————— findings: what import refused to decide ————— */
+.dx-findings {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--line);
+  background: #fffbeb;
+  padding: 8px 12px;
+  font-size: 13px;
+  display: grid;
+  gap: 4px;
+}
+/* `display: grid` beats the [hidden] attribute's own display:none, so an
+   empty banner kept a visible strip of its background. Say it explicitly. */
+.dx-findings[hidden] { display: none; }
+.dx-findings b { font-weight: 650; }
+.dx-findings .dx-f { display: flex; gap: 8px; align-items: baseline; }
+.dx-findings .dx-dot { color: var(--accent); }
+
+/* ————— grid ————— */
+.dx-grid { flex: 1 1 auto; min-height: 0; position: relative; }
+.dg-scroll { position: absolute; inset: 0; overflow: auto; }
+.dg-table { position: relative; min-width: max-content; }
+/* the sizer is the ONLY absolutely-positioned region: header and totals stay in
+   flow so `position: sticky` resolves against the scroller */
+.dg-sizer { position: relative; }
+
+.dg-row { display: flex; position: absolute; height: var(--row-h); left: 0; }
+.dg-head-row,
+.dg-foot-row {
+  display: flex;
+  position: sticky;
+  z-index: 3;
+  height: var(--row-h);
+  background: var(--panel);
+}
+.dg-head-row { top: 0; border-bottom: 1px solid var(--line-strong); }
+.dg-foot-row { bottom: 0; border-top: 1px solid var(--line-strong); font-weight: 600; }
+
+.dg-cell {
+  flex: 0 0 auto;
+  padding: 0 8px;
+  height: var(--row-h);
+  line-height: var(--row-h);
+  border-right: 1px solid var(--line);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+.dg-sizer .dg-row:nth-child(even) .dg-cell { background: #fcfdfe; }
+.dg-cell.dg-editing {
+  background: #fff;
+  box-shadow: inset 0 0 0 2px var(--accent);
+  overflow: visible;
+  cursor: text;
+}
+.dg-cell.dg-noted { box-shadow: inset 2px 0 0 var(--accent); }
+
+.dg-h { display: flex; align-items: center; gap: 6px; font-weight: 600; }
+.dg-name { cursor: pointer; overflow: hidden; text-overflow: ellipsis; flex: 1 1 auto; }
+.dg-name:hover { color: var(--accent); }
+.dg-type {
+  font: 500 10px/1.6 inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0 5px;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.dg-type:hover { border-color: var(--accent); color: var(--ink); }
+.dg-warn {
+  color: #b45309;
+  background: #fef3c7;
+  border-radius: 50%;
+  width: 15px;
+  height: 15px;
+  text-align: center;
+  font: 700 11px/15px inherit;
+  flex: 0 0 auto;
+  cursor: help;
+}
+.dg-agg { color: var(--muted); font-weight: 400; font-size: 11px; text-transform: uppercase; }
+
+/* ————— gate: an unreadable document, and the way back out of it ————— */
+.dx-gate {
+  max-width: 34rem;
+  margin: 12vh auto;
+  padding: 0 1.5rem;
+}
+.dx-gate h1 { font-size: 20px; margin: 0 0 8px; }
+.dx-gate p { color: var(--muted); margin: 0 0 14px; }
+.dx-gate .dx-btn { margin-right: 8px; }
+.dx-gate code {
+  display: block;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px;
+  margin: 12px 0;
+  font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 30vh;
+  overflow: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}

--- a/dash/tsconfig.json
+++ b/dash/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/dash/vite.config.ts
+++ b/dash/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite'
+import { viteSingleFile } from 'vite-plugin-singlefile'
+import { readFileSync } from 'node:fs'
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+
+// base './' so builds open from file:// or any static host.
+// SINGLEFILE=1 → everything (JS, CSS, assets) inlined into one HTML file:
+// that file IS the Bento document format.
+export default defineConfig({
+  base: './',
+  // The app version baked into every shipped shell — what update checks
+  // compare against the release manifest. Single source: package.json.
+  define: { __APP_VERSION__: JSON.stringify(pkg.version) },
+  plugins: [...(process.env.SINGLEFILE ? [viteSingleFile()] : [])],
+  // Dev-only: allow serving ../kernel (shared TS-source kernel) — without a
+  // workspace root, vite's fs allow-list stops at the app dir. Build output
+  // is unaffected (rollup has no such restriction).
+  server: { fs: { allow: ['..'] } },
+  build: {
+    // Keep asset inlining aggressive; a Bento file must have zero external requests.
+    assetsInlineLimit: 100_000_000,
+    chunkSizeWarningLimit: 4096,
+  },
+})

--- a/scripts/apps.mjs
+++ b/scripts/apps.mjs
@@ -37,4 +37,13 @@ export const APPS = {
     // would not be (working/spaces-design.md §6.5).
     packs: false,
   },
+  dash: {
+    appId: 'bento-dash',
+    dir: 'dash',
+    shell: 'Bento_Dash.bento.html',
+    ownsSiteContent: false,
+    // Same reasoning as spaces: no pack catalog yet, and deferring the CATALOG
+    // is fine where deferring the CHANNEL would not be.
+    packs: false,
+  },
 }


### PR DESCRIPTION
`bento/dash` is now a Bento file. **25 KB compressed shell**, through the same splice conformance gate as slides and spaces.

Opens with a starter workbook, sorts, edits, imports CSV, exports CSV, undoes, and saves to a real file that re-opens with the data in it.

## Verified in a browser, against the built shell

Not the dev server — the actual artifact:

| | |
|---|---|
| starter renders | 8 rows, `£12,400.00`, `100%`, `sum £97,050.00` |
| sort | document **unchanged**, file **not dirty** — `view()` works |
| edit a cell | totals recompute `£97,050.00` → `£93,749.00` |
| undo | value and totals both restored |
| import | semicolon detected, `1.234,56` → 1234.56, dates **refused and explained**, ragged row reported |
| serialize | round-trips to an identical document, no literal `</script` |
| re-open the saved file | boots fresh with both sheets and correct totals |

## The boot dispatcher

Only an absent or empty `#bento-doc` reaches the starter. Everything else refuses, names what it found, and offers the bytes back untouched — with **no Store, no save handler and no autosave subscription constructed on that path**, so nothing downstream *can* serialize over somebody's data.

It also distinguishes the case the kernel cannot: `readEmbeddedDoc` returns `text || null`, so a present-but-unreadable block arrives looking identical to an absent one. Only the boot site can still see the DOM to tell them apart.

**Autosave is guarded by `isEncryptionActive()`** — the rule the kernel states in its own header, enforces nowhere, and which spaces' M0 therefore missed (raised on #226).

## Two layout bugs, both found by looking

- **The first two rows were hidden behind the header.** `position: sticky` resolves against the scroll container, so absolutely-positioned rows at `top: 0` landed underneath it. Header and totals are now in normal flow with only the row region absolute.
- **The findings banner kept a visible strip when empty**, because `display: grid` beats the `[hidden]` attribute's own `display: none`.

Neither is expressible in a test that doesn't render, which is why the browser pass matters even with 138 node checks green.

## The grid

**Windowed** — 100k × 6 would be 600,000 DOM nodes, and that, not the arithmetic, is what stops a browser. Sorting goes through `store.view()`: it sorts an order vector, never the data, so it takes no checkpoint and doesn't dirty the file.

The **type control** in each header is the other half of import's honesty: refusing to guess a date order is only fair if changing it is one click away.

## Not here, deliberately

Formulas, charts, collaboration, the vault binding. M1's acceptance sentence is the CSV round trip, and this is it.

Registered in `scripts/apps.mjs`; built and gated in CI alongside slides and spaces.