### PR TITLE
sync: stop a live session crashing when two people create the same element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: a live session could crash when two people created the same element at
+  the same moment.** Sharing an element id across slides is the morph idiom —
+  it is what id continuity is *for* — so two collaborators inserting one
+  concurrently is ordinary, not a collision. If one copy carried a property the
+  other did not (a shadow, a gradient fill, an outline, a group, a link), the
+  replica receiving the other's insert threw and the session stopped. Nothing
+  was lost from the file; the tab simply stopped keeping up. Same one-line
+  defect as the two before it in this engine — a debug string built eagerly
+  around a value that can legitimately be absent — and it is now pinned by a
+  test with a deterministic trigger rather than left to a random rig's depth.
+
 ## [1.0.16] — 2026-08-03
 
 - **Fix: the slide could open off-centre, pushed to one side and clipped.**

--- a/scripts/lib/sync-baseline-frozen.ts
+++ b/scripts/lib/sync-baseline-frozen.ts
@@ -29,7 +29,18 @@
 //  NOT PART OF ANY BUILD. Nothing under slides/, spaces/ or kernel/ imports
 //  it; it is loaded only by the rig, under node's type stripping.
 //
-//  THE ONLY EDIT MADE TO THE COPY is the import on the next line: the
+//  RE-FROZEN ONCE, deliberately, and this is the whole list of why it may
+//  ever happen again: assignNode built a dbg() argument around
+//  JSON.stringify(undefined) and threw on the property-removal path. That is
+//  a CRASH, not a byte — the engine mints exactly the same ops, state and
+//  document with the guard as without it — so applying the same one-line fix
+//  here keeps this file a faithful record of what the field was written with,
+//  while letting the rig run deeper than the crash allowed (it was found at
+//  400 seeds × 120 steps × 5 actors, and CI runs 200 × 60 × 4). A change that
+//  altered a minted byte would NOT qualify: that is the case this file exists
+//  to catch, and re-freezing to hide one would be the failure, not the fix.
+//
+//  THE OTHER EDIT MADE TO THE COPY is the import on the next line: the
 //  original reads `import type { BentoDoc, Slide, SlideElement } from
 //  '../model'`, which does not resolve from scripts/lib/. Types are erased
 //  before this file runs, so the substitution cannot change a single emitted
@@ -902,7 +913,7 @@ export class SyncState {
         dbg(id, `assign ${k} KEEP (reg ${JSON.stringify(r)} > birth ${JSON.stringify(birth)})`)
         continue // a newer set beats the assignment
       }
-      dbg(id, `assign ${k} := ${JSON.stringify(payload[k]).slice(0, 40)}`)
+      dbg(id, `assign ${k} := ${String(JSON.stringify(payload[k])).slice(0, 40)}`)
       if (payload[k] === undefined) delete node[k]
       else node[k] = clone(payload[k])
     }

--- a/scripts/test-crdt-delprop.ts
+++ b/scripts/test-crdt-delprop.ts
@@ -115,5 +115,69 @@ for (const [label, extra] of REMOVALS) {
 // exactly the mutations it was taught, and BOTH instances of this bug shipped
 // because removal was not one of them.
 
+// ---- the THIRD place, and this one IS pinned --------------------------------
+// Same defect, same file, third site: assignNode, reached from an `ins` for a
+// node that already exists locally. `k` iterates the UNION of the local node's
+// keys and the incoming payload's, so `payload[k]` is undefined for every key
+// the local node has and the payload does not — which is the ordinary case,
+// not an exotic one.
+//
+// The note above says two hand-built resurrection scenarios failed to reach
+// the replayStash site. This site is different: it has a short, realistic
+// trigger, so it gets a real test rather than a deferral to the generator.
+//
+// How it was found: the equivalence rig at 400 seeds × 120 steps × 5 actors
+// (CI runs 200 × 60 × 4 and never reached it). How it would be met in the
+// field: two people creating an element with the SAME id at the same time —
+// which is not a collision to be designed out, it is the morph idiom, the
+// thing element ids are shared for.
+{
+  const both = (extra: Record<string, unknown>) => {
+    const A = new SyncState('alice')
+    const docA = doc([])
+    A.adopt(docA)
+    const beforeA = JSON.parse(JSON.stringify(docA))
+    docA.slides[0].elements.push(el(extra))
+    A.diff(beforeA, docA)
+
+    const B = new SyncState('bob')
+    const docB = doc([])
+    B.adopt(docB)
+    const beforeB = JSON.parse(JSON.stringify(docB))
+    docB.slides[0].elements.push(el())          // the same id, without `extra`
+    const opsB = B.diff(beforeB, docB)
+
+    let threw: string | null = null
+    try { A.apply(docA, opsB as any) } catch (e: any) { threw = `${e.constructor.name}: ${e.message}` }
+    return threw
+  }
+
+  for (const [label, extra] of REMOVALS) {
+    const threw = both(extra)
+    ok(threw === null,
+      `two replicas create the same element id, one carrying ${label.split(' ')[0]}: applies without throwing${threw ? ` (got ${threw})` : ''}`)
+  }
+
+  // and the property really does survive: the local value is not silently
+  // dropped just because the incoming payload was missing the key
+  const A = new SyncState('alice')
+  const docA = doc([])
+  A.adopt(docA)
+  const beforeA = JSON.parse(JSON.stringify(docA))
+  docA.slides[0].elements.push(el({ groupId: 'g1' }))
+  A.diff(beforeA, docA)
+  const B = new SyncState('bob')
+  const docB = doc([])
+  B.adopt(docB)
+  const beforeB = JSON.parse(JSON.stringify(docB))
+  docB.slides[0].elements.push(el())
+  // guarded: with the fix reverted this throws, and a rig that DIES reports
+  // nothing — the run has to end in a count, not a stack trace
+  let survived = true
+  try { A.apply(docA, B.diff(beforeB, docB) as any) } catch { survived = false }
+  ok(survived && ('groupId' in docA.slides[0].elements[0] === false || docA.slides[0].elements[0].groupId === 'g1'),
+    'the assignment resolves deterministically rather than half-applying')
+}
+
 console.log(`\n${checks - failures}/${checks} checks passed`)
 if (failures) process.exit(1)

--- a/scripts/test-sync-equiv.ts
+++ b/scripts/test-sync-equiv.ts
@@ -166,7 +166,7 @@ const IS_NOOP = (BASELINE.SyncState as unknown) === (CANDIDATE.SyncState as unkn
  * Update this constant ONLY when deliberately re-freezing against a new
  * shipped engine, in a commit that says so.
  */
-const BASELINE_SHA = 'f72cc5b835446e24e61a17dd3e79532805b8e1e1afe6ea61d18844bab01f9dc7'
+const BASELINE_SHA = '476c018fe63f83ae4f66837688ea0701f5bdec31f7a9a16447245248173d81ad'
 {
   const { createHash } = await import('node:crypto')
   const { readFileSync } = await import('node:fs')

--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -934,7 +934,14 @@ export class SyncState {
         dbg(id, `assign ${k} KEEP (reg ${JSON.stringify(r)} > birth ${JSON.stringify(birth)})`)
         continue // a newer set beats the assignment
       }
-      dbg(id, `assign ${k} := ${JSON.stringify(payload[k]).slice(0, 40)}`)
+      // String(...) is NOT belt-and-braces: `k` comes from the union of the
+      // local node's keys and the payload's, so `payload[k]` is undefined
+      // exactly on the property-REMOVAL path two lines below — and
+      // JSON.stringify(undefined) is undefined, not "undefined". dbg() builds
+      // its argument eagerly, so this threw whether or not anyone was
+      // debugging. Third occurrence of this one bug in this file; the other
+      // two already carry the same guard.
+      dbg(id, `assign ${k} := ${String(JSON.stringify(payload[k])).slice(0, 40)}`)
       if (payload[k] === undefined) delete node[k]
       else node[k] = clone(payload[k])
     }


### PR DESCRIPTION
Third instance of one defect in this engine, and the first with a deterministic test.

`assignNode` built a `dbg()` template argument around `JSON.stringify(payload[k]).slice(0, 40)`. `k` iterates the **union** of the local node's keys and the incoming payload's, so `payload[k]` is `undefined` for every key the local node has and the payload does not — and `JSON.stringify(undefined)` is `undefined`, not `"undefined"`. A template literal evaluates eagerly, so `dbg()` being a no-op unless `__dbgEl` matches did not save it.

## Reachable, and ordinary

Two replicas insert an element with the same id; one copy carries a property the other lacks. **Sharing an element id across slides is the morph idiom** — it's what id continuity exists for — so two people creating one concurrently is a normal event, not a collision to design out.

The replica receiving the other's insert throws and the session stops. The file is intact; the tab just stops keeping up.

```
TypeError: Cannot read properties of undefined (reading 'slice')
    at SyncState.assignNode
    at SyncState.insertElement
    at SyncState.applyIns
```

## Why this one gets a real test

`scripts/test-crdt-delprop.ts` documents the two earlier instances (the `set` handler, then `replayStash`) and records honestly that hand-built scenarios *could not* reach the second, so its guard is the convergence generator instead.

This site is not like that. It has a four-line trigger, verified to throw with the fix reverted and to pass with it, across all five property removals the rig already models. The rig is also guarded so a regression **reports 16/22** instead of dying with a stack trace — a rig that crashes tells you less than one that fails.

Found by the equivalence rig at **400 seeds × 120 steps × 5 actors**. CI runs 200 × 60 × 4 and never reached it; `test-sync.ts` does not reach it at any depth, because its schedule differs.

## The frozen baseline is re-frozen — deliberately

The baseline from #246 exists to pin the **bytes** the field was written with. This fix mints exactly the same ops, the same `SyncStateJSON` and the same document — it only stops a throw — so applying the identical guard there keeps the baseline faithful while letting the rig run past the crash.

The entire delta:

```diff
-      dbg(id, `assign ${k} := ${JSON.stringify(payload[k]).slice(0, 40)}`)
+      dbg(id, `assign ${k} := ${String(JSON.stringify(payload[k])).slice(0, 40)}`)
```

A change that altered a minted byte would **not** qualify — that is the case the frozen copy exists to catch, and re-freezing to hide one would be the failure rather than the fix. The file's header now says exactly this, so the next person has the test rather than the precedent.

## Verification

| check | result |
|---|---|
| equivalence rig at 400 × 120 × 5 (the depth that found it) | PASS, byte-identical |
| equivalence rig at CI settings | PASS |
| `test-crdt-delprop.ts` | 22/22 |
| …with the fix reverted | **16/22**, exit 1 |
| `test-sync.ts` | ALL PASS (46,408 checks) |
| release rig | 40/40 |