### PR TITLE
The ⋯ menu is no longer trapped under the panel drawers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,6 +594,15 @@ names provisional.
    svg on the page (CSS animations with fill modes even beat later static rules).
 8. Tiny text labels make unusable click targets when scaled down — interactive
    controls get padded transparent `link` overlay rects, not links on the text itself.
+9. **`.ed-topbar`'s z-index is a CEILING, not just an order.** The bar is a flex
+   item of `.ed-root`, and a flex item honours z-index even at
+   `position: static` — so the value opens a stacking context that caps every
+   descendant. At 20 the ⋯ menu's own `z-index: 50` was clamped to 20 and the
+   phone-mode panel drawers (z 40) painted straight over it: the menu rendered
+   in full, and every click landed on the panel behind it. Raising the MENU can
+   never fix this; only the ceiling moves. Same trap for any future chrome that
+   must escape the bar. Diagnose with `document.elementsFromPoint()` — the menu
+   sat fourth in the stack under its own coordinates.
 
 - **Compressed shell (Phase 1)**: `scripts/postbuild-compress.mjs` (runs in
   build:single) deflates runtime JS+CSS into base64 `bento/deflate-b64` script

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -112,7 +112,16 @@ option { background: #fff; color: #1e2a3a; }
            8px max(14px, env(safe-area-inset-left), var(--tray-safe-left, 0px));
   background: #fff;
   border-bottom: 1px solid var(--line);
-  z-index: 20;
+  /* Above the phone-mode panel drawers (z 40), and this number is doing more
+     work than it looks. The bar is a FLEX ITEM of .ed-root, and a flex item
+     honours z-index even at position:static — so this value does not merely
+     order the bar, it opens a STACKING CONTEXT that caps everything inside it.
+     At 20 the ⋯ menu's own z-index: 50 was capped at 20 and the drawers at 40
+     painted straight over it: on a narrow window with the properties panel
+     open, the menu rendered in full and every click landed on the panel behind
+     it. Raising its own z-index could never have fixed that — only the ceiling
+     moves. Keep this above the drawers and below the dialogs/toasts (59+). */
+  z-index: 50;
 }
 
 .ed-logo { display: flex; align-items: center; gap: 7px; font-size: 15px; white-space: nowrap; }


### PR DESCRIPTION
On a narrow window with the properties panel open, the ⋯ menu rendered in full but every click landed on the panel behind it — reported alongside the topbar-overflow bug.

## Cause

`.ed-topbar` is a **flex item** of `.ed-root`, and a flex item honours `z-index` even at `position: static`. So `z-index: 20` was not merely ordering the bar — it opened a **stacking context that caps every descendant at 20**. The ⋯ menu's own `z-index: 50` was clamped to 20, and the phone-mode panel drawers (`z-index: 40`, styles.css:1999) painted over it.

Raising the menu's z-index can never fix this — only the ceiling moves. Confirmed: setting the menu to `z-index: 9999 !important` changed nothing; lowering the *panel* did.

## Measurement

`elementsFromPoint()` at the menu's own centre, panel open, identical geometry (menu 454–654, panel 424–660) on both builds at a 660px viewport:

| build | topbar z | top element at menu centre | menu clickable |
|---|---|---|---|
| before | 20 | `.ed-props` | **false** |
| after | 50 | a menu item | **true** |

## Why 50

Above the drawers (40), below the present-overlay layers and dialogs (59+), which the bar never competes with. The bar and the drawers do not overlap geometrically, so nothing else changes visually.

Also adds the trap to CLAUDE.md's hard-won list — it is invisible at desktop widths and the obvious fix is the wrong one.