### PR TITLE
webext: the file we write must BE the sender's file, not merely share its name

### DIFF
--- a/scripts/test-webext-background.ts
+++ b/scripts/test-webext-background.ts
@@ -37,10 +37,16 @@ function ok(cond: boolean, msg: string) {
 // ---- a fake granted folder --------------------------------------------------
 const written = new Map<string, string>()
 
-function fileHandle(name: string) {
+/**
+ * A file in the fake grant. `rel` is its path RELATIVE to the granted folder,
+ * which is what a real `FileSystemDirectoryHandle.resolve()` returns — and the
+ * thing the identity check depends on.
+ */
+function fileHandle(name: string, rel?: string[]) {
   return {
     kind: 'file' as const,
     name,
+    __rel: rel ?? [name],
     async createWritable() {
       let buf = ''
       return {
@@ -51,14 +57,21 @@ function fileHandle(name: string) {
   }
 }
 
-function dirHandle(tree: Record<string, any>, perm = 'granted') {
+function dirHandle(tree: Record<string, any>, perm = 'granted', base: string[] = []) {
   return {
     kind: 'directory' as const,
-    name: 'Decks',
+    name: base.at(-1) ?? 'Decks',
     async queryPermission() { return perm },
+    /** The real API: path segments from THIS directory down to `child`, or null. */
+    async resolve(child: any) {
+      const rel = child?.__rel
+      if (!rel) return null
+      // only children at or below this directory resolve
+      return base.every((seg, i) => rel[i] === seg) ? rel.slice(base.length) : null
+    },
     async *entries() {
       for (const [k, v] of Object.entries(tree)) {
-        yield [k, typeof v === 'object' && !v.kind ? dirHandle(v, perm) : v] as const
+        yield [k, typeof v === 'object' && !v.kind ? dirHandle(v, perm, [...base, k]) : v] as const
       }
     },
   }
@@ -95,8 +108,8 @@ const deps = (tree: Record<string, any>, perm = 'granted') => ({
 {
   // the same name in two subfolders — the case a real Decks folder hits
   const tree = {
-    ClientA: { 'Q3.bento.html': fileHandle('a/Q3.bento.html') },
-    ClientB: { 'Q3.bento.html': fileHandle('b/Q3.bento.html') },
+    ClientA: { 'Q3.bento.html': fileHandle('Q3.bento.html', ['ClientA', 'Q3.bento.html']) },
+    ClientB: { 'Q3.bento.html': fileHandle('Q3.bento.html', ['ClientB', 'Q3.bento.html']) },
   }
   const r = await resolve(senderFor('/Users/x/Decks/ClientA/Q3.bento.html'), deps(tree))
   ok(r.ok === false && /ambiguous/.test(r.reason!),
@@ -113,6 +126,42 @@ const deps = (tree: Record<string, any>, perm = 'granted') => ({
     deps({ 'Q3.bento.html': fileHandle('Q3.bento.html') }))
   ok(r.ok === false && /not a local file/.test(r.reason!),
     'an http page cannot resolve a file in the granted folder')
+}
+
+// ---- 2b. a NAME match is not an IDENTITY match ------------------------------
+// The bug this rig did not previously cover, and it destroyed files with no
+// attacker involved: the grant holds Clients/Q3.bento.html, the user opens a
+// working copy at ~/Desktop/Q3.bento.html, and exactly one hit is found —
+// because the sender's own copy is outside the grant and so is not a second
+// hit. Writing that hit puts the Desktop deck's bytes over the Clients file and
+// never writes the file being edited.
+{
+  const tree = { Clients: { 'Q3.bento.html': fileHandle('Q3.bento.html', ['Clients', 'Q3.bento.html']) } }
+  const r = await resolve(senderFor('/Users/x/Desktop/Q3.bento.html'), deps(tree))
+  ok(r.ok === false && /different file/.test(r.reason ?? ''),
+    'a same-named file elsewhere in the grant is NOT treated as the sender\'s file')
+}
+{
+  // and the legitimate nested case still resolves
+  const tree = { Clients: { 'Q3.bento.html': fileHandle('Q3.bento.html', ['Clients', 'Q3.bento.html']) } }
+  const r = await resolve(senderFor('/Users/x/Decks/Clients/Q3.bento.html'), deps(tree))
+  ok(r.ok === true, 'the sender\'s own file in a subfolder still resolves')
+}
+{
+  // a candidate the directory refuses to resolve is refused here too
+  const orphan = fileHandle('Q3.bento.html')
+  ;(orphan as any).__rel = null
+  const r = await resolve(senderFor('/Users/x/Decks/Q3.bento.html'), deps({ 'Q3.bento.html': orphan }))
+  ok(r.ok === false && /not inside the granted folder/.test(r.reason ?? ''),
+    'a candidate that does not resolve inside the grant is declined')
+}
+{
+  // a write must be refused for the same reason, not only a claim
+  written.clear()
+  const tree = { Clients: { 'Q3.bento.html': fileHandle('Q3.bento.html', ['Clients', 'Q3.bento.html']) } }
+  const r = await write(senderFor('/Users/x/Desktop/Q3.bento.html'), 'attacker bytes', deps(tree))
+  ok(r.ok === false, 'a write to a same-named file elsewhere is refused')
+  ok(written.size === 0, 'and nothing was written')
 }
 
 // ---- 3. a write needs no prior claim (service-worker eviction) --------------
@@ -137,7 +186,7 @@ const deps = (tree: Record<string, any>, perm = 'granted') => ({
 // ---- 5. the depth limit ----------------------------------------------------
 {
   // 6 levels deep — past the limit, so it must NOT be found rather than hang
-  let deep: any = { 'Q3.bento.html': fileHandle('deep/Q3.bento.html') }
+  let deep: any = { 'Q3.bento.html': fileHandle('Q3.bento.html', ['sub','sub','sub','sub','sub','sub','Q3.bento.html']) }
   for (let i = 0; i < 6; i++) deep = { sub: deep }
   const r = await resolve(senderFor('/Users/x/Decks/Q3.bento.html'), deps(deep))
   ok(r.ok === false, 'a file buried past the depth limit is declined, not searched forever')

--- a/tray/webext/README.md
+++ b/tray/webext/README.md
@@ -130,13 +130,31 @@ declines. Correct, but it means the extension only covers `.bento.html` files.
 ## The matching problem
 
 A page gives us `/Users/…/Decks/Q3.bento.html`. A `FileSystemDirectoryHandle`
-knows its own **name** but not its path, and nothing in the API exposes one — so
-the two cannot be compared directly.
+knows its own **name** but not its path, so the grant and the sender cannot be
+compared directly. Resolution is two steps, and the second is the one that
+matters:
 
-`findByName` searches the granted tree (depth-limited) and requires **exactly one
-match**. Unambiguous in the ordinary case; when it is ambiguous it declines and
-the native picker takes over. Declining costs a prompt, guessing costs somebody's
-file.
+1. find files in the granted tree with the sender's file **name**, and require
+   exactly one — ambiguity is declined, never guessed at;
+2. ask the directory to **`resolve()`** that candidate, which returns its path
+   segments *relative to the grant*, and require the sender's own path to end
+   with them.
+
+**Step 1 alone was wrong, and shipped that way.** A name match is not an
+identity match. With the grant at `~/Documents` holding
+`~/Documents/Clients/Q3.bento.html`, opening a working copy at
+`~/Desktop/Q3.bento.html` produced exactly one hit — the sender's own copy is
+outside the grant, so it is not a second hit and the ambiguity guard cannot
+fire. A save then wrote the Desktop document over the Clients one and never
+wrote the file being edited. No attacker required.
+
+**Residual, stated plainly because the API cannot close it.** Nothing exposes
+the grant's absolute path, so step 2 verifies a relative *suffix*, not a full
+path. A page deliberately placed at `<somewhere-else>/Clients/Q3.bento.html`
+still matches a grant containing `Clients/Q3.bento.html`. That is far narrower
+than a bare filename — it requires reproducing the victim's folder structure —
+but it is not nothing, and it is why the content-script match stays limited
+rather than covering every local HTML file.
 
 ## Trying it
 

--- a/tray/webext/src/background.js
+++ b/tray/webext/src/background.js
@@ -114,7 +114,30 @@ export async function resolve(sender, deps = {}) {
       reason: hits.length ? `${name} is ambiguous in the granted folder` : 'not in the granted folder',
     }
   }
-  return { ok: true, name, handle: hits[0] }
+
+  // The candidate shares the sender's FILE NAME. That is not the same as being
+  // the sender's file, and treating it as such destroys documents:
+  //
+  //   grant = ~/Documents, which holds ~/Documents/Clients/Q3.bento.html
+  //   the user opens a working copy at ~/Desktop/Q3.bento.html
+  //   -> exactly one hit, so a save wrote the Desktop deck over the Clients one
+  //      and never wrote the file being edited.
+  //
+  // The ambiguity guard above cannot catch that: the sender's own copy is
+  // OUTSIDE the grant, so it is not a second hit. No attacker is required.
+  //
+  // `resolve()` on the directory gives the candidate's path segments relative to
+  // the grant, so the sender's absolute path must end with them. An earlier
+  // comment here claimed the two "cannot be compared directly" — that is true of
+  // the directory handle, which knows no path, but not of a resolved child.
+  const rel = await dir.resolve(hits[0])
+  if (!rel || !rel.length) return { ok: false, reason: 'not inside the granted folder' }
+  const suffix = `/${rel.join('/')}`
+  if (!path.endsWith(suffix)) {
+    return { ok: false, reason: `${name} in the granted folder is a different file` }
+  }
+
+  return { ok: true, name, handle: hits[0], within: suffix }
 }
 
 /** Can this sender's file be written in place? Resolves; writes nothing. */


### PR DESCRIPTION
`resolve()` computed the sender's full path and then **threw the directory
away**, matching on basename alone. So it didn't write "the sender's file" — it
wrote whichever file in the granted tree happened to share a last path segment.

## It destroys documents with no attacker involved

```
grant   ~/Documents, holding ~/Documents/Clients/Q3.bento.html
user opens a working copy at ~/Desktop/Q3.bento.html
→ exactly ONE hit, so ⌘S wrote the Desktop document over the Clients file
  and never wrote the file being edited
```

The ambiguity guard can't catch this: the sender's own copy is *outside* the
grant, so it isn't a second hit. That guard only ever protected the case where
the sender's file is already inside the grant.

**This is live on `main`** (`7483ae2`). It needs a name collision inside the
grant to bite, but nothing else.

## The fix

`dir.resolve(child)` returns the candidate's path segments *relative to the
grant*, so the sender's own path must end with them.

My earlier comment claimed the two "cannot be compared directly" — true of the
directory handle, which knows no path, but **not** of a resolved child. That
wrong sentence is why the check was never written.

## Residual, documented rather than glossed

Nothing exposes the grant's absolute path, so this verifies a relative *suffix*,
not a full path. A page placed at `<elsewhere>/Clients/Q3.bento.html` still
matches a grant holding `Clients/Q3.bento.html` — far narrower than a bare
filename, since it requires reproducing the victim's folder structure, but not
nothing. It's the reason to keep the content-script match narrow rather than
covering every local HTML file.

## The rig gained the case it never had

Its "a file outside the grant is declined" check only exercised a name **absent**
from the tree. The failing shape is a name **present at a different path**. Four
new checks, and the stub directory now implements `resolve()` as the real API
does.

Verified as a real gate: reverting `background.js` alone fails exactly those
four, 15/19.

---

Found by an adversarial review of a later change, in code already on `main`.
Fixed on its own, ahead of that change, because it's live.