### PR TITLE
changelog: the security release says it is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Security: update this file. A deck could run code hidden in its own
+  content.** Ordinary-looking document content — an image, a shape, an embedded
+  drawing — could carry script that ran when the slide was drawn, or quietly
+  send the reader somewhere else. No unusual file was needed and nothing looked
+  wrong on screen.
+
+  That matters more here than in most applications, because a Bento file is not
+  a passive document: the page holding it also holds the live-session keys, the
+  local autosave copy, and — where the browser allows it — permission to write
+  back to the file on disk. Anything running inside the page inherits all of it.
+
+  Every path that turns author content into a page is now sanitised: the
+  renderer, the still image written for file-manager thumbnails, and the PDF
+  export. The iOS host no longer trusts a filename a document supplies, blob
+  fetches verify what they received, and new password-protected files use a
+  stronger key derivation.
+
+  **Two exports were also leaking.** "Copy document JSON" carried the live
+  room's private keys — while suggesting you paste the result into an AI chat —
+  and "Save as template…" wrote readable content out of a password-protected
+  deck. A third case kept a key in an invite copy that should not have had one.
+  All three now strip, through one list in one place rather than three
+  independent decisions.
+
+  **If you have already shared a live deck** — its JSON, or the file itself, to
+  a chat, a ticket or an agent — updating does not retract that. Use *Share →
+  Rotate keys*, which mints a new room and revokes the old one, then re-share
+  the new copy. If you published a template made from a password-protected
+  deck, treat its contents as disclosed: rotation cannot take back what the
+  template already wrote in the clear.
+
+  Found by auditing this repository rather than by a report, with an
+  independent adversarial review on each round, and every fix was checked to
+  fail against the previous build before being kept. The collaboration relay is
+  deliberately **not** part of this release — a relay deployment cannot be
+  undone by a file update, so it ships separately once its own regression is
+  resolved.
+
 - **A deck that is being shared now says so before an agent reads it.** A file
   with live collaboration switched on carries the keys to its own session —
   that is what makes sharing work without accounts, and it means anything


### PR DESCRIPTION
The fixes in #277 landed with **no CHANGELOG entry**, which here isn't a tidiness problem.

The first five bold lead-ins become the `notes` in the **signed manifest** — what a shipped file shows in the About dialog while its reader decides whether to update. A security release whose notes never mention security wastes the only channel that reaches files already in the world. And those files stay vulnerable until someone chooses to update, because there is no way to push.

Signed notes with this in place:

```
• Security: update this file. A deck could run code hidden in its own content.
• A deck that is being shared now says so before an agent reads it.
• Hide a slide from the show.
• Fix: a live session could crash when two people created the same element at the same moment.
```

Placed first, because the notes take lead-ins in order.

## Three deliberate choices

**The lead-in spends its one line on severity and action**, not mechanism. Detail belongs in the advisory — this note ships to every deck while un-updated ones are still exposed.

**It carries what an update cannot fix.** "Copy document JSON" leaked the room's private keys *while recommending you paste the result into an AI chat*, and "Save as template…" wrote plaintext out of a password-protected deck. Stopping both does nothing for what already left — so the entry says to rotate, and says a leaked template's contents cannot be rotated back.

**It says the relay is not in this release**, so nobody reads it as "collaboration is now secure".