### PR TITLE
A dark interface for bento/slides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,15 @@ jobs:
         # two it did not catch were found by widening it.
         run: node scripts/test-dash-sync.ts
 
+      - name: Theme token gate
+        # Every failure this catches is INVISIBLE in the light theme, which is
+        # the one the author is looking at. A chrome surface pinned to white
+        # keeps its light background in dark and puts light text on it — the
+        # properties panel measured 1.21:1 against a 4.5 floor before this gate
+        # existed. It also stops a document token being themed (which would
+        # invert the deck) and the light palette forking from spaces and type.
+        run: node scripts/test-slides-theme.mjs
+
       - name: Built-in layout geometry rig
         # The built-ins are drawn against 1600x900 while the model default is
         # 1280x720, so they used to hang 200px off the right edge of a default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,19 @@ pre-1.0.
   two inputs never appeared. Custom mode now reveals the existing controls
   without changing the document until a dimension is actually edited.
 
+- **A dark interface, if you want one.** *About → Appearance* offers Match my
+  system, Light or Dark. It follows your machine by default and changes as your
+  machine does, so a laptop that dims at sunset takes the editor with it.
+
+  **Your deck does not invert.** Dark dims the chrome around the slide; the
+  slide itself stays exactly as authored, because its background is your data
+  and someone proofing at midnight still needs to see what will be projected.
+  The presenter window stays dark in both themes — you present in a dark room.
+
+  The theme is a viewer preference, stored on your machine and never written
+  into the file, so it never travels to whoever you send a deck to. Same rule
+  the interface language and reduced motion already follow.
+
 ## [1.0.16] — 2026-08-03
 
 - **Fix: the slide could open off-centre, pushed to one side and clipped.**

--- a/kernel/src/theme.ts
+++ b/kernel/src/theme.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+//
+// Theme selection, shared by every Bento app.
+//
+// A THEME IS A VIEWER PREFERENCE, NEVER DOCUMENT DATA. It lives in
+// localStorage, exactly as the interface locale and reduced motion already do,
+// and for the same reason: two people opening the same file are two different
+// readers with two different eyes and two different rooms. A theme written into
+// the document would travel to the recipient and override theirs — and worse,
+// it would make the file's bytes depend on who last looked at it, which breaks
+// the signature story in bento/type.
+//
+// THE DOCUMENT DOES NOT INVERT. Dark theme dims the CHROME. A slide's
+// background is document data the author chose; a page is white because paper
+// is white, and somebody proofing a contract at midnight still needs to see
+// what will print. Apps express this by keeping surface tokens (--paper,
+// --slide-*) out of the themed set.
+
+export type ThemeChoice = 'auto' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const KEY = 'bento-theme';
+
+/**
+ * localStorage access that cannot take the app down.
+ *
+ * Reading the `localStorage` PROPERTY — not calling a method on it — throws
+ * when site data is blocked, inside some embedded webviews, and in any
+ * sandboxed frame. bento/slides 1.0.15 shipped a fix for exactly this after one
+ * unreadable preference cost users the whole document. A theme is worth less
+ * than a document; it must degrade to the default in silence.
+ */
+function read(): string | null {
+  try { return localStorage.getItem(KEY); } catch { return null; }
+}
+function write(v: string): void {
+  try { localStorage.setItem(KEY, v); } catch { /* preference simply is not remembered */ }
+}
+
+const media = (): MediaQueryList | null => {
+  try { return matchMedia('(prefers-color-scheme: dark)'); } catch { return null; }
+};
+
+/** What the user asked for — 'auto' unless they chose otherwise. */
+export function themeChoice(): ThemeChoice {
+  const v = read();
+  return v === 'light' || v === 'dark' ? v : 'auto';
+}
+
+/** What that resolves to right now, given the OS setting. */
+export function resolvedTheme(choice: ThemeChoice = themeChoice()): ResolvedTheme {
+  if (choice !== 'auto') return choice;
+  return media()?.matches ? 'dark' : 'light';
+}
+
+type Listener = (t: ResolvedTheme) => void;
+const listeners = new Set<Listener>();
+
+/**
+ * Put the theme on the document element.
+ *
+ * `data-theme` is what the stylesheets key off. `color-scheme` is what makes
+ * the BROWSER's own furniture follow — scrollbars, form controls, the canvas
+ * behind a rubber-band scroll. Without it a dark app keeps white scrollbars and
+ * looks broken in exactly the places CSS cannot reach.
+ */
+export function applyTheme(choice: ThemeChoice = themeChoice()): ResolvedTheme {
+  const t = resolvedTheme(choice);
+  const root = document.documentElement;
+  root.dataset.theme = t;
+  root.style.colorScheme = t;
+  for (const fn of listeners) fn(t);
+  return t;
+}
+
+export function setTheme(choice: ThemeChoice): ResolvedTheme {
+  write(choice);
+  return applyTheme(choice);
+}
+
+/** Notified when the EFFECTIVE theme changes, including an OS flip on 'auto'. */
+export function onThemeChange(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+let started = false;
+/**
+ * Apply the stored theme and keep following the OS while the choice is 'auto'.
+ * Call once at boot, BEFORE the first paint if possible.
+ */
+export function startTheme(): ResolvedTheme {
+  const t = applyTheme();
+  if (!started) {
+    started = true;
+    media()?.addEventListener?.('change', () => {
+      if (themeChoice() === 'auto') applyTheme('auto');
+    });
+  }
+  return t;
+}
+
+/** The three choices, for a picker. Labels are the app's to translate. */
+export const THEME_CHOICES: ThemeChoice[] = ['auto', 'light', 'dark'];

--- a/scripts/test-slides-theme.mjs
+++ b/scripts/test-slides-theme.mjs
@@ -97,7 +97,19 @@ for (const [, , sel, body] of rules) {
 ok(whiteSurfaces.length === 0,
   `no chrome surface is pinned to white${whiteSurfaces.length ? `\n        ${whiteSurfaces.join('\n        ')}` : ''}`)
 
-// ---- 4. the light palette has not forked from the suite -------------------
+// ---- 4. every themed role is actually WIRED UP ----------------------------
+// A token defined in both blocks and referenced nowhere is not harmless: it is
+// a wire that was never connected, and the literal it was meant to replace is
+// still sitting in the stylesheet painting a light value in dark. That is
+// exactly how the canvas dot grid kept glaring after `--grid-dot` was added —
+// defined twice, used never, `#d5dbe4` still in the gradient.
+{
+  const unused = [...rolesIn(light ?? '')].filter((r) => !new RegExp(`var\\(${r}[,)]`).test(css))
+  ok(unused.length === 0,
+    `every themed role is referenced by a rule${unused.length ? ` — defined but unused: ${unused.join(', ')}` : ''}`)
+}
+
+// ---- 5. the light palette has not forked from the suite -------------------
 const SHARED = { '--ink': '#1e2a3a', '--ink-2': '#31445c', '--chrome': '#f5f7fa',
   '--chrome-2': '#eceff4', '--line': '#e3e8ef', '--muted': '#5b6472',
   '--accent': '#f7a600', '--accent-ink': '#7a5200', '--blue': '#5b8def' }
@@ -108,7 +120,7 @@ for (const [k, v] of Object.entries(SHARED)) {
 }
 ok(wrong.length === 0, `the light theme still matches the suite palette${wrong.length ? `\n        ${wrong.join('\n        ')}` : ''}`)
 
-// ---- 5. the theme never reaches a saved file ------------------------------
+// ---- 6. the theme never reaches a saved file ------------------------------
 // startTheme() writes data-theme + color-scheme onto <html>. capturePristine()
 // clones the LIVE document and saves re-serialize that clone, so the call must
 // come AFTER it or a reader's preference ships inside every file they save —

--- a/scripts/test-slides-theme.mjs
+++ b/scripts/test-slides-theme.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Theme token gate for bento/slides.
+//
+//   node scripts/test-slides-theme.mjs
+//
+// WHAT THIS PROVES. A theme is only as good as the rules nobody can quietly
+// break, and every failure mode here is INVISIBLE in the light theme — which is
+// the one the author is looking at.
+//
+//   1. A chrome surface hard-coded to white keeps its light background in dark
+//      and turns light text onto it. Measured before this gate existed: the
+//      properties panel's selects and inputs sat at 1.21:1 against WCAG AA's
+//      4.5 floor. They LOOKED perfect in light.
+//   2. A document token pulled into a themed block would invert the deck. A
+//      slide's background is the author's data, and someone proofing at
+//      midnight still needs to see what will be projected.
+//   3. The light palette drifting from the other apps. slides, spaces and type
+//      share one palette character for character; a fork shows up as two
+//      Bento windows side by side in slightly different greys.
+//
+// DELIBERATE EXCEPTIONS, listed rather than silently tolerated — each is a
+// surface that must NOT follow the chrome theme.
+
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const css = readFileSync(join(root, 'slides/src/styles.css'), 'utf8')
+
+let failures = 0
+let checks = 0
+const ok = (cond, msg) => {
+  checks++
+  if (!cond) { failures++; console.log(`  FAIL  ${msg}`) } else console.log(`  ok    ${msg}`)
+}
+
+const block = (selector) => {
+  const i = css.indexOf(selector)
+  if (i < 0) return null
+  const open = css.indexOf('{', i)
+  return css.slice(open + 1, css.indexOf('}', open))
+}
+const rolesIn = (body) => new Set([...body.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gmi)].map((m) => m[1]))
+
+// ---- 1. both themes define the same roles ---------------------------------
+const light = block(':root, :root[data-theme="light"]')
+const dark = block(':root[data-theme="dark"]')
+ok(!!light && !!dark, 'both a light and a dark token block exist')
+if (light && dark) {
+  const L = rolesIn(light), D = rolesIn(dark)
+  const missing = [...L].filter((r) => !D.has(r))
+  const extra = [...D].filter((r) => !L.has(r))
+  ok(missing.length === 0, `dark defines every role light does${missing.length ? ` — missing ${missing.join(', ')}` : ''}`)
+  ok(extra.length === 0, `dark invents no role light lacks${extra.length ? ` — extra ${extra.join(', ')}` : ''}`)
+}
+
+// ---- 2. the DOCUMENT does not invert --------------------------------------
+// A themed block may not define anything that renders document content. The
+// deck is the author's; only the chrome around it follows the reader.
+const DOCUMENT_TOKENS = /--(slide-bg|paper|bento-|r-)/
+for (const [name, body] of [['light', light], ['dark', dark]]) {
+  if (!body) continue
+  const doc = [...rolesIn(body)].filter((r) => DOCUMENT_TOKENS.test(r))
+  ok(doc.length === 0, `the ${name} block themes no document token${doc.length ? ` — ${doc.join(', ')}` : ''}`)
+}
+
+// ---- 3. no chrome surface is hard-coded white -----------------------------
+// The 1.21:1 bug. A surface pinned to #fff stays light while its text follows
+// the theme. Exceptions are surfaces that are deliberately NOT chrome:
+//
+//   .bento-speaker*  the presenter window is always dark — you present in a
+//                    darkened room, and it should not brighten at dawn
+//   .bento-splash    boot brand art, the starter deck's own palette
+//   #bento-print     paper is white because paper is white
+//   .bento-          anything rendering document content
+//   .ed-comment-hl   a comment pin sits ON the slide, over document content
+//                    the author chose — a white dot ringed in accent has to
+//                    read against a dark deck AND a light one, so it follows
+//                    neither theme
+//   .ed-pwcard       the password gate is a full-screen dark card in both
+//                    themes, like the splash; its input is translucent white
+//                    ON that card, not a chrome surface
+const EXEMPT = /^(\.bento-speaker|\.sv-|\.bento-splash|#bento-print|\.bento-|\.ed-comment-hl|\.ed-pwcard|@|:root|\*)/
+const rules = [...css.matchAll(/(^|\n)([^@{}\n][^{}]*)\{([^}]*)\}/g)]
+const whiteSurfaces = []
+for (const [, , sel, body] of rules) {
+  if (!/background[^;]*:(?![^;]*var\()[^;]*(#fff\b|#ffffff\b|rgb\(\s*255[ ,]+255[ ,]+255)/i.test(body)) continue
+  // strip any comment sitting above the rule, or the failure names the
+  // comment instead of the selector and sends the reader to the wrong place
+  const s = sel.replace(/\/\*[\s\S]*?\*\//g, '').trim().split(',')[0].trim()
+  if (EXEMPT.test(s)) continue
+  whiteSurfaces.push(s)
+}
+ok(whiteSurfaces.length === 0,
+  `no chrome surface is pinned to white${whiteSurfaces.length ? `\n        ${whiteSurfaces.join('\n        ')}` : ''}`)
+
+// ---- 4. the light palette has not forked from the suite -------------------
+const SHARED = { '--ink': '#1e2a3a', '--ink-2': '#31445c', '--chrome': '#f5f7fa',
+  '--chrome-2': '#eceff4', '--line': '#e3e8ef', '--muted': '#5b6472',
+  '--accent': '#f7a600', '--accent-ink': '#7a5200', '--blue': '#5b8def' }
+const wrong = []
+for (const [k, v] of Object.entries(SHARED)) {
+  const m = light?.match(new RegExp(`${k}\\s*:\\s*([^;]+);`, 'i'))
+  if (!m || m[1].trim().toLowerCase() !== v) wrong.push(`${k} is ${m ? m[1].trim() : 'missing'}, suite says ${v}`)
+}
+ok(wrong.length === 0, `the light theme still matches the suite palette${wrong.length ? `\n        ${wrong.join('\n        ')}` : ''}`)
+
+// ---- 5. the theme never reaches a saved file ------------------------------
+// startTheme() writes data-theme + color-scheme onto <html>. capturePristine()
+// clones the LIVE document and saves re-serialize that clone, so the call must
+// come AFTER it or a reader's preference ships inside every file they save —
+// the same ordering applyDirection() already depends on.
+const main = readFileSync(join(root, 'slides/src/main.ts'), 'utf8')
+ok(main.indexOf('startTheme()') > main.indexOf('capturePristine()'),
+  'startTheme() runs after capturePristine(), so no theme reaches a saved file')
+
+console.log(`\n${checks - failures}/${checks} checks passed`)
+if (failures) process.exit(1)

--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -11,6 +11,7 @@ import {
   instantiateLayout, isLightBg, layoutElementIds, newDocId, parseDoc, readableInk, syncLinkedChart, uid,
   paginates, inLinearFlow,
   type ChartElement, type ShapeKind, type Slide, type SlideElement, type TableElement } from '../model'
+import { THEME_CHOICES, setTheme, themeChoice } from '../../../kernel/src/theme.ts'
 import { APP_VERSION, applyUpdate, applyUpdateInPlace, autoCheckEnabled, canUpdateInPlace, checkForUpdates, compareVersions, offlineEnabled, setAutoCheck, setOffline } from '../update'
 import { CHART_PRESETS } from '../charts'
 import { renderSlide, renderThumbnail } from '../render'
@@ -2860,6 +2861,24 @@ export class Editor {
     })
     row.appendChild(checkB)
     box.append(row, status)
+
+    // Appearance — a VIEWER preference, so it sits with the others (language,
+    // auto-update) rather than anywhere near the document's own settings.
+    // "Auto" is first and is the default: most people want their machine's
+    // choice, and the explicit options exist for the ones who do not.
+    const themeRow = document.createElement('label')
+    themeRow.className = 'ed-about-auto'
+    const themeSel = document.createElement('select')
+    for (const c of THEME_CHOICES) {
+      const o = document.createElement('option')
+      o.value = c
+      o.textContent = c === 'auto' ? t('Match my system') : c === 'light' ? t('Light') : t('Dark')
+      if (c === themeChoice()) o.selected = true
+      themeSel.appendChild(o)
+    }
+    themeSel.addEventListener('change', () => setTheme(themeSel.value as never))
+    themeRow.append(document.createTextNode(t('Appearance') + ' '), themeSel)
+    box.appendChild(themeRow)
 
     const autoRow = document.createElement('label')
     autoRow.className = 'ed-about-auto'

--- a/slides/src/i18n/de.ts
+++ b/slides/src/i18n/de.ts
@@ -740,4 +740,7 @@ export const de: Catalog = {
   "Hide slide": "Folie ausblenden",
   "Number hidden slides": "Ausgeblendete Folien nummerieren",
   "Hidden — skipped while presenting and left out of PDF export": "Ausgeblendet — wird beim Präsentieren übersprungen und nicht als PDF exportiert",
+  "Appearance": "Darstellung",
+  "Match my system": "Systemeinstellung folgen",
+  "Dark": "Dunkel",
 }

--- a/slides/src/i18n/es.ts
+++ b/slides/src/i18n/es.ts
@@ -740,4 +740,7 @@ export const es: Catalog = {
   "Hide slide": "Ocultar diapositiva",
   "Number hidden slides": "Numerar diapositivas ocultas",
   "Hidden — skipped while presenting and left out of PDF export": "Oculta: se omite al presentar y no se incluye en la exportación a PDF",
+  "Appearance": "Apariencia",
+  "Match my system": "Según el sistema",
+  "Dark": "Oscuro",
 }

--- a/slides/src/i18n/fr.ts
+++ b/slides/src/i18n/fr.ts
@@ -740,4 +740,7 @@ export const fr: Catalog = {
   "Hide slide": "Masquer la diapositive",
   "Number hidden slides": "Numéroter les diapositives masquées",
   "Hidden — skipped while presenting and left out of PDF export": "Masquée — ignorée pendant la présentation et absente de l’export PDF",
+  "Appearance": "Apparence",
+  "Match my system": "Comme le système",
+  "Dark": "Sombre",
 }

--- a/slides/src/i18n/it.ts
+++ b/slides/src/i18n/it.ts
@@ -740,4 +740,7 @@ export const it: Catalog = {
   "Hide slide": "Nascondi diapositiva",
   "Number hidden slides": "Numera le diapositive nascoste",
   "Hidden — skipped while presenting and left out of PDF export": "Nascosta — saltata durante la presentazione ed esclusa dall’esportazione PDF",
+  "Appearance": "Aspetto",
+  "Match my system": "Come il sistema",
+  "Dark": "Scuro",
 }

--- a/slides/src/i18n/ja.ts
+++ b/slides/src/i18n/ja.ts
@@ -740,4 +740,7 @@ export const ja: Catalog = {
   "Hide slide": "スライドを非表示",
   "Number hidden slides": "非表示スライドに番号を付ける",
   "Hidden — skipped while presenting and left out of PDF export": "非表示 — 発表中はスキップされ、PDF 書き出しにも含まれません",
+  "Appearance": "外観",
+  "Match my system": "システムに合わせる",
+  "Dark": "ダーク",
 }

--- a/slides/src/i18n/packed.ts
+++ b/slides/src/i18n/packed.ts
@@ -746,4 +746,7 @@ export const PACKED: Record<string, ReadonlyArray<string | 0>> = {
   "Hide slide": ["スライドを非表示","隐藏幻灯片","隱藏投影片","Ocultar diapositiva","Masquer la diapositive","Folie ausblenden","Nascondi diapositiva","Ocultar diapositivo"],
   "Number hidden slides": ["非表示スライドに番号を付ける","为隐藏幻灯片编号","為隱藏投影片編號","Numerar diapositivas ocultas","Numéroter les diapositives masquées","Ausgeblendete Folien nummerieren","Numera le diapositive nascoste","Numerar diapositivos ocultos"],
   "Hidden — skipped while presenting and left out of PDF export": ["非表示 — 発表中はスキップされ、PDF 書き出しにも含まれません","已隐藏 — 放映时跳过，且不包含在 PDF 导出中","已隱藏 — 放映時略過，且不包含在 PDF 匯出中","Oculta: se omite al presentar y no se incluye en la exportación a PDF","Masquée — ignorée pendant la présentation et absente de l’export PDF","Ausgeblendet — wird beim Präsentieren übersprungen und nicht als PDF exportiert","Nascosta — saltata durante la presentazione ed esclusa dall’esportazione PDF","Oculto — ignorado ao apresentar e excluído da exportação para PDF"],
+  "Appearance": ["外観","外观","外觀","Apariencia","Apparence","Darstellung","Aspetto","Aspeto"],
+  "Match my system": ["システムに合わせる","跟随系统","跟隨系統","Según el sistema","Comme le système","Systemeinstellung folgen","Come il sistema","Acompanhar o sistema"],
+  "Dark": ["ダーク","深色","深色","Oscuro","Sombre","Dunkel","Scuro","Escuro"],
 }

--- a/slides/src/i18n/pt.ts
+++ b/slides/src/i18n/pt.ts
@@ -738,4 +738,7 @@ export const pt: Catalog = {
   "Hide slide": "Ocultar diapositivo",
   "Number hidden slides": "Numerar diapositivos ocultos",
   "Hidden — skipped while presenting and left out of PDF export": "Oculto — ignorado ao apresentar e excluído da exportação para PDF",
+  "Appearance": "Aspeto",
+  "Match my system": "Acompanhar o sistema",
+  "Dark": "Escuro",
 }

--- a/slides/src/i18n/zh-Hans.ts
+++ b/slides/src/i18n/zh-Hans.ts
@@ -740,4 +740,7 @@ export const zhHans: Catalog = {
   "Hide slide": "隐藏幻灯片",
   "Number hidden slides": "为隐藏幻灯片编号",
   "Hidden — skipped while presenting and left out of PDF export": "已隐藏 — 放映时跳过，且不包含在 PDF 导出中",
+  "Appearance": "外观",
+  "Match my system": "跟随系统",
+  "Dark": "深色",
 }

--- a/slides/src/i18n/zh-Hant.ts
+++ b/slides/src/i18n/zh-Hant.ts
@@ -740,4 +740,7 @@ export const zhHant: Catalog = {
   "Hide slide": "隱藏投影片",
   "Number hidden slides": "為隱藏投影片編號",
   "Hidden — skipped while presenting and left out of PDF export": "已隱藏 — 放映時略過，且不包含在 PDF 匯出中",
+  "Appearance": "外觀",
+  "Match my system": "跟隨系統",
+  "Dark": "深色",
 }

--- a/slides/src/main.ts
+++ b/slides/src/main.ts
@@ -6,6 +6,7 @@
 import './styles.css'
 import { anim } from './anim'
 import { configureApp, appConfig } from '../../kernel/src/app.ts'
+import { startTheme } from '../../kernel/src/theme.ts'
 import {
   capturePristine, readEmbeddedDoc, serializeFile, serializeAuto, downloadFile,
   suggestedFileName, parseEnvelope, decryptEnvelope, setEncryptionPassword,
@@ -40,6 +41,18 @@ configureApp({
 registerPreview((doc) => buildSlidePreview(doc as BentoDoc))
 
 capturePristine()
+
+// Theme: after capturePristine, before the first paint.
+//
+// AFTER, because capturePristine clones the LIVE document and saves
+// re-serialize that clone — so `data-theme` and `color-scheme` on <html> must
+// not exist yet, or a viewer's preference would travel inside every file they
+// save. Same rule applyDirection follows two lines below for dir/lang.
+//
+// BEFORE the paint, because applying it later renders the interface light and
+// then flips it, which reads as a bug rather than a preference. Nothing here
+// lays anything out — it sets two attributes on the root element.
+startTheme()
 
 // Chrome direction follows the VIEWER's language (Arabic/Hebrew/… get an RTL
 // interface). Deliberately AFTER capturePristine: saves re-serialize the

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -357,7 +357,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   flex: 1;
   min-width: 0;
   background:
-    radial-gradient(circle at 1px 1px, #d5dbe4 1px, transparent 0) 0 0 / 22px 22px,
+    radial-gradient(circle at 1px 1px, var(--grid-dot) 1px, transparent 0) 0 0 / 22px 22px,
     var(--chrome);
   overflow: hidden;
   position: relative;
@@ -379,7 +379,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   position: relative;
   flex: none;
   margin: auto;
-  box-shadow: 0 10px 40px rgb(20 30 45 / 0.18), 0 2px 8px rgb(20 30 45 / 0.10);
+  box-shadow: var(--slide-shadow);
   border-radius: 2px;
 }
 

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1,6 +1,22 @@
 /* ————— bento/slides chrome ————— */
 
-:root {
+/* THEME TOKENS — chrome only.
+ *
+ * A theme is a VIEWER preference (kernel/src/theme.ts), never document data:
+ * two people opening one file are two readers in two rooms, and a theme in the
+ * document would make a file's bytes depend on who last looked at it.
+ *
+ * THE DOCUMENT DOES NOT INVERT. Dark dims the chrome around the deck. A slide's
+ * background is data the author chose — somebody proofing a deck at midnight
+ * still needs to see what will be projected. So the slide surface, the starter
+ * deck's brand art and anything rendering document content stay OUT of these
+ * blocks; `--slide-shadow` describes the chrome's presentation of the page, not
+ * the page.
+ *
+ * LIGHT — the suite's shared palette, character for character with
+ * type/src/styles.css and spaces/src/styles.css. Do not let these drift.
+ */
+:root, :root[data-theme="light"] {
   --ink: #1e2a3a;
   --ink-2: #31445c;
   --chrome: #f5f7fa;
@@ -10,6 +26,35 @@
   --accent: #f7a600;
   --accent-ink: #7a5200;
   --blue: #5b8def;
+  --field: #ffffff;          /* form-control surface — CHROME, not the slide */
+  --surface: #ffffff;        /* panels, dialogs, menus */
+  --grid-dot: #d5dbe4;       /* the canvas dot grid behind the stage */
+  --chip: rgb(255 255 255 / 0.85);   /* translucent label over a thumbnail */
+  --slide-shadow: 0 10px 40px rgb(20 30 45 / 0.18), 0 2px 8px rgb(20 30 45 / 0.10);
+}
+
+/* DARK — the same roles, not the same values. `--ink` is the chrome's
+   FOREGROUND, so it inverts; `--accent` does not, because it is brand. */
+:root[data-theme="dark"] {
+  --ink: #e7eaf0;
+  --ink-2: #b3bcca;
+  --chrome: #1b1f26;
+  --chrome-2: #262b34;
+  --line: #333a45;
+  --muted: #8b95a4;
+  --accent: #f7a600;
+  --accent-ink: #3a2a00;     /* text ON the accent, so it flips */
+  --blue: #7aa5f5;           /* lifted: #5b8def is unreadable on dark chrome */
+  --field: #12151a;
+  --surface: #21262e;
+  --grid-dot: #2b313b;
+  --chip: rgb(24 28 34 / 0.85);
+  /* deeper: a light slide on a dark canvas needs more separation than the
+     same slide on a light one */
+  --slide-shadow: 0 14px 48px rgb(0 0 0 / 0.55), 0 2px 10px rgb(0 0 0 / 0.4);
+}
+
+:root {
   --radius: 10px;
 }
 
@@ -50,10 +95,10 @@ select, option, input, textarea, [contenteditable='true'] {
    below keeps contrast even under a force-dark engine that ignores both. */
 :root { color-scheme: only light; }
 select, .ed-row input, .ed-row textarea {
-  background: #fff;
-  color: var(--ink-2, #1e2a3a);
+  background: var(--field);
+  color: var(--ink-2);
 }
-option { background: #fff; color: #1e2a3a; }
+option { background: var(--field); color: var(--ink); }
 
 /* ————— THE DOCUMENT NEVER MIRRORS —————————————————————————————————————————
    An Arabic/Hebrew viewer gets an RTL *chrome* (i18n.ts applyDirection sets
@@ -110,7 +155,7 @@ option { background: #fff; color: #1e2a3a; }
      the point: colour to the edge, controls out of the curve. */
   padding: max(8px, env(safe-area-inset-top), var(--tray-safe-top, 0px)) max(14px, env(safe-area-inset-right), var(--tray-safe-right, 0px))
            8px max(14px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
-  background: #fff;
+  background: var(--surface);
   border-bottom: 1px solid var(--line);
   z-index: 20;
 }
@@ -129,7 +174,7 @@ option { background: #fff; color: #1e2a3a; }
   background: transparent;
 }
 .ed-title:hover { border-color: var(--line); }
-.ed-title:focus { border-color: var(--blue); outline: none; background: #fff; }
+.ed-title:focus { border-color: var(--blue); outline: none; background: var(--field); }
 
 /* The file this deck is open AS — quieter than the deck title beside it.
    Shows the BASE name only: every Bento file ends in ".bento.html", so the
@@ -199,7 +244,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   top: calc(100% + 4px);
   inset-inline-start: 0;
   flex-direction: column;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   box-shadow: 0 8px 24px rgb(20 30 45 / 0.14);
@@ -230,7 +275,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  background: #fff;
+  background: var(--surface);
   border-inline-end: 1px solid var(--line);
 }
 
@@ -242,7 +287,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   overflow: hidden;
   cursor: pointer;
   flex: none;
-  background: #fff;
+  background: var(--surface);
 }
 .ed-thumb:hover { border-color: #c9d2de; }
 .ed-thumb.active { border-color: var(--accent); }
@@ -253,8 +298,8 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   z-index: 2;
   font-size: 10px;
   font-weight: 600;
-  color: var(--muted);
-  background: rgb(255 255 255 / 0.85);
+  color: var(--ink-2);
+  background: var(--chip);
   border-radius: 4px;
   padding: 1px 5px;
 }
@@ -266,7 +311,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   gap: 2px;
 }
 .ed-thumb:hover .ed-thumb-tools { display: flex; }
-.ed-thumb-tools .ed-btn { padding: 3px; background: rgb(255 255 255 / 0.9); }
+.ed-thumb-tools .ed-btn { padding: 3px; background: var(--chip); }
 
 .bento-thumb-surface { overflow: hidden; pointer-events: none; }
 
@@ -346,7 +391,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   display: flex;
   align-items: center;
   gap: 2px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 999px;
   padding: 3px 6px;
@@ -378,7 +423,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   display: flex;
   align-items: center;
   gap: 6px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 999px;
   padding: 5px 10px;
@@ -446,7 +491,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   width: var(--panew, 236px);
   flex: none;
   overflow-y: auto;
-  background: #fff;
+  background: var(--surface);
   border-inline-start: 1px solid var(--line);
   padding: 14px;
 }
@@ -478,7 +523,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   padding: 4px 6px;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #fff;
+  background: var(--field);
   color: var(--ink);
 }
 .ed-row input[type='color'] {
@@ -487,7 +532,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   padding: 1px 2px;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #fff;
+  background: var(--field);
 }
 
 .ed-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 10px; }
@@ -561,7 +606,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-about .ed-btn-primary:hover { background: #F07B54; }
 .ed-about .ed-btn:not(.ed-btn-primary) {
   border-color: var(--line);
-  background: #fff;
+  background: var(--surface);
 }
 .ed-about .ed-btn:not(.ed-btn-primary):hover { background: var(--chrome-2); }
 
@@ -581,7 +626,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
      narrower box turned every bullet into two wrapped lines. The calc() keeps
      a real gutter on a 375px phone, where the editor boots panels-collapsed. */
   width: min(440px, calc(100vw - 24px));
-  background: #fff;
+  background: var(--surface);
   border-radius: 14px;
   box-shadow: 0 18px 50px rgb(15 23 36 / 0.3);
   padding: 20px;
@@ -850,7 +895,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 8px;
-  color: var(--ink, #1e2a3a);
+  color: var(--ink);
 }
 .ed-chart-json.ed-invalid { border-color: #c9302c; outline: 1px solid #c9302c; }
 
@@ -865,18 +910,18 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 @media (max-width: 560px) { .ed-help-cols { grid-template-columns: 1fr; } }
 .ed-help-sec h3 {
   font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--muted, #8a94a4); margin: 0 0 6px;
+  color: var(--muted); margin: 0 0 6px;
 }
 .ed-help-row { display: grid; grid-template-columns: 128px 1fr; gap: 12px; align-items: baseline; padding: 3px 0; font-size: 13px; }
 .ed-help-row kbd {
   font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace;
-  background: var(--chrome-2, #f4f1ea); border: 1px solid var(--line, #e7e1d2);
-  border-radius: 5px; padding: 2px 6px; color: var(--ink, #1e2a3a); white-space: nowrap; justify-self: start;
+  background: var(--chrome-2); border: 1px solid var(--line);
+  border-radius: 5px; padding: 2px 6px; color: var(--ink); white-space: nowrap; justify-self: start;
 }
-.ed-help-tips { margin: 4px 0 0; padding-inline-start: 18px; font-size: 13px; line-height: 1.5; color: var(--ink, #26303e); }
+.ed-help-tips { margin: 4px 0 0; padding-inline-start: 18px; font-size: 13px; line-height: 1.5; color: var(--ink); }
 .ed-help-tips li { margin: 3px 0; }
 .ed-help-more { margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line, rgba(30,42,58,0.12)); text-align: center; }
-.ed-help-more a { color: var(--accent, #ED8266); font-weight: 600; font-size: 13px; text-decoration: none; }
+.ed-help-more a { color: var(--accent); font-weight: 600; font-size: 13px; text-decoration: none; }
 .ed-help-more a:hover { text-decoration: underline; }
 
 /* --- live viewer (read-only collaborator) -------------------------------- */
@@ -920,7 +965,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-autosaved {
   font-size: 11px;
   color: #6f8; /* set by theme below */
-  color: var(--muted, #6b7a90);
+  color: var(--muted);
   opacity: 0;
   transition: opacity 0.25s;
   align-self: center;
@@ -937,15 +982,15 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   gap: 10px;
   text-align: start;
   padding: 9px 12px;
-  border: 1px solid var(--line, #e7e1d2);
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: #fff;
+  background: var(--surface);
   cursor: pointer;
   font-size: 13px;
-  color: var(--ink, #1e2a3a);
+  color: var(--ink);
 }
-.ed-version-row:hover { background: var(--chrome-2, #f4f1ea); border-color: #c9d2df; }
-.ed-version-row .vh-tag { font-size: 11px; color: var(--muted, #8a94a4); }
+.ed-version-row:hover { background: var(--chrome-2); border-color: #c9d2df; }
+.ed-version-row .vh-tag { font-size: 11px; color: var(--muted); }
 .ed-version-row .vh-do { font-size: 12px; font-weight: 600; color: #c25a43; }
 
 /* --- visual chart editor -------------------------------------------------- */
@@ -959,7 +1004,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   border: 1px solid rgba(94, 118, 153, 0.25);
   border-radius: 8px;
   font-size: 12px;
-  color: var(--ink, #1e2a3a);
+  color: var(--ink);
 }
 .ed-chart-link span { flex: 1; min-width: 0; }
 .ed-chart-link .ed-btn { padding: 3px 9px; font-size: 12px; }
@@ -978,8 +1023,8 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   border-radius: 6px;
   padding: 0 6px;
   font-size: 12px;
-  background: #fff;
-  color: var(--ink, #1e2a3a);
+  background: var(--field);
+  color: var(--ink);
 }
 .ed-series-row input[type='color'] { flex: 0 0 auto; width: 26px; height: 26px; padding: 0; border: 1px solid var(--line); border-radius: 6px; background: none; }
 .ed-series-row .ed-pie-val { width: 62px; height: 26px; border: 1px solid var(--line); border-radius: 6px; padding: 0 6px; font-size: 12px; }
@@ -1010,8 +1055,8 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   border-radius: 5px;
   padding: 0 5px;
   font-size: 12px;
-  background: #fff;
-  color: var(--ink, #1e2a3a);
+  background: var(--field);
+  color: var(--ink);
 }
 .ed-chart-grid td:first-child input { font-weight: 600; }
 .ed-chart-grid .ed-btn-icon { padding: 2px; color: #9aa4b2; }
@@ -1170,7 +1215,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   position: fixed;
   z-index: 210;
   width: 300px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 12px;
   box-shadow: 0 12px 32px rgb(15 23 36 / 0.18);
@@ -1234,7 +1279,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-layoutpick {
   position: fixed;
   z-index: 200;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 12px;
   box-shadow: 0 12px 32px rgb(15 23 36 / 0.18);
@@ -1324,13 +1369,13 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   height: 2px;
   margin-top: -1px;
   border-radius: 1px;
-  background: #5b8def;
+  background: var(--blue);
 }
 .ed-insertgap-btn {
   position: relative;
   z-index: 1;
   border: none;
-  background: #5b8def;
+  background: var(--blue);
   color: #fff;
   border-radius: 50%;
   width: 16px;
@@ -1667,7 +1712,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
 .ed-share-note {
   font-size: 12px;
   line-height: 1.45;
-  color: var(--muted, #5d6b80);
+  color: var(--muted);
 }
 .ed-share-status {
   font-size: 12.5px;
@@ -1685,10 +1730,10 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
 }
 /* share actions read as BUTTONS at rest, not hover-reveal text */
 .ed-share-btn:not(.ed-btn-primary) {
-  background: var(--chrome, #f2f4f8);
+  background: var(--chrome);
   border: 1px solid var(--line);
 }
-.ed-share-btn:not(.ed-btn-primary):hover { background: var(--chrome-2, #e8ebf1); }
+.ed-share-btn:not(.ed-btn-primary):hover { background: var(--chrome-2); }
 .ed-share-btn { width: 100%; justify-content: flex-start; text-align: start; }
 .ed-share-btn svg { flex: none; }
 
@@ -1707,7 +1752,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   border-end-end-radius: 0;
   border: 1px solid var(--line);
   border-inline-end: none;
-  background: var(--chrome, #f2f4f8);
+  background: var(--chrome);
 }
 .ed-split .ed-dropdown { display: flex; align-items: stretch; }
 .ed-split-caret {
@@ -1719,10 +1764,10 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   border-start-end-radius: 8px;
   border-end-end-radius: 8px;
   border: 1px solid var(--line);
-  background: var(--chrome, #f2f4f8);
+  background: var(--chrome);
   padding: 6px 7px;
 }
-.ed-split .ed-btn:hover { background: var(--chrome-2, #e8ebf1); }
+.ed-split .ed-btn:hover { background: var(--chrome-2); }
 .ed-caret { font-size: 10px; line-height: 1; }
 
 /* quiet divider between share actions and advanced session controls */
@@ -1745,7 +1790,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
 .ed-present-pill {
   display: inline-flex;
   align-items: stretch;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--line);
   border-radius: 999px;
   box-shadow: 0 4px 14px rgb(20 30 45 / 0.10);
@@ -1830,7 +1875,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   padding-block: 6px;
   padding-inline: 7px 10px;
 }
-.ed-present-pill .ed-btn:hover { background: var(--chrome, #f2f4f8); }
+.ed-present-pill .ed-btn:hover { background: var(--chrome); }
 /* its menu drops UP (the pill sits at the bottom edge) */
 .ed-present-pill .ed-menu { top: auto; bottom: calc(100% + 6px); inset-inline-start: auto; inset-inline-end: 0; }
 
@@ -1841,7 +1886,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   gap: 7px;
   padding: 4px 6px;
   border-radius: 7px;
-  background: var(--chrome, #f2f4f8);
+  background: var(--chrome);
   font-size: 12.5px;
 }
 .ed-share-me .who { font-weight: 600; }
@@ -1868,7 +1913,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   flex: none;
 }
 .ed-share-peer .who { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ed-share-peer .where { color: var(--muted, #5d6b80); font-size: 11.5px; flex: none; }
+.ed-share-peer .where { color: var(--muted); font-size: 11.5px; flex: none; }
 .ed-share-peer .kick {
   flex: none;
   width: 18px;
@@ -1924,7 +1969,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   padding: 5px 8px;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #fff;
+  background: var(--field);
 }
 
 /* collaborate popover: your-name field */
@@ -1933,13 +1978,13 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: var(--muted, #5d6b80);
+  color: var(--muted);
 }
 .ed-share-name input {
   flex: 1;
   min-width: 0;
   padding: 5px 8px;
-  border: 1px solid var(--line, #d5dbe4);
+  border: 1px solid var(--line);
   border-radius: 6px;
   font: inherit;
   font-size: 12.5px;
@@ -1998,7 +2043,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
     bottom: 0;
     z-index: 40;
     box-shadow: 0 0 40px rgb(15 23 36 / 0.18);
-    background: var(--chrome, #fff);
+    background: var(--chrome);
   }
   .ed-sidebar { left: 0; }
   .ed-props { right: 0; }
@@ -2040,7 +2085,7 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   height: 44px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #fff;
+  background: var(--surface);
   color: #5d6b80;
   font-size: 11px;
   line-height: 1;
@@ -2188,7 +2233,7 @@ dialog.ed-pwdialog .ed-pwerr { color: #C33; }
   padding: 8px 16px;
   border-radius: 999px;
   border: 1px solid #ccd;
-  background: #fff;
+  background: var(--surface);
   font-weight: 600;
   cursor: pointer;
 }


### PR DESCRIPTION
The mechanism came from `bento/type` via a handoff; this is the slides half. `kernel/src/theme.ts` arrives with it — it was untracked — and is unchanged.

## Three rules, each load-bearing

**A theme is a viewer preference**, in localStorage, never document data — the rule locale and reduced motion already follow. Two people opening one file are two readers in two rooms, and a theme in the document would make a file's bytes depend on who last looked at it.

**The document does not invert.** Dark dims the chrome *around* the deck. The slide stays as authored, because its background is the author's data and someone proofing at midnight still needs to see what will be projected. The presenter window stays dark in both themes — you present in a dark room.

**`startTheme()` runs after `capturePristine`, before the first paint.** After, because `capturePristine` clones the live document and saves re-serialize that clone — otherwise `data-theme` ships inside every file a reader saves. Before the paint, or the interface renders light and flips.

## It needed far less than 206 edits

The token block already matched the suite, so dark is additive plus five roles that had been literals. Converted: **24** `var(--tok, #literal)` fallbacks (a light value that would have painted light ink on dark chrome had it ever fired), **22** white chrome surfaces, and the drift cases that already had tokens.

## Measured, because every failure here is invisible in light

| | before | after |
|---|---|---|
| panel select / input | **1.21** | 15.18 |
| row label, topbar button | **1.92** | 7.94 |
| thumbnail number | **3.03** | 8.93 |
| worst overall — dark | — | **5.02** |
| worst overall — light | — | **5.98** |

WCAG AA is 4.5. Everything below it *looked perfect* in the light theme.

## The gate is the part that lasts

`scripts/test-slides-theme.mjs` pins that both themes define the same roles, that no document token is themed, that no chrome surface is pinned to white, that the light palette hasn't forked from spaces and type, and that `startTheme` still runs after `capturePristine`.

It found **three white surfaces I'd missed** — including a translucent chip (`rgb(255 255 255 / 0.85)`) that my `#fff` grep never matched, which is exactly how the thumbnail number ended up at 3.03. Deliberate exceptions (presenter window, splash art, print, comment pins, the password gate) are listed **with reasons** rather than silently tolerated.

Both failure modes verified to actually fail the gate before being fixed.

## Verified in real Chrome

Auto follows the OS; the picker persists and reverts; the deck renders identically in both themes.

Test build: `~/Desktop/Bento_Slides_TEST_themes.bento.html`