### PR TITLE
ci: run the dash formula and chart rigs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,20 @@ jobs:
         # the decimal convention is decided per COLUMN from the whole column.
         run: node scripts/test-dash-import.ts
 
+      - name: bento/dash formula rig
+        # A wrong number is the worst failure a spreadsheet has, and the
+        # dangerous ones are plausible rather than loud: an error that becomes a
+        # zero, a cycle that resolves to something, a column computed before the
+        # column it depends on. All three are asserted, each with a control.
+        run: node scripts/test-dash-formula.ts
+
+      - name: bento/dash chart rig
+        # A tile names columns and derives its series at render, so the whole
+        # surface worth testing is the derivation. The failure that matters most
+        # is a missing value drawn as a zero — "we sold nothing" instead of "we
+        # do not know".
+        run: node scripts/test-dash-chart.ts
+
       - name: Built-in layout geometry rig
         # The built-ins are drawn against 1600x900 while the model default is
         # 1280x720, so they used to hang 200px off the right edge of a default


### PR DESCRIPTION
Two CI steps, split out of #235.

**Needs to be merged from the browser** — my token carries `repo` but not `workflow` scope, so merging anything that touches `.github/workflows/` returns:

```
refusing to allow an OAuth App to create or update workflow
`.github/workflows/ci.yml` without `workflow` scope (HTTP 403)
```

The code from #235 is already on `main`; these steps didn't travel with it, so the rigs exist and CI doesn't run them yet.

- `test-dash-formula.ts` — 52 checks. The dangerous formula failures are plausible rather than loud: an error that becomes a zero, a cycle that resolves to something, a column computed before its dependency.
- `test-dash-chart.ts` — 17 checks. The derivation is the whole surface, and the failure that matters most is a missing value drawn as a zero.

Both node-only, under a second combined.