### PR TITLE
slides: a tap opens the text box a tap selected — text is uneditable on touch

### DIFF
--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -26,11 +26,6 @@ import type { Peer } from '../sync/session'
 const TAP_SLOP = 10
 /** …and how long it may rest. Past this it is a press, not a tap. */
 const TAP_HOLD_MS = 700
-/** The compatibility mouse burst follows a touch by ~300ms; 450 covers a slow
- *  frame without reaching far enough to catch a deliberate second interaction. */
-const GHOST_WINDOW_MS = 450
-/** …and it lands within a pixel or two of the touch, never across the screen. */
-const GHOST_SLOP = 25
 
 export class SlideCanvas {
   private stage: HTMLElement
@@ -274,13 +269,24 @@ export class SlideCanvas {
     // a previous tap already selected, so that is what enters editing. Checking
     // the selection first is what keeps it safe: the tap that SELECTS an element
     // can never be the one that opens it, so nothing is swallowed.
+    //
+    // TOUCH events, not pointer events, and deliberately so. A pointer handler
+    // runs for a mouse as well and has to filter itself back out by
+    // pointerType; the compatibility mouse burst it leaves behind then has to
+    // be filtered too — two separate chances to change desktop behaviour by
+    // accident. A touch handler cannot fire for a mouse at all, and cancelling
+    // the touchend stops the browser SYNTHESIZING that burst in the first
+    // place, so there is nothing left to filter. (Suggested by @7jameslondon,
+    // who tested the pointer version on a real iPhone.)
     let tap: { x: number; y: number; t: number; id: string | null; wasSelected: boolean } | null = null
-    this.scroller.addEventListener('pointerdown', (ev) => {
-      if (ev.pointerType !== 'touch' || !ev.isPrimary) { tap = null; return }
-      const id = this.topElementAt(ev.clientX, ev.clientY)
+    this.scroller.addEventListener('touchstart', (ev) => {
+      // a second finger means a pinch, never a tap
+      if (ev.touches.length !== 1) { tap = null; return }
+      const t = ev.touches[0]
+      const id = this.topElementAt(t.clientX, t.clientY)
       const sel = this.store.selection
       tap = {
-        x: ev.clientX, y: ev.clientY, t: ev.timeStamp, id,
+        x: t.clientX, y: t.clientY, t: ev.timeStamp, id,
         // Asked HERE and not on release, because Selecto selects on the press:
         // by the time the finger lifts, the tap that merely selected has
         // already made this element the selection and would open the editor
@@ -288,41 +294,46 @@ export class SlideCanvas {
         wasSelected: !!id && sel.length === 1 && sel[0] === id,
       }
     }, true)
-    this.scroller.addEventListener('pointerup', (ev) => {
+    this.scroller.addEventListener('touchmove', (ev) => {
+      const t = ev.touches[0]
+      if (!tap || !t) return
+      // a moved finger was a drag or a pan, not a tap
+      if (Math.hypot(t.clientX - tap.x, t.clientY - tap.y) > TAP_SLOP) tap = null
+    }, true)
+    // non-passive: this is the listener that has to be able to cancel
+    this.scroller.addEventListener('touchend', (ev) => {
       const start = tap
       tap = null
-      if (!start || ev.pointerType !== 'touch' || this.store.readOnly) return
+      if (!start || ev.touches.length || this.store.readOnly) return
       if (this.editing || this.editingCell || this.isPathEditing) return
-      // a moved finger was a drag or a pan, and a held one is a long press —
-      // both are other gestures, and neither should open an editor
-      if (Math.hypot(ev.clientX - start.x, ev.clientY - start.y) > TAP_SLOP) return
-      if (ev.timeStamp - start.t > TAP_HOLD_MS) return
+      const t = ev.changedTouches[0]
+      if (!t) return
+      if (Math.hypot(t.clientX - start.x, t.clientY - start.y) > TAP_SLOP) return
+      if (ev.timeStamp - start.t > TAP_HOLD_MS) return // a held finger is a press
       if (!start.wasSelected) return // this tap is the one that selects
-      const id = this.topElementAt(ev.clientX, ev.clientY)
+      const id = this.topElementAt(t.clientX, t.clientY)
       if (!id || id !== start.id) return // started and ended on the same element
       const sel = this.store.selection
       if (sel.length !== 1 || sel[0] !== id) return // selection moved under us
       const node = this.scaleHost.querySelector<HTMLElement>(`[data-el-id="${CSS.escape(id)}"]`)
       if (!node) return
+      let opened = false
       if (node.classList.contains('bento-el-text')) {
-        this.swallowGhostMouse(ev.clientX, ev.clientY)
         this.startTextEdit(node)
-        return
+        opened = true
+      } else if (node.classList.contains('bento-el-table')) {
+        // a table opens the CELL under the thumb. Its <td>s are real DOM boxes,
+        // so they can be hit-tested directly — but the control box is above
+        // them, hence the whole stack rather than the topmost node.
+        opened = this.editCellUnder(node, t.clientX, t.clientY)
       }
-      // a table opens the CELL under the thumb. Its <td>s are real DOM boxes, so
-      // they can be hit-tested directly — but the control box is above them,
-      // hence the whole stack rather than the topmost node.
-      if (node.classList.contains('bento-el-table')) {
-        const td = document
-          .elementsFromPoint(ev.clientX, ev.clientY)
-          .map((n) => (n as HTMLElement).closest?.<HTMLElement>('td[data-c]'))
-          .find((n): n is HTMLElement => !!n && node.contains(n))
-        if (td) {
-          this.swallowGhostMouse(ev.clientX, ev.clientY)
-          this.editCellFromTd(td)
-        }
-      }
-    }, true)
+      // Cancel the tap we consumed. Without this the browser replays it as
+      // mousedown → mouseup → click ~300ms later at the ORIGINAL screen point,
+      // which focus() has by then scrolled away from to reveal the caret — so
+      // Selecto read the ghost press as "outside the text being edited" and
+      // committed the edit a blink after it opened.
+      if (opened && ev.cancelable) ev.preventDefault()
+    }, { passive: false })
 
     new ResizeObserver(() => this.relayout()).observe(wrap)
 
@@ -603,32 +614,15 @@ export class SlideCanvas {
     return [...out]
   }
 
-  /**
-   * Swallow the compatibility mouse burst that a browser fires ~300ms after a
-   * touch it did not see prevented (mousedown → mouseup → click).
-   *
-   * It has to go, because it arrives at the ORIGINAL screen point: focusing the
-   * text has by then scrolled the canvas to reveal the caret, so that point is
-   * usually empty space, and Selecto reads the ghost mousedown as "pressed
-   * outside the text being edited" — committing the edit a blink after the tap
-   * opened it. preventDefault matters as much as stopPropagation: without it
-   * the ghost press blurs the contenteditable, and blur commits too.
-   *
-   * Bounded by both time and distance so a real mouse on a hybrid device (a
-   * touchscreen laptop, an iPad with a trackpad) can never be caught by it.
-   */
-  private swallowGhostMouse(x: number, y: number) {
-    const kill = (ev: Event) => {
-      const m = ev as MouseEvent
-      if (Math.hypot(m.clientX - x, m.clientY - y) > GHOST_SLOP) return
-      ev.stopPropagation()
-      ev.preventDefault()
-    }
-    const types = ['mousedown', 'mouseup', 'click'] as const
-    for (const t of types) window.addEventListener(t, kill, true)
-    setTimeout(() => {
-      for (const t of types) window.removeEventListener(t, kill, true)
-    }, GHOST_WINDOW_MS)
+  /** Open the table cell under a client point. Reports whether it found one. */
+  private editCellUnder(node: HTMLElement, x: number, y: number): boolean {
+    const td = document
+      .elementsFromPoint(x, y)
+      .map((n) => (n as HTMLElement).closest?.<HTMLElement>('td[data-c]'))
+      .find((n): n is HTMLElement => !!n && node.contains(n))
+    if (!td) return false
+    this.editCellFromTd(td)
+    return true
   }
 
   /** The element a client point lands on — the same answer Selecto's own click

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -21,6 +21,17 @@ type DrawKind = 'line' | 'path' | 'connector' | 'free' | 'poly'
 import { CommentsUI } from './comments'
 import type { Peer } from '../sync/session'
 
+/** How far a finger may travel and still count as a tap rather than a drag.
+ *  10px matches what a thumb does on glass while trying to hold still. */
+const TAP_SLOP = 10
+/** …and how long it may rest. Past this it is a press, not a tap. */
+const TAP_HOLD_MS = 700
+/** The compatibility mouse burst follows a touch by ~300ms; 450 covers a slow
+ *  frame without reaching far enough to catch a deliberate second interaction. */
+const GHOST_WINDOW_MS = 450
+/** …and it lands within a pixel or two of the touch, never across the screen. */
+const GHOST_SLOP = 25
+
 export class SlideCanvas {
   private stage: HTMLElement
   private scaleHost: HTMLElement
@@ -253,6 +264,65 @@ export class SlideCanvas {
       const td = (ev.target as HTMLElement).closest<HTMLElement>('.bento-el-table td[data-c]')
       if (td) this.editCellFromTd(td)
     })
+
+    // Touch has no double-click. Selecto and Moveable preventDefault the touch
+    // stream they handle, so the synthesized mouse events never arrive on the
+    // canvas — not click, and not dblclick. The route above is therefore
+    // unreachable from a phone, and text simply could not be edited there.
+    //
+    // The gesture every touch editor uses for "open this" is a tap on the thing
+    // a previous tap already selected, so that is what enters editing. Checking
+    // the selection first is what keeps it safe: the tap that SELECTS an element
+    // can never be the one that opens it, so nothing is swallowed.
+    let tap: { x: number; y: number; t: number; id: string | null; wasSelected: boolean } | null = null
+    this.scroller.addEventListener('pointerdown', (ev) => {
+      if (ev.pointerType !== 'touch' || !ev.isPrimary) { tap = null; return }
+      const id = this.topElementAt(ev.clientX, ev.clientY)
+      const sel = this.store.selection
+      tap = {
+        x: ev.clientX, y: ev.clientY, t: ev.timeStamp, id,
+        // Asked HERE and not on release, because Selecto selects on the press:
+        // by the time the finger lifts, the tap that merely selected has
+        // already made this element the selection and would open the editor
+        // on the FIRST tap.
+        wasSelected: !!id && sel.length === 1 && sel[0] === id,
+      }
+    }, true)
+    this.scroller.addEventListener('pointerup', (ev) => {
+      const start = tap
+      tap = null
+      if (!start || ev.pointerType !== 'touch' || this.store.readOnly) return
+      if (this.editing || this.editingCell || this.isPathEditing) return
+      // a moved finger was a drag or a pan, and a held one is a long press —
+      // both are other gestures, and neither should open an editor
+      if (Math.hypot(ev.clientX - start.x, ev.clientY - start.y) > TAP_SLOP) return
+      if (ev.timeStamp - start.t > TAP_HOLD_MS) return
+      if (!start.wasSelected) return // this tap is the one that selects
+      const id = this.topElementAt(ev.clientX, ev.clientY)
+      if (!id || id !== start.id) return // started and ended on the same element
+      const sel = this.store.selection
+      if (sel.length !== 1 || sel[0] !== id) return // selection moved under us
+      const node = this.scaleHost.querySelector<HTMLElement>(`[data-el-id="${CSS.escape(id)}"]`)
+      if (!node) return
+      if (node.classList.contains('bento-el-text')) {
+        this.swallowGhostMouse(ev.clientX, ev.clientY)
+        this.startTextEdit(node)
+        return
+      }
+      // a table opens the CELL under the thumb. Its <td>s are real DOM boxes, so
+      // they can be hit-tested directly — but the control box is above them,
+      // hence the whole stack rather than the topmost node.
+      if (node.classList.contains('bento-el-table')) {
+        const td = document
+          .elementsFromPoint(ev.clientX, ev.clientY)
+          .map((n) => (n as HTMLElement).closest?.<HTMLElement>('td[data-c]'))
+          .find((n): n is HTMLElement => !!n && node.contains(n))
+        if (td) {
+          this.swallowGhostMouse(ev.clientX, ev.clientY)
+          this.editCellFromTd(td)
+        }
+      }
+    }, true)
 
     new ResizeObserver(() => this.relayout()).observe(wrap)
 
@@ -531,6 +601,48 @@ export class SlideCanvas {
     const out = new Set(ids)
     for (const el of els) if (el.groupId && groups.has(el.groupId)) out.add(el.id)
     return [...out]
+  }
+
+  /**
+   * Swallow the compatibility mouse burst that a browser fires ~300ms after a
+   * touch it did not see prevented (mousedown → mouseup → click).
+   *
+   * It has to go, because it arrives at the ORIGINAL screen point: focusing the
+   * text has by then scrolled the canvas to reveal the caret, so that point is
+   * usually empty space, and Selecto reads the ghost mousedown as "pressed
+   * outside the text being edited" — committing the edit a blink after the tap
+   * opened it. preventDefault matters as much as stopPropagation: without it
+   * the ghost press blurs the contenteditable, and blur commits too.
+   *
+   * Bounded by both time and distance so a real mouse on a hybrid device (a
+   * touchscreen laptop, an iPad with a trackpad) can never be caught by it.
+   */
+  private swallowGhostMouse(x: number, y: number) {
+    const kill = (ev: Event) => {
+      const m = ev as MouseEvent
+      if (Math.hypot(m.clientX - x, m.clientY - y) > GHOST_SLOP) return
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+    const types = ['mousedown', 'mouseup', 'click'] as const
+    for (const t of types) window.addEventListener(t, kill, true)
+    setTimeout(() => {
+      for (const t of types) window.removeEventListener(t, kill, true)
+    }, GHOST_WINDOW_MS)
+  }
+
+  /** The element a client point lands on — the same answer Selecto's own click
+   *  selection gives, because it is the same question: what is painted here?
+   *  (A model-box hit test is NOT equivalent: decorative full-bleed elements
+   *  overlap smaller ones in model space while sitting behind or beside them
+   *  on screen.) Walking the whole stack rather than taking elementFromPoint is
+   *  what steps over Moveable's control box, which covers whatever is selected. */
+  private topElementAt(clientX: number, clientY: number): string | null {
+    for (const n of document.elementsFromPoint(clientX, clientY)) {
+      const el = n.closest<HTMLElement>('.bento-el')
+      if (el && this.scaleHost.contains(el) && el.dataset.elId) return el.dataset.elId
+    }
+    return null
   }
 
   /** Alt-click: select the element under (px, py), digging one step deeper


### PR DESCRIPTION
## The problem

**On a phone or tablet, a bento deck is effectively read-only.** You can select
elements, drag them, resize them — but you cannot change a single word.

Opening a text box is bound to one event:

```ts
// slides/src/editor/canvas.ts
this.stage.addEventListener('dblclick', (ev) => { … startTextEdit(textEl) … })
```

`dblclick` never reaches the canvas from a touch screen. Selecto and Moveable
call `preventDefault()` on the touch stream they handle, and that suppresses the
*entire* synthesized mouse sequence — `click` and `dblclick` alike. Instrumenting
the canvas under an iPhone profile, a double-tap on a text element delivers:

```
pointerdown, touchstart, touchend      ← and nothing else
```

There is no second route into `startTextEdit`, so there is no way in.

## The fix

A tap on the element that a **previous tap already selected** opens it — the
gesture every touch editor uses for "open this". A table opens the cell under
the thumb.

Two details carry the change:

- **The "was it selected?" question is asked on the press, not the release.**
  Selecto selects on the press, so by the time the finger lifts, the tap that
  merely *selected* has already made the element the selection and would open
  the editor on the **first** tap. Asking on `touchstart` is what keeps
  tap-to-select intact.
- **The opening tap is cancelled, so the compatibility mouse burst is never
  synthesized.** A touch the browser does not see cancelled is replayed as
  `mousedown → mouseup → click` ~300ms later at the *original* screen point —
  which `focus()` has by then scrolled away from, to bring the caret into view.
  Selecto read that ghost press as "pressed outside the text being edited" and
  committed the edit a blink after it opened. This only reproduced once the
  canvas was zoomed enough to scroll, which is exactly the state a phone is in.
  Only the tap that actually opens an editor is cancelled; a tap that merely
  selects is left alone.

Hit-testing goes through `document.elementsFromPoint` rather than the model
boxes, because that is the same question Selecto's own click selection answers —
"what is painted here?". A model-box test is *not* equivalent: decorative
full-bleed elements overlap smaller ones in model space while sitting behind
them on screen, and the two disagreed on the starter deck's own headline.

## Before / after

Identical gesture sequence in both panels: tap, tap again, then double-tap.

| before | after |
|---|---|
| tap, tap, double-tap — nothing opens | second tap opens the box; typing works |

![tap to edit, before and after](https://raw.githubusercontent.com/iamgeo92/bento/pr-media/media/tap-to-edit.gif)

<details>
<summary>Stills</summary>

| before — no caret, no keyboard | after — edited and committed |
|---|---|
| <img src="https://raw.githubusercontent.com/iamgeo92/bento/pr-media/media/tap-to-edit-before.png" width="320"> | <img src="https://raw.githubusercontent.com/iamgeo92/bento/pr-media/media/tap-to-edit-after.png" width="320"> |

</details>

## Nothing changes for a mouse

- Single click still selects; it can never open, because the selecting tap is
  never the opening one.
- Double-click still opens, unchanged.
- The recogniser is bound to **touch events**, which cannot fire for a mouse at
  all — so there is no `pointerType` filter to get wrong, and nothing on a
  hybrid device (a touchscreen laptop, an iPad with a trackpad) can reach it
  through the mouse.
- Nothing listens for mouse events on the document, and nothing is suppressed
  after the fact.

## How this was verified

`slides/` on the dev server, driven through Chrome DevTools' iPhone emulation
(390×664, DPR 3, `hasTouch`), with real touch event dispatch — plus a mouse
control at 1280×800 for the regression cases:

| case | result |
|---|---|
| tap #1 selects, does not open | pass |
| tap #2 on the selected box opens it | pass |
| typed text reaches the document model | pass |
| a drag (finger moves >10px) does not open | pass |
| a long press (>700ms) does not open | pass |
| tapping a *different* element re-selects, never opens | pass |
| table: tap opens exactly the cell under the thumb | pass |
| desktop double-click still opens | pass |
| a slow second mouse *click* does not open | pass |
| zoomed canvas (the scrolling case) opens and stays open | pass |

Gates run on this branch:

```
node_modules/.bin/tsc -b                                        clean
npm run build:single                                            ok (664KB shell)
node scripts/shell-gate.mjs …/Bento_Slides.bento.html           splice contract OK
```

No new user-facing strings, so no i18n catalog changes. No format change, no
kernel change, nothing under `sync/`.

## Update after review

@7jameslondon built and tested the first version on a **real iPhone** and on
desktop, and suggested recognising the gesture on touch events and cancelling
the tap rather than tracking pointer events and filtering the mouse events they
produce. That is a better shape and it is now what the branch does — second
commit on this PR.

The first version needed *two* mechanisms to protect desktop behaviour: a
`pointerType === 'touch'` guard, and a window-level capture listener that
swallowed `mousedown`/`mouseup`/`click` for 450ms within 25px of the touch.
Both were mine to get wrong. Cancelling the `touchend` stops the browser
generating that burst in the first place, so `swallowGhostMouse` and its two
constants are gone — a net **−21 lines**, and the guard is structural rather
than heuristic.

Two assertions were added with it: the opening tap produces **no** synthesized
mouse events, and the *selecting* tap is **not** cancelled.

**Verified on a real iPhone.** My own testing is Chromium's iPhone emulation, so
I flagged one thing emulation cannot prove: that the on-screen keyboard still
opens when the tap that focuses the text is also the tap that gets cancelled.
@7jameslondon has since re-tested **this** commit on a real iPhone and on
desktop and confirmed it — *"everything works as expected including the keyboard
hiding and showing only when it should"* — so that caveat is closed.

---

<details>
<summary><b>Changelog entry</b> — not in the diff, on purpose</summary>

`CHANGELOG.md` is this repo's named conflict magnet (`docs/PARALLEL-WORK.md` §3). With several of these open at once, and `[Unreleased]` being emptied every time a release is cut, a changelog hunk made every one of them conflict on that file and nothing else — twice over. They carry no `CHANGELOG.md` change so they stay mergeable; here is the entry to drop in at release time, or I'll add it back in whatever form you prefer.

```markdown
- **Fix: text could not be edited at all on a phone or tablet.** Opening a text
  box was bound to `dblclick`, and that event never reaches the canvas from a
  touch screen — Selecto and Moveable call `preventDefault` on the touch stream
  they handle, which suppresses the whole synthesized mouse sequence, `click`
  and `dblclick` alike. There was no second route, so on an iPhone the deck was
  effectively read-only: elements selected, moved and resized, but no words
  could be changed. A tap on the element a previous tap already selected now
  opens it — the gesture every touch editor uses for "open this" — and a table
  opens the cell under the thumb. Nothing changes for a mouse: the tap that
  selects can never be the one that opens, so single-click selection is intact,
  and double-click still works as before.
```

</details>
