### PR TITLE
fix(slides): reveal custom page size controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ pre-1.0.
   around a value that can legitimately be absent — and it is now pinned by a
   test with a deterministic trigger rather than left to a random rig's depth.
 
+- **Fix: choosing a custom slide size now reveals its width and height.** The
+  page-size picker rebuilt the properties panel before recording any custom
+  state, so a preset-sized deck immediately snapped back to its preset and the
+  two inputs never appeared. Custom mode now reveals the existing controls
+  without changing the document until a dimension is actually edited.
+
 ## [1.0.16] — 2026-08-03
 
 - **Fix: the slide could open off-centre, pushed to one side and clipped.**

--- a/slides/src/editor/panels.ts
+++ b/slides/src/editor/panels.ts
@@ -230,21 +230,30 @@ export class PropsPanel {
     const { width: dw, height: dh } = this.store.doc.size
     const presetKey =
       Object.entries(PropsPanel.PAGE_PRESETS).find(([, s]) => s.w === dw && s.h === dh)?.[0] ?? 'Custom…'
+    let widthRow: HTMLLabelElement
+    let heightRow: HTMLLabelElement
+    const showCustomSize = (show: boolean) => {
+      widthRow.style.display = show ? '' : 'none'
+      heightRow.style.display = show ? '' : 'none'
+    }
     this.row('Page size', this.select(
       [...Object.keys(PropsPanel.PAGE_PRESETS), 'Custom…'],
       presetKey,
       (v) => {
         const s = PropsPanel.PAGE_PRESETS[v]
-        if (s) this.edit(() => { this.store.doc.size = { width: s.w, height: s.h } }, true)
-        else this.rebuild(true) // custom: just reveal the W/H inputs
+        if (s) {
+          showCustomSize(false)
+          this.edit(() => { this.store.doc.size = { width: s.w, height: s.h } }, true)
+        } else {
+          showCustomSize(true)
+        }
       },
     ))
-    if (presetKey === 'Custom…') {
-      this.row('Width', this.number(dw, 10, (v, fin) =>
-        this.edit(() => { this.store.doc.size.width = Math.max(320, Math.min(4000, Math.round(v))) }, fin)))
-      this.row('Height', this.number(dh, 10, (v, fin) =>
-        this.edit(() => { this.store.doc.size.height = Math.max(320, Math.min(4000, Math.round(v))) }, fin)))
-    }
+    widthRow = this.row('Width', this.number(dw, 10, (v, fin) =>
+      this.edit(() => { this.store.doc.size.width = Math.max(320, Math.min(4000, Math.round(v))) }, fin)))
+    heightRow = this.row('Height', this.number(dh, 10, (v, fin) =>
+      this.edit(() => { this.store.doc.size.height = Math.max(320, Math.min(4000, Math.round(v))) }, fin)))
+    showCustomSize(presetKey === 'Custom…')
     this.row('Background', this.color(slide.background, (v, fin) =>
       this.edit(() => { this.store.slide.background = v }, fin)))
     this.row('Transition', this.select(
@@ -1938,7 +1947,7 @@ export class PropsPanel {
     this.host.appendChild(h)
   }
 
-  private row(label: string, input: HTMLElement) {
+  private row(label: string, input: HTMLElement): HTMLLabelElement {
     const row = document.createElement('label')
     row.className = 'ed-row'
     const span = document.createElement('span')
@@ -1949,6 +1958,7 @@ export class PropsPanel {
     if (tip && !input.title) row.title = t(tip)
     row.append(span, input)
     this.host.appendChild(row)
+    return row
   }
 
   private mini(label: string, value: number, onChange: (v: number) => void): HTMLElement {


### PR DESCRIPTION
**What & why**

Fixes #263. Selecting “Custom…” from a preset page size immediately rebuilt the panel, causing it to detect the unchanged preset dimensions and never show the width and height controls.

This shows the width and height controls when “Custom…” is selected. The document changes only when a dimension is edited.

**How I verified it**

- Typecheck passed
- `npm run build:single` passed
- Shell conformance gate passed
- Browser-tested preset → Custom → edit → rebuild → preset

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/`
- [x] New UI strings added to every catalog in `slides/src/i18n/`
- [x] Document format changes are additive and backward-compatible
- [x] Did not bump the version or cut a release (maintainers sign releases)
