### PR TITLE
The topbar fits itself by measuring, not by width breakpoints

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -421,25 +421,34 @@ export class Editor {
       for (const k of kids) this.phoneChrome.homeOf.set(k, g)
     }
 
-    // drive it now and whenever the query flips
-    // Held on `this` deliberately: a MediaQueryList that nothing references can
-    // be collected along with its listener, and the bar then never unfolds when
-    // the window grows — the CSS flips but the JS half silently stops.
-    this.phoneQuery = window.matchMedia('(max-width: 700px)')
+    // drive it now and whenever the bar's size or content changes.
     // build() has just re-authored the bar, so whatever folding state a PREVIOUS
     // bar was in no longer describes this DOM. Without this reset a rebuild on a
     // phone (switching language, say) would early-return on `true === true` and
     // leave the freshly authored DESKTOP bar in place — overflowing, with Save
     // off-screen again.
     this.phoneChromeOn = null
-    this.applyPhoneChrome(this.phoneQuery.matches)
-    this.phoneQuery.addEventListener('change', (e) => this.applyPhoneChrome(e.matches))
-    // ...and on plain resize as well. matchMedia's change event is the correct
-    // signal but not a universally reliable one — it does not fire at all under
-    // CDP-driven viewport changes, and a phone ROTATING is exactly this path.
-    // applyPhoneChrome early-returns when the state is unchanged, so calling it
-    // on every resize costs a comparison.
-    window.addEventListener('resize', () => this.applyPhoneChrome(window.innerWidth <= 700))
+    this.topbar = bar
+    this.fitTopbar()
+    // A ResizeObserver on the bar itself is the primary width signal. It fires
+    // for every viewport change (matchMedia change events do not fire at all
+    // under CDP-driven viewport changes, and a phone ROTATING is exactly this
+    // path); the plain resize listener is belt and braces on top. fitTopbar
+    // is idempotent, so the overlap costs a few reads.
+    this.barRO?.disconnect()
+    this.barRO = new ResizeObserver(() => this.fitTopbar())
+    this.barRO.observe(bar)
+    window.addEventListener('resize', () => this.fitTopbar())
+    // The bar's CONTENT changes width too, at a constant viewport (avatars
+    // join, the update chip appears, the file chip fills in, the "Saved" tag
+    // flashes), and each of these used to clip the end of the bar. fitTopbar
+    // drops the records its own mutations queue, so this cannot loop.
+    this.barMO?.disconnect()
+    this.barMO = new MutationObserver(() => this.fitTopbar())
+    this.barMO.observe(bar, {
+      childList: true, subtree: true, characterData: true,
+      attributes: true, attributeFilter: ['style', 'hidden'],
+    })
 
     this.restorePanelWidths()
     this.canvas = new SlideCanvas(canvasWrap, this.store)
@@ -571,11 +580,13 @@ export class Editor {
   } | null = null
 
   /**
-   * Fold the topbar into menus on a phone, and unfold it again on a wide
-   * window. REPARENTS the existing buttons rather than building phone copies:
-   * a duplicate would need its own listeners and would desync from live state
-   * (the dirty dot lives ON the save button; the comment button carries an
-   * armed class). Moving a node keeps all of that by construction.
+   * Fold the topbar into menus, and unfold it again when there is room.
+   * Driven by fitTopbar (every phone, plus any window where even the icon
+   * tier overflows). REPARENTS the existing buttons rather than building
+   * phone copies: a duplicate would need its own listeners and would desync
+   * from live state (the dirty dot lives ON the save button; the comment
+   * button carries an armed class). Moving a node keeps all of that by
+   * construction.
    */
   private applyPhoneChrome(on: boolean) {
     const p = this.phoneChrome
@@ -642,7 +653,59 @@ export class Editor {
   }
 
   private phoneChromeOn: boolean | null = null
-  private phoneQuery: MediaQueryList | null = null
+  private topbar: HTMLElement | null = null
+  private barRO: ResizeObserver | null = null
+  private barMO: MutationObserver | null = null
+
+  /**
+   * Size the topbar by MEASURING it, not by width breakpoints. Breakpoints
+   * in px were wrong here: browser zoom, OS text scaling, wider translations
+   * and live content (avatars, the update chip) all change how much room the
+   * same buttons need at the same viewport width, and each of those cases
+   * used to clip the end of the bar. Instead, start from the widest layout
+   * and step down a tier while the bar still overflows its own box. First
+   * ed-bar-compact hides the button labels, then ed-bar-tight drops the
+   * wordmark, then ed-bar-fold moves buttons into menus (applyPhoneChrome).
+   */
+  private fitTopbar() {
+    const bar = this.topbar
+    if (!bar || !bar.isConnected) return
+    const tiers = ['ed-bar-compact', 'ed-bar-tight', 'ed-bar-fold']
+    // Phones fold unconditionally. The 700px media query is also what turns
+    // the panels into overlay drawers, and the folded bar belongs with it.
+    if (window.innerWidth <= 700) {
+      bar.classList.add(...tiers)
+      this.applyPhoneChrome(true)
+      this.barMO?.takeRecords()
+      return
+    }
+    // Re-fitting starts by unfolding, which reparents buttons and would slam
+    // shut a dropdown the user is reading. Skip while one is open; the next
+    // resize or content change runs this again.
+    if (bar.querySelector('.ed-dropdown.open')) return
+    // scrollWidth counts content that sticks out of the padding box even with
+    // overflow visible, so "scrollWidth > clientWidth" IS the clipped-buttons
+    // condition (ed-root clips whatever leaks). The 1px slack absorbs
+    // subpixel rounding at fractional zoom levels.
+    const overflow = () => bar.scrollWidth - bar.clientWidth > 1
+    // The title input is the bar's only shrinkable item, so flexbox crushes
+    // it toward its 48px floor before anything overflows. Waiting for hard
+    // overflow would mean full button labels beside an unusable title, so
+    // step down while the title is squeezed badly, not only on true overflow.
+    const title = bar.querySelector<HTMLElement>('.ed-title')
+    const cramped = () => overflow() || (!!title && title.getBoundingClientRect().width < 120)
+    bar.classList.remove(...tiers)
+    this.applyPhoneChrome(false)
+    if (cramped()) bar.classList.add('ed-bar-compact')
+    if (cramped()) bar.classList.add('ed-bar-tight')
+    if (overflow()) {
+      bar.classList.add('ed-bar-fold')
+      this.applyPhoneChrome(true)
+    }
+    // the class flips and reparenting above queued mutation records of their
+    // own; drop them, or the observer re-runs this forever
+    this.barMO?.takeRecords()
+  }
 
   togglePanel(side: 'left' | 'right') {
     const el = side === 'left' ? this.sidebar : this.props

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -151,7 +151,7 @@ option { background: #fff; color: #1e2a3a; }
   cursor: default;
 }
 .ed-filechip[hidden] { display: none; }
-@media (max-width: 1200px) { .ed-filechip { display: none; } }
+.ed-topbar.ed-bar-compact .ed-filechip { display: none; }
 
 /* unsaved-changes dot — badges the SAVE button's corner (amber when dirty) */
 .ed-dirty {
@@ -1936,45 +1936,73 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   font-size: 12.5px;
 }
 
-/* --- responsive topbar: labels give way, never a scrollbar ---------------- */
+/* --- responsive topbar: labels give way, never a scrollbar ----------------
+   The tiers are CLASSES, not width breakpoints. editor.ts fitTopbar()
+   MEASURES the bar and steps down a tier while it still overflows. Width
+   breakpoints were wrong here because the same buttons need a different
+   amount of room at the same viewport width (OS text scaling, browser zoom,
+   wider translations, the update chip or the avatar strip appearing), and
+   every one of those cases used to clip the end of the bar.
+   ed-bar-compact hides button labels, ed-bar-tight drops the wordmark,
+   ed-bar-fold moves buttons into menus (applyPhoneChrome). */
 .ed-topbar { min-width: 0; }
 .ed-topbar .ed-group { flex-shrink: 0; }
 .ed-logo { flex-shrink: 0; }
 .ed-title { flex: 0 1 220px; min-width: 48px; }
-@media (max-width: 1200px) {
-  .ed-topbar .ed-btn > span { display: none; } /* icons + tooltips take over */
-  .ed-topbar .ed-btn.ed-btn-update > span { display: inline; } /* version chip is signal */
-  /* …but NEVER inside an open dropdown/menu — those items are text; hiding
-     their labels left icon-only mystery menus on phones. */
-  .ed-topbar .ed-menu .ed-btn > span,
-  .ed-topbar .ed-menu button > span { display: inline; }
-  /* keep the safe-area insets — a bare padding here would undo them */
-  .ed-topbar {
-    gap: 6px;
-    padding: max(8px, env(safe-area-inset-top), var(--tray-safe-top, 0px)) max(8px, env(safe-area-inset-right), var(--tray-safe-right, 0px))
-             8px max(8px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
-  }
+.ed-topbar.ed-bar-compact .ed-btn > span { display: none; } /* icons + tooltips take over */
+.ed-topbar.ed-bar-compact .ed-btn.ed-btn-update > span { display: inline; } /* version chip is signal */
+/* …but NEVER inside an open dropdown/menu — those items are text; hiding
+   their labels left icon-only mystery menus on phones. */
+.ed-topbar.ed-bar-compact .ed-menu .ed-btn > span,
+.ed-topbar.ed-bar-compact .ed-menu button > span { display: inline; }
+/* keep the safe-area insets — a bare padding here would undo them */
+.ed-topbar.ed-bar-compact {
+  gap: 6px;
+  padding: max(8px, env(safe-area-inset-top), var(--tray-safe-top, 0px)) max(8px, env(safe-area-inset-right), var(--tray-safe-right, 0px))
+           8px max(8px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
 }
-@media (max-width: 760px) {
-  .ed-topbar {
-    gap: 4px;
-    padding: max(6px, env(safe-area-inset-top), var(--tray-safe-top, 0px)) max(6px, env(safe-area-inset-right), var(--tray-safe-right, 0px))
-             6px max(6px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
-  }
-  .ed-logo > b { display: none; } /* mark only — the icon is the brand */
+.ed-topbar.ed-bar-tight {
+  gap: 4px;
+  padding: max(6px, env(safe-area-inset-top), var(--tray-safe-top, 0px)) max(6px, env(safe-area-inset-right), var(--tray-safe-right, 0px))
+           6px max(6px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
+}
+.ed-topbar.ed-bar-tight .ed-logo > b { display: none; } /* mark only — the icon is the brand */
+
+/* --- fold: the bar cannot fit, so most of it moves into menus -------------
+   Hiding labels is not enough — 17 icon buttons at 36px plus gaps is an
+   irreducible ~684px floor. When even the tight tier overflows (every phone,
+   and a desktop window under heavy zoom or huge system text) fitTopbar adds
+   ed-bar-fold and applyPhoneChrome() REPARENTS the low-priority controls
+   into "＋" and "⋯" dropdowns, leaving: logo · title · ☰ · ＋ · undo · format ·
+   save · ⋯ . Labels come back inside menus via the compact rule above. */
+/* the phone-only controls exist in the DOM at every width; only the fold class
+   shows them, so applyPhoneChrome never has to create or destroy anything */
+.ed-phone-only { display: none; }
+.ed-topbar.ed-bar-fold .ed-phone-only { display: inline-flex; }
+/* Save stays one tap; its save-AS caret does not fit beside the fold's small
+   set of buttons and is the least-used half. The list it opens is not lost —
+   editor.ts appends it to the bottom of ⋯ while the fold is on. */
+.ed-topbar.ed-bar-fold .ed-split-caret { display: none; }
+/* ⋯ carries the demoted buttons AND that list, so it can outgrow the
+   screen in BOTH directions.
+   Down: without a bound it runs off the bottom, and a dropdown is absolutely
+   positioned, so nothing else can scroll it back into reach.
+   Sideways: these menus open from buttons in the right half of a 402px bar,
+   and a start-anchored menu grows AWAY from the screen — ⋯ sits at x≈374, so
+   even the old six short rows were partly cut off. Anchoring to the end grows
+   them inward instead. */
+.ed-topbar.ed-bar-fold .ed-menu {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  max-width: calc(100vw - 16px);
+  max-height: calc(100dvh - 96px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-/* --- phones: the bar cannot fit, so most of it moves into menus -----------
-   Hiding labels is not enough — 17 icon buttons at 36px plus gaps is an
-   irreducible ~684px floor. Under 700px (the same threshold the JS uses to
-   collapse both panels) applyPhoneChrome() REPARENTS the low-priority controls
-   into "＋" and "⋯" dropdowns, leaving: logo · title · ☰ · ＋ · undo · format ·
-   save · ⋯ . Labels come back inside menus via the 1200px rule above. */
-/* the phone-only controls exist in the DOM at every width; only the query shows
-   them, so applyPhoneChrome never has to create or destroy anything */
-.ed-phone-only { display: none; }
+/* --- phones proper: viewport-scoped chrome that is about TOUCH and small
+   screens, not about whether the bar fits, so it stays a media query */
 @media (max-width: 700px) {
-  .ed-phone-only { display: inline-flex; }
   /* HIG touch targets — a 36px icon is a mis-tap on glass */
   .ed-topbar .ed-btn { min-width: 44px; min-height: 44px; justify-content: center; }
   .ed-topbar .ed-menu .ed-btn { min-width: 0; } /* menu rows are text, not targets */
@@ -1997,26 +2025,6 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   .ed-main { position: relative; }
   /* the 16px resizer chevrons are replaced by real buttons in the bar */
   .ed-panel-toggle { display: none; }
-  /* Save stays one tap; its save-AS caret does not fit beside a 44px target
-     and is the least-used half. The list it opens is not lost — editor.ts
-     appends it to the bottom of ⋯ while phone chrome is on. */
-  .ed-topbar .ed-split-caret { display: none; }
-  /* ⋯ now carries the demoted buttons AND that list, so it can outgrow the
-     screen in BOTH directions.
-     Down: without a bound it runs off the bottom, and a dropdown is absolutely
-     positioned, so nothing else can scroll it back into reach.
-     Sideways: these menus open from buttons in the right half of a 402px bar,
-     and a start-anchored menu grows AWAY from the screen — ⋯ sits at x≈374, so
-     even the old six short rows were partly cut off. Anchoring to the end grows
-     them inward instead. */
-  .ed-topbar .ed-menu {
-    inset-inline-start: auto;
-    inset-inline-end: 0;
-    max-width: calc(100vw - 16px);
-    max-height: calc(100dvh - 96px);
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-  }
   .ed-title { min-width: 0; }
 }
 


### PR DESCRIPTION
Px breakpoints clipped the end of the bar whenever the same buttons needed more room at the same viewport width (browser zoom, OS text scaling, wider translations, the update chip or avatars appearing). fitTopbar() now measures the bar and steps down a tier while it still overflows: ed-bar-compact hides labels, ed-bar-tight drops the wordmark, ed-bar-fold moves buttons into menus via applyPhoneChrome. Driven by a ResizeObserver on the bar plus a MutationObserver for content changes; the 700px media query keeps only the viewport-scoped phone chrome (drawer panels, touch targets).

<!-- Thanks for contributing! Keep PRs focused — one concern each. -->

**What & why**

The editor topbar used to collapse at fixed pixel breakpoints (1200 for labels, 760 for the wordmark, 700 for the phone fold). The problem is that the room the same buttons need at the same viewport width isn't constant. Browser zoom, OS text scaling, wider translations, and live content like the update chip or the avatar strip all change it, and every one of those cases could clip buttons off the end of the bar. CSS can't see any of this because media queries and container queries measure the container, never whether the content actually fits in it.

So the tiers are now classes instead of breakpoints. A new fitTopbar() in editor.ts starts from the widest layout and steps down while the bar still overflows its own box (scrollWidth against clientWidth, plus a check for the title input getting crushed, since it's the only shrinkable thing in the bar and absorbs all the pressure first). ed-bar-compact hides button labels, ed-bar-tight drops the wordmark, and ed-bar-fold moves buttons into menus through the existing applyPhoneChrome reparenting. A ResizeObserver on the bar catches width changes and a MutationObserver catches content changes. The 700px media query stays, but only for the genuinely viewport-scoped phone chrome (overlay drawer panels and 44px touch targets), and phones always fold like before.

A few things worth knowing about how this behaves. The mutation observer watches child changes, text, and the style and hidden attributes, so if future bar content changes its width purely through a class toggle it won't trigger a re-fit until the next resize (easy one-line filter tweak when that comes up). Re-fits are also skipped while a dropdown is open, because re-fitting would slam it shut; in the rare case content grows during that window the bar can sit slightly overflowed until the next event, and then fixes itself. And debugging the bar's state now means looking at which ed-bar classes were applied rather than reading the stylesheet.

**How I verified it**

Verified in the browser at 1500, 1100, 750, and 640px, and with CSS zoom at a fixed viewport (the exact case the old breakpoints couldn't see). tsc, build:single, shell-gate, i18n coverage, and the preview, autosave, validate, clipboard, layouts, and savepurpose rigs all pass.

**Checklist**

- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Document format changes are additive and backward-compatible
- [x] Did not bump the version or cut a release (maintainers sign releases)
