### PR TITLE
Editor: hide the autosave tag after it fades, so the title gets its space back in the topbar

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -2496,13 +2496,21 @@ export class Editor {
   }
 
   private savedTimer = 0
+  private savedHideTimer = 0
   private flashSaved(message = t('Saved')) {
     let tag = document.querySelector<HTMLElement>('.ed-autosaved')
     if (!tag) { tag = div('ed-autosaved'); document.querySelector('.ed-topbar .ed-title')?.after(tag) }
     tag.textContent = message
+    // hidden while idle: at opacity 0 the tag still held its width, so after
+    // the first backup the title permanently lost the space this text needs
+    tag.hidden = false
+    void tag.offsetWidth // paint a frame at opacity 0 so the fade-in runs
     tag.classList.add('show')
     clearTimeout(this.savedTimer)
+    clearTimeout(this.savedHideTimer)
     this.savedTimer = window.setTimeout(() => tag!.classList.remove('show'), 1400)
+    // leave layout only after the 0.25s fade-out has finished
+    this.savedHideTimer = window.setTimeout(() => { tag!.hidden = true }, 1700)
   }
 
   async save(forcePicker: boolean) {


### PR DESCRIPTION
**What & why**

The `.ed-autosaved` tag ("Saved" / "Backed up in this browser") appears beside the title input and then fades out through `opacity: 0`. However, while invisible, the element still has a width, and thus, never leaves the layout. So the first backup of a session permanently taxes the title: measured at a 900px window, the faded tag holds 135px while the title sits crushed at its 48px floor. The flash was designed to be transient and yet its footprint isnt.

The fix is small: the tag is `hidden` while idle. `flashSaved` unhides it, forces one frame at opacity 0 so the fade-in still runs, and after the 1400ms flash plus the 0.25s fade-out it leaves layout again. No CSS change needed (the element never sets `display`, so the UA's `[hidden]` rule does the collapsing). Same measurement after the fix: the title gets 103px back (48px → 151px) the moment the tag goes idle.

One file, +8 lines, no new strings (the tag's messages already exist in every catalog), no format change.

**How I verified it**

Ran `node_modules/.bin/tsc -b` and `npm run build:single` from slides (clean; shell 1358KB → 664KB compressed), and `node scripts/shell-gate.mjs` on the built shell (splice contract OK). Measured the layout claim in the live editor: a faded tag at `opacity: 0` occupies 135px and pins the title at 48px; with `hidden` set, the title recovers to 151px. Timer churn is covered — a save landing mid-fade re-clears both timeouts, so the tag cannot be hidden out from under a visible flash.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from slides)
- [x] Ran `node scripts/test-sync.ts` if I touched sync *(not touched)*
- [x] New UI strings added to every catalog in i18n *(none added — reuses existing strings)*
- [x] Document format changes are additive and backward-compatible *(no format changes)*
- [x] Did not bump the version or cut a release (maintainers sign releases)