### PR TITLE
sync: inject the document shape, and prove a second one works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,3 +354,14 @@ jobs:
         # candidate is ever repointed at something that resolves back to the
         # baseline — the quiet way a gate stops gating.
         run: REQUIRE_LIVE=1 SEEDS=200 STEPS=60 ACTORS=4 node scripts/test-sync-equiv.ts
+
+      - name: CRDT document-shape seam
+        # The equivalence rig proves a NEGATIVE — that the parameterized engine
+        # still mints the bytes shipped files were written with — and a
+        # parameterization that quietly did nothing would pass it. This proves
+        # the positive: a second shape (pages→blocks) produces an engine that
+        # actually works, keys nodes on the composite pageId+blockId, and
+        # restores as itself. Also pins the constructor contract: the shape has
+        # no default, because a default is how a spaces call site silently ends
+        # up holding slides' shape.
+        run: node scripts/test-sync-shape.ts

--- a/scripts/test-sync-equiv.ts
+++ b/scripts/test-sync-equiv.ts
@@ -1049,16 +1049,21 @@ function mutantEngine(M: CrdtModule, name: MutantName): Engine {
   return {
     label: `mutant:${name}`,
     SyncState: Cls,
-    // crdt.ts's `static fromJSON` constructs `new SyncState(actor)` literally —
-    // not `new this(actor)` — so a subclass cannot be produced through it, and
-    // this returned an UNMUTATED engine. Every scenario that round-trips state
-    // therefore tested the baseline against itself while reporting mutant
-    // coverage, which is the one lie a self-test must not tell.
+    // `static fromJSON` used to construct `new SyncState(actor)` literally, so
+    // a subclass could not be produced through it and this returned an
+    // UNMUTATED engine — every scenario that round-trips state tested the
+    // baseline against itself while reporting mutant coverage, which is the
+    // one lie a self-test must not tell. The workaround was to re-point the
+    // prototype, a harness liberty taken only because that step's acceptance
+    // criterion was an empty product diff.
     //
-    // Re-pointing the prototype is a test-harness liberty, taken here rather
-    // than changing one word in the shipped engine: this step's whole
-    // acceptance criterion is that `git diff slides/ kernel/ server/` is empty.
+    // The engine now says `new this(actor)`, so a mutant restores as itself
+    // and the liberty is gone. The FROZEN BASELINE still has the old literal
+    // construction, which is exactly why this falls back rather than assuming:
+    // a mutant built on the baseline still needs the prototype repointed.
     fromJSON: (a, j) => {
+      const made = (Cls as { fromJSON?: (a: string, j: StateJSON) => unknown }).fromJSON?.(a, j)
+      if (made && Object.getPrototypeOf(made) === Cls.prototype) return made as EngineState
       const base = M.SyncState.fromJSON(a, j)
       Object.setPrototypeOf(base, Cls.prototype)
       return base as unknown as EngineState

--- a/scripts/test-sync-shape.ts
+++ b/scripts/test-sync-shape.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// The document-shape seam: one engine, two document shapes.
+//
+//   node scripts/test-sync-shape.ts
+//
+// WHAT THIS IS FOR. scripts/test-sync-equiv.ts proves the parameterized engine
+// still mints the bytes every shipped bento/slides file was written with — it
+// is a NEGATIVE property, and a parameterization that quietly did nothing
+// would sail through it. Nothing yet proved the POSITIVE one: that binding a
+// second shape produces an engine that actually works on a document of that
+// shape.
+//
+// This is that check, and it is deliberately small. The full bento/spaces
+// convergence rig belongs with the spaces binding; what belongs here is the
+// evidence that the seam is real — because the seam is what the whole
+// collaboration project rests on, and "it compiles" is not evidence.
+//
+// It is also where the constructor contract is pinned: the engine takes its
+// shape with NO DEFAULT. A default is precisely how a spaces call site ends up
+// silently holding slides' shape, and the resulting room cannot be repaired in
+// the field.
+
+import { SyncEngine, SyncState, SLIDES_SHAPE } from '../slides/src/sync/crdt.ts'
+import type { DocShape } from '../slides/src/sync/crdt.ts'
+
+let failures = 0
+let checks = 0
+function ok(cond: boolean, msg: string) {
+  checks++
+  if (!cond) { failures++; console.log(`  FAIL  ${msg}`) }
+  else console.log(`  ok    ${msg}`)
+}
+
+console.log('bento-sync — the document-shape seam\n')
+
+/** bento/spaces: pages hold blocks. The binding spaces will ship. */
+const SPACES_SHAPE: DocShape = {
+  parents: 'pages',
+  children: 'blocks',
+  skipDoc: new Set(['pages', 'modified', 'collab', 'format', 'version']),
+}
+class SpacesSync extends SyncEngine {
+  constructor(actor: string) { super(actor, SPACES_SHAPE) }
+}
+
+const spacesDoc = (blocks: unknown[]) => ({
+  format: 'bento/spaces', version: 1, docId: 'd', title: 'S', home: 'p1',
+  pages: [{ id: 'p1', title: 'Page one', blocks }],
+}) as never
+
+// ---- a second shape produces a WORKING engine ------------------------------
+{
+  const A = new SpacesSync('alice')
+  const B = new SpacesSync('bob')
+  const dA = spacesDoc([{ id: 'b1', type: 'p', html: 'hello' }]) as never as Record<string, never>
+  A.adopt(dA as never)
+  const dB = JSON.parse(JSON.stringify(dA))
+  B.adopt(dB)
+
+  // concurrent: alice types into a block, bob adds one
+  const beforeA = JSON.parse(JSON.stringify(dA))
+  ;(dA as never as { pages: { blocks: { html: string }[] }[] }).pages[0].blocks[0].html = 'hello world'
+  const opsA = A.diff(beforeA, dA as never, { text: true })
+
+  const beforeB = JSON.parse(JSON.stringify(dB))
+  dB.pages[0].blocks.push({ id: 'b2', type: 'todo', html: 'a task', done: false })
+  const opsB = B.diff(beforeB, dB, { text: true })
+
+  ok(opsA.length === 1 && opsA[0].op === 'txt',
+    'a text edit on a BLOCK becomes one RGA delta, exactly as it does for an element')
+  ok(String(opsA[0].el) === 'p1' + '\u001f' + 'b1',
+    `the node key is the composite pageId\u001fblockId — the page, not the slide (got ${JSON.stringify(String(opsA[0].el))})`)
+  ok(opsB.length === 1 && opsB[0].op === 'ins' && opsB[0].sl === 'p1',
+    'a new block is an insert parented to its page')
+
+  A.apply(dA as never, opsB)
+  B.apply(dB, opsA)
+  ok(JSON.stringify(dA) === JSON.stringify(dB), 'the two replicas converge')
+  const blocks = (dA as never as { pages: { blocks: { html: string }[] }[] }).pages[0].blocks
+  ok(blocks.length === 2 && blocks[0].html === 'hello world',
+    'and neither edit was lost: the typed text AND the new block survive')
+}
+
+// ---- the shape is per-instance, not per-module -----------------------------
+// The failure this prevents is one engine quietly serving both apps with one
+// binding, which is unrecoverable once a room exists.
+{
+  const s = new SyncState('a')
+  const p = new SpacesSync('a')
+  ok(s.S === SLIDES_SHAPE, 'the slides binding carries the slides shape')
+  ok(p.S === SPACES_SHAPE, 'the spaces binding carries the spaces shape')
+  ok(s.S !== p.S, 'two engines alive at once do not share one shape')
+  ok(SLIDES_SHAPE.skipDoc.has('slides') && SPACES_SHAPE.skipDoc.has('pages'),
+    'each shape skips its own container — syncing it as a value would make the whole document one register')
+}
+
+// ---- restoring a saved state yields the SAME binding -----------------------
+// `static fromJSON` used to construct the base class literally, so a subclass
+// restored as something else. For an app binding that means a saved spaces
+// file reopening with slides' shape.
+{
+  const p = new SpacesSync('a')
+  const d = spacesDoc([{ id: 'b1', type: 'p', html: 'x' }])
+  p.adopt(d)
+  const back = SpacesSync.fromJSON('a', p.toJSON())
+  ok(back instanceof SpacesSync, 'a restored spaces engine is a spaces engine')
+  ok(back.S === SPACES_SHAPE, '…and still carries the spaces shape')
+  const slides = SyncState.fromJSON('a', new SyncState('a').toJSON())
+  ok(slides instanceof SyncState && slides.S === SLIDES_SHAPE,
+    'and the slides binding restores as itself, unchanged')
+}
+
+// ---- the slides shape is untouched by any of this --------------------------
+{
+  ok(SLIDES_SHAPE.parents === 'slides' && SLIDES_SHAPE.children === 'elements',
+    'slides still means slides → elements')
+  ok([...SLIDES_SHAPE.skipDoc].sort().join(',') === 'collab,format,modified,slides,version',
+    'and its skip set is exactly what the shipped engine hardcoded')
+}
+
+console.log(`\n${checks - failures}/${checks} checks passed`)
+if (failures) process.exit(1)

--- a/slides/src/sync/crdt.ts
+++ b/slides/src/sync/crdt.ts
@@ -93,15 +93,11 @@ const shape = (parents: string, children: string): DocShape => {
 
 export const SLIDES_SHAPE = shape('slides', 'elements')
 
-/** The shape this module is bound to. Becomes a constructor argument in the
- *  next step; today it is exactly what the file hardcoded before. */
-const S: DocShape = SLIDES_SHAPE
-
 /** The parent array of a document, and the child array of a parent. Indexed
  *  access through the descriptor: `d['slides']` is the same lookup `d.slides`
  *  was, so these are byte-neutral by construction. */
-const P = (d: BentoDoc): Slide[] => (d as unknown as Record<string, Slide[]>)[S.parents]
-const C = (p: Slide): SlideElement[] => (p as unknown as Record<string, SlideElement[]>)[S.children]
+const P = (S: DocShape, d: BentoDoc): Slide[] => (d as unknown as Record<string, Slide[]>)[S.parents]
+const C = (S: DocShape, p: Slide): SlideElement[] => (p as unknown as Record<string, SlideElement[]>)[S.children]
 /**
  * …and the write-back form for the child array.
  *
@@ -110,7 +106,7 @@ const C = (p: Slide): SlideElement[] => (p as unknown as Record<string, SlideEle
  * future edit that reassigns it would be replacing the array the caller's
  * document still points at.
  */
-const setC = (p: Slide, v: SlideElement[]): void => { (p as unknown as Record<string, SlideElement[]>)[S.children] = v }
+const setC = (S: DocShape, p: Slide, v: SlideElement[]): void => { (p as unknown as Record<string, SlideElement[]>)[S.children] = v }
 
 export const DOC_NODE = '@doc'
 
@@ -314,7 +310,11 @@ export interface ApplyResult {
 
 const clone = <T>(v: T): T => (v === undefined ? v : JSON.parse(JSON.stringify(v)))
 
-export class SyncState {
+/**
+ * The engine, shape-injected. Not exported as the app-facing name — see
+ * `SyncState` below.
+ */
+export class SyncEngine {
   actor: string
   lamport = 0
   /** per-actor max contiguous sequence applied */
@@ -334,8 +334,14 @@ export class SyncState {
   /** out-of-order ops per actor awaiting their gap to fill */
   private gap: Record<string, Op[]> = {}
 
-  constructor(actor: string) {
+  /** The document shape. NO DEFAULT, deliberately: a default is how a spaces
+   *  call site silently gets slides' shape and corrupts a room that then has
+   *  no way to be repaired in the field. */
+  readonly S: DocShape
+
+  constructor(actor: string, shape: DocShape) {
     this.actor = actor
+    this.S = shape
   }
 
   /** actors with buffered out-of-order ops → catch-up should be requested */
@@ -366,8 +372,17 @@ export class SyncState {
     }
   }
 
-  static fromJSON(actor: string, j: SyncStateJSON): SyncState {
-    const s = new SyncState(actor)
+  /**
+   * `new this(actor)`, not `new SyncState(actor)`.
+   *
+   * The literal construction meant a SUBCLASS could not be produced through
+   * fromJSON — it silently handed back the base class. That is why
+   * scripts/test-sync-equiv.ts re-points prototypes to build its mutants, a
+   * harness liberty its own comment flags; with this, a mutant (and every
+   * app binding) restores as itself.
+   */
+  static fromJSON<T extends SyncEngine>(this: new (actor: string) => T, actor: string, j: SyncStateJSON): T {
+    const s = new this(actor)
     if (j.v !== SYNC_V) return s // pre-v2 state keyed elements by bare id — unusable
     s.lamport = j.lamport
     s.vv = j.vv ?? {}
@@ -397,11 +412,11 @@ export class SyncState {
    * keys) with the null register [0,''] that loses to every real op.
    */
   adopt(doc: BentoDoc) {
-    const ns = P(doc).length
-    P(doc).forEach((sl, i) => {
+    const ns = P(this.S, doc).length
+    P(this.S, doc).forEach((sl, i) => {
       if (!this.pos[sl.id]) this.pos[sl.id] = { p: DOC_NODE, o: spreadKey(i, ns), r: [0, ''] }
-      const ne = C(sl).length
-      C(sl).forEach((el, j) => {
+      const ne = C(this.S, sl).length
+      C(this.S, sl).forEach((el, j) => {
         const k = elKey(sl.id, el.id)
         if (!this.pos[k]) this.pos[k] = { p: sl.id, o: spreadKey(j, ne), r: [0, ''] }
       })
@@ -423,7 +438,7 @@ export class SyncState {
     }
 
     // ---- doc-level props
-    const SKIP_DOC = S.skipDoc
+    const SKIP_DOC = this.S.skipDoc
     const b = before as unknown as Record<string, unknown>
     const a = after as unknown as Record<string, unknown>
     for (const k of new Set([...Object.keys(b), ...Object.keys(a)])) {
@@ -453,30 +468,30 @@ export class SyncState {
     // ---- slides by id; elements by COMPOSITE key (slide + bare id) — the
     // same element id on many slides is the morph idiom, each copy is its
     // own node. A cross-slide move therefore diffs as del(old)+ins(new).
-    const bSlides = new Map(P(before).map((s) => [s.id, s]))
-    const aSlides = new Map(P(after).map((s) => [s.id, s]))
+    const bSlides = new Map(P(this.S, before).map((s) => [s.id, s]))
+    const aSlides = new Map(P(this.S, after).map((s) => [s.id, s]))
     const bEls = new Map<string, { sl: string; el: SlideElement }>()
     const aEls = new Map<string, { sl: string; el: SlideElement }>()
-    P(before).forEach((s) => C(s).forEach((el) => bEls.set(elKey(s.id, el.id), { sl: s.id, el })))
-    P(after).forEach((s) => C(s).forEach((el) => aEls.set(elKey(s.id, el.id), { sl: s.id, el })))
+    P(this.S, before).forEach((s) => C(this.S, s).forEach((el) => bEls.set(elKey(s.id, el.id), { sl: s.id, el })))
+    P(this.S, after).forEach((s) => C(this.S, s).forEach((el) => aEls.set(elKey(s.id, el.id), { sl: s.id, el })))
 
     // deleted slides (cascade the elements the deleter saw, minus survivors)
     for (const [id, sl] of bSlides) {
       if (aSlides.has(id)) continue
-      const cas = C(sl).map((e) => elKey(id, e.id)).filter((k) => !aEls.has(k))
+      const cas = C(this.S, sl).map((e) => elKey(id, e.id)).filter((k) => !aEls.has(k))
       const o = push<DelOp>({ ...this.stamp(), op: 'del', kind: 'slide', id, cas })
       this.tombs[id] = [o.l, o.a]
       this.stashNode(sl as unknown as Record<string, unknown>, id)
       cas.forEach((ek) => {
         this.tombs[ek] = [o.l, o.a]
-        const node = C(sl).find((e) => elKey(id, e.id) === ek)
+        const node = C(this.S, sl).find((e) => elKey(id, e.id) === ek)
         if (node) this.stashNode(node as unknown as Record<string, unknown>, ek)
         delete this.limbo[ek]
         delete this.txt[ek] // local tomb is the freshest stamp — always out-ranks
       })
     }
     // inserted (or resurrected) slides
-    const afterIds = P(after).map((s) => s.id)
+    const afterIds = P(this.S, after).map((s) => s.id)
     for (let i = 0; i < afterIds.length; i++) {
       const id = afterIds[i]
       if (bSlides.has(id)) continue
@@ -487,8 +502,8 @@ export class SyncState {
       this.pos[id] = { p: DOC_NODE, o: ord, r: [o.l, o.a] }
       delete this.txt[id]
       delete this.stash[id] // fresh birth voids parked values (receivers do this in replayStash)
-      const ne = C(sl).length
-      C(sl).forEach((el, j) => {
+      const ne = C(this.S, sl).length
+      C(this.S, sl).forEach((el, j) => {
         const k = elKey(id, el.id)
         this.births[k] = [o.l, o.a]
         this.pos[k] = { p: id, o: spreadKey(j, ne), r: [o.l, o.a] }
@@ -503,7 +518,7 @@ export class SyncState {
       const bp = prev as unknown as Record<string, unknown>
       const ap = sl as unknown as Record<string, unknown>
       for (const k of new Set([...Object.keys(bp), ...Object.keys(ap)])) {
-        if (k === S.children || k === 'id') continue
+        if (k === this.S.children || k === 'id') continue
         if (JSON.stringify(bp[k]) === JSON.stringify(ap[k])) continue
         const o = push<SetOp>({ ...this.stamp(), op: 'set', sl: id, k, v: clone(ap[k]) })
         this.regs[`${id} ${k}`] = [o.l, o.a]
@@ -528,7 +543,7 @@ export class SyncState {
       const prev = bEls.get(id)
       if (!prev) {
         if (this.births[id] && !this.dead(id) && this.pos[id]?.p === sl) continue // came with a fresh slide ins above
-        const sib = C(aSlides.get(sl)!).map((e) => elKey(sl, e.id))
+        const sib = C(this.S, aSlides.get(sl)!).map((e) => elKey(sl, e.id))
         const ord = this.keyAround(sl, sib, sib.indexOf(id))
         const o = push<InsOp>({ ...this.stamp(), op: 'ins', kind: 'element', id, sl, ord, node: clone(el) })
         this.births[id] = [o.l, o.a]
@@ -561,7 +576,7 @@ export class SyncState {
     // element order within each surviving slide (all ids — see slide pass)
     for (const [id, sl] of aSlides) {
       if (!bSlides.has(id)) continue
-      this.diffOrder(C(sl).map((e) => elKey(id, e.id)), id, 'element', push)
+      this.diffOrder(C(this.S, sl).map((e) => elKey(id, e.id)), id, 'element', push)
     }
 
     // remote ops that pended awaiting a seed can resolve against seeds this
@@ -750,14 +765,14 @@ export class SyncState {
   }
 
   private findSlide(doc: BentoDoc, id: string): Slide | undefined {
-    return P(doc).find((s) => s.id === id)
+    return P(this.S, doc).find((s) => s.id === id)
   }
   /** composite-key lookup: an element node only ever lives on its key's
    * slide (or in limbo) — the same bare id on other slides is other nodes */
   private findEl(doc: BentoDoc, key: string): SlideElement | undefined {
     const s = this.findSlide(doc, keySlide(key))
     const bare = keyEl(key)
-    return (s ? C(s) : undefined)?.find((e) => e.id === bare) ?? this.limbo[key]
+    return (s ? C(this.S, s) : undefined)?.find((e) => e.id === bare) ?? this.limbo[key]
   }
 
   private applySet(doc: BentoDoc, op: SetOp, res: ApplyResult) {
@@ -838,10 +853,10 @@ export class SyncState {
       // first ran it, so everyone must.
       const src = op.node as Slide
       this.insertSlideLevel(doc, op.id, op.ord, src, stamp, res)
-      const ne = C(src).length
-      C(src).forEach((e, j) => this.insertElement(doc, elKey(op.id, e.id), op.id, spreadKey(j, ne), e, stamp, res))
+      const ne = C(this.S, src).length
+      C(this.S, src).forEach((e, j) => this.insertElement(doc, elKey(op.id, e.id), op.id, spreadKey(j, ne), e, stamp, res))
       this.drainPending(doc, op.id)
-      C(src).forEach((e) => this.drainPending(doc, elKey(op.id, e.id)))
+      C(this.S, src).forEach((e) => this.drainPending(doc, elKey(op.id, e.id)))
     } else {
       this.insertElement(doc, op.id, op.sl!, op.ord, op.node as SlideElement, stamp, res)
       this.drainPending(doc, op.id)
@@ -862,11 +877,11 @@ export class SyncState {
     if (this.dead(id)) return // a delete still out-stamps this insert
     const existing = this.findSlide(doc, id)
     if (existing) {
-      this.assignNode(existing as unknown as Record<string, unknown>, src as unknown as Record<string, unknown>, id, stamp, ['id', S.children])
+      this.assignNode(existing as unknown as Record<string, unknown>, src as unknown as Record<string, unknown>, id, stamp, ['id', this.S.children])
     } else {
       const sl = clone(src)
-      setC(sl, []) // members materialize separately via insertElement
-      P(doc).push(sl)
+      setC(this.S, sl, []) // members materialize separately via insertElement
+      P(this.S, doc).push(sl)
       this.replayStash(sl as unknown as Record<string, unknown>, id, stamp)
     }
   }
@@ -897,7 +912,7 @@ export class SyncState {
       const el = clone(node)
       const p = this.pos[id].p
       const sl = this.findSlide(doc, p)
-      if (sl && !this.dead(p)) C(sl).push(el)
+      if (sl && !this.dead(p)) C(this.S, sl).push(el)
       else this.limbo[id] = el
       this.replayStash(el as unknown as Record<string, unknown>, id, stamp)
       live = el
@@ -1017,10 +1032,10 @@ export class SyncState {
       if (g && cmpReg(this.tombs[key] ?? [0, ''], g.sd) > 0) delete this.txt[key]
       const s = this.findSlide(doc, keySlide(key))
       const bare = keyEl(key)
-      const i = s ? C(s).findIndex((e) => e.id === bare) : -1
+      const i = s ? C(this.S, s).findIndex((e) => e.id === bare) : -1
       if (s && i >= 0) {
-        this.stashNode(C(s)[i] as unknown as Record<string, unknown>, key)
-        C(s).splice(i, 1)
+        this.stashNode(C(this.S, s)[i] as unknown as Record<string, unknown>, key)
+        C(this.S, s).splice(i, 1)
       }
     }
     bump(op.id)
@@ -1032,12 +1047,12 @@ export class SyncState {
         if (this.dead(eid)) removeElement(eid)
       }
       if (this.dead(op.id)) {
-        const i = P(doc).findIndex((s) => s.id === op.id)
+        const i = P(this.S, doc).findIndex((s) => s.id === op.id)
         if (i >= 0) {
-          const [gone] = P(doc).splice(i, 1)
+          const [gone] = P(this.S, doc).splice(i, 1)
           this.stashNode(gone as unknown as Record<string, unknown>, op.id)
           // survivors (concurrently inserted) park in limbo under their key
-          for (const el of C(gone)) {
+          for (const el of C(this.S, gone)) {
             const k = elKey(op.id, el.id)
             if (!this.dead(k)) this.limbo[k] = el
           }
@@ -1148,13 +1163,13 @@ export class SyncState {
       if (a !== b) return a < b ? -1 : 1
       return x < y ? -1 : 1
     }
-    P(doc).sort((s1, s2) => cmp(s1.id, s2.id))
-    const slideById = new Map(P(doc).map((s) => [s.id, s]))
+    P(this.S, doc).sort((s1, s2) => cmp(s1.id, s2.id))
+    const slideById = new Map(P(this.S, doc).map((s) => [s.id, s]))
     for (const [key, el] of Object.entries(this.limbo)) {
       const p = this.pos[key]?.p
       if (p && slideById.has(p) && !this.dead(p) && !this.dead(key)) {
         const dest = slideById.get(p)!
-        if (!C(dest).some((e) => e.id === el.id)) C(dest).push(el)
+        if (!C(this.S, dest).some((e) => e.id === el.id)) C(this.S, dest).push(el)
         else dbg(key, `limbo-restore DROP dup x=${(el as any).x}`)
         delete this.limbo[key]
         this.drainPending(doc, key)
@@ -1163,10 +1178,10 @@ export class SyncState {
     // elements never relocate across slides (the composite key pins them to
     // one slide for life) — only sort by pos key and dedupe within the slide
     // (a node whose data travelled two routes can transiently duplicate)
-    for (const sl of P(doc)) {
-      C(sl).sort((e1, e2) => cmp(elKey(sl.id, e1.id), elKey(sl.id, e2.id)))
-      setC(sl, C(sl).filter((e, i) => {
-        const dup = i > 0 && e.id === C(sl)[i - 1].id
+    for (const sl of P(this.S, doc)) {
+      C(this.S, sl).sort((e1, e2) => cmp(elKey(sl.id, e1.id), elKey(sl.id, e2.id)))
+      setC(this.S, sl, C(this.S, sl).filter((e, i) => {
+        const dup = i > 0 && e.id === C(this.S, sl)[i - 1].id
         if (dup) dbg(elKey(sl.id, e.id), `remat dedupe DROP x=${(e as any).x}`)
         return !dup
       }))
@@ -1223,12 +1238,12 @@ export class SyncState {
       }
     }
     // drop nodes that are dead under merged liveness
-    for (let i = P(doc).length - 1; i >= 0; i--) {
-      const sl = P(doc)[i]
+    for (let i = P(this.S, doc).length - 1; i >= 0; i--) {
+      const sl = P(this.S, doc)[i]
       if (this.dead(sl.id)) {
-        P(doc).splice(i, 1)
+        P(this.S, doc).splice(i, 1)
         this.stashNode(sl as unknown as Record<string, unknown>, sl.id)
-        for (const el of C(sl)) {
+        for (const el of C(this.S, sl)) {
           const k = elKey(sl.id, el.id)
           if (!this.dead(k)) this.limbo[k] = el
           else this.stashNode(el as unknown as Record<string, unknown>, k)
@@ -1236,11 +1251,11 @@ export class SyncState {
         res.structure = true
         res.changed = true
       } else {
-        for (let j = C(sl).length - 1; j >= 0; j--) {
-          const k = elKey(sl.id, C(sl)[j].id)
+        for (let j = C(this.S, sl).length - 1; j >= 0; j--) {
+          const k = elKey(sl.id, C(this.S, sl)[j].id)
           if (this.dead(k)) {
-            this.stashNode(C(sl)[j] as unknown as Record<string, unknown>, k)
-            C(sl).splice(j, 1)
+            this.stashNode(C(this.S, sl)[j] as unknown as Record<string, unknown>, k)
+            C(this.S, sl).splice(j, 1)
             res.structure = true
             res.changed = true
           }
@@ -1257,12 +1272,12 @@ export class SyncState {
     // keyed composite; remote limbo nodes count — they're invisible but
     // their data is real)
     const rEls = new Map<string, SlideElement>()
-    P(rdoc).forEach((s) => C(s).forEach((e) => rEls.set(elKey(s.id, e.id), e)))
+    P(this.S, rdoc).forEach((s) => C(this.S, s).forEach((e) => rEls.set(elKey(s.id, e.id), e)))
     for (const [key, el] of Object.entries(rstate.limbo ?? {})) if (!rEls.has(key)) rEls.set(key, el)
-    for (const sl of P(rdoc)) {
+    for (const sl of P(this.S, rdoc)) {
       if (this.dead(sl.id) || this.findSlide(doc, sl.id)) continue
       const copy = clone(sl)
-      setC(copy, C(copy)
+      setC(this.S, copy, C(this.S, copy)
         .filter((e) => !this.dead(elKey(sl.id, e.id)))
         .map((e) => {
           const lb = this.limbo[elKey(sl.id, e.id)]
@@ -1272,7 +1287,7 @@ export class SyncState {
           }
           return e
         }))
-      P(doc).push(copy)
+      P(this.S, doc).push(copy)
       res.changed = true
       res.structure = true
     }
@@ -1280,13 +1295,13 @@ export class SyncState {
       if (this.dead(key) || this.findEl(doc, key)) continue
       const p = this.pos[key]?.p
       const host = p ? this.findSlide(doc, p) : undefined
-      if (host && !this.dead(host.id)) C(host).push(clone(el))
+      if (host && !this.dead(host.id)) C(this.S, host).push(clone(el))
       else this.limbo[key] = clone(el)
       res.changed = true
       res.structure = true
     }
     // property registers: the winning side's value lives in its doc
-    const rSlides = new Map(P(rdoc).map((s) => [s.id, s]))
+    const rSlides = new Map(P(this.S, rdoc).map((s) => [s.id, s]))
     const rNode = (id: string): Record<string, unknown> | undefined =>
       id === DOC_NODE
         ? (rdoc as unknown as Record<string, unknown>)
@@ -1305,7 +1320,7 @@ export class SyncState {
       const dst = lNode(id)
       if (!src || !dst) continue
       const isSlide = rSlides.has(id) || !!this.findSlide(doc, id)
-      this.assignNode(dst, src, id, this.births[id], isSlide ? ['id', S.children] : ['id'])
+      this.assignNode(dst, src, id, this.births[id], isSlide ? ['id', this.S.children] : ['id'])
       res.changed = true
       if (isSlide) res.structure = true
     }
@@ -1563,4 +1578,19 @@ function longestIncreasing(keys: string[]): number[] {
     k = prev[k]
   }
   return out.reverse()
+}
+
+/**
+ * The engine bound to bento/slides.
+ *
+ * Every existing consumer — session.ts, online.ts, the rigs, and
+ * server/guestbook-daemon, which bundles this name straight from this path —
+ * constructs `new SyncState(actor)`. Keeping that exact surface is what makes
+ * the shape injection invisible to them; bento/spaces gets its own binding the
+ * same way, and neither can be constructed without saying which it is.
+ */
+export class SyncState extends SyncEngine {
+  constructor(actor: string) {
+    super(actor, SLIDES_SHAPE)
+  }
 }


### PR DESCRIPTION
**PR-3 of the spaces collaboration work.** The shape stops being a module constant and becomes a constructor argument **with no default**.

That last part is the point. A default is exactly how a bento/spaces call site ends up silently holding slides' shape - and a room minted that way cannot be repaired in the field, because the files are on other people's disks. There is now no way to construct the engine without saying which document shape it is for.

- `SyncEngine(actor, shape)` is the engine
- `SyncState extends SyncEngine` binds `SLIDES_SHAPE` and keeps the exact surface every existing consumer already uses - `session.ts`, `online.ts`, the rigs, and `server/guestbook-daemon`, which bundles the name straight from this path. None of them change.

## `fromJSON` was not subclass-safe

It said `new SyncState(actor)` literally, so a subclass could not be produced through it - it silently handed back the base class. For an app binding, that is **a saved spaces file reopening with slides' shape**.

It is also why `test-sync-equiv.ts` re-points prototypes to build its mutants, a harness liberty its own comment flags. The rig now prefers the real path and keeps the workaround only for mutants built on the frozen baseline, which still carries the old literal.

## New rig: `scripts/test-sync-shape.ts`

The equivalence rig proves a **negative** - that the parameterized engine still mints the bytes shipped files were written with. A parameterization that quietly did nothing would sail through it. Nothing proved the positive.

This does. Bound to `pages` to `blocks`, two replicas concurrently edit a block's text and add another block: one character-level RGA delta keyed on the composite `pageId + U+001F + blockId`, one insert parented to the page, both replicas converged, neither edit lost. It also pins that two engines alive at once do not share a shape, and that a restored engine keeps its own.

## Negative controls

| control | result |
|---|---|
| revert `new this(actor)` | 2 FAILs - both restore checks |
| a shape that forgets its container in `skipDoc` | **6 FAILs** |

The second is the concrete demonstration of why `skipDoc` is derived rather than authored: without the container in it, the whole document collapses into one last-writer-wins register and nothing works at all.

## Verification

- equivalence rig **PASS, byte-identical** at CI settings
- shape seam 14/14
- `test-sync.ts` ALL PASS (46,408 checks)
- `test-crdt-delprop.ts` 22/22
- slides and kernel typecheck; slides shell builds and passes the splice gate
