### PR TITLE
Prepare 1.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.17] — 2026-08-10
+
 - **Security: update this file. A deck could run code hidden in its own
   content.** Ordinary-looking document content — an image, a shape, an embedded
   drawing — could carry script that ran when the slide was drawn, or quietly
@@ -49,19 +51,18 @@ pre-1.0.
   undone by a file update, so it ships separately once its own regression is
   resolved.
 
-- **A deck that is being shared now says so before an agent reads it.** A file
-  with live collaboration switched on carries the keys to its own session —
-  that is what makes sharing work without accounts, and it means anything
-  receiving the file receives the room: a chat, a ticket, an agent harness.
-  Nothing about a document looks like a credential, so this was easy to do by
-  accident.
+- **A dark interface, if you want one.** *About → Appearance* offers Match my
+  system, Light or Dark. It follows your machine by default and changes as your
+  machine does, so a laptop that dims at sunset takes the editor with it.
 
-  The agent guide and the packaged skill now open by checking for it and
-  saying so, and `window.bento.validate()` reports it as
-  `collab-secrets-present` — only when private key material is actually there,
-  so a read-only copy stays quiet. Removing the keys afterwards does not
-  retract them; if a shared deck has already gone somewhere, *Share → Rotate
-  keys* is the remedy.
+  **Your deck does not invert.** Dark dims the chrome around the slide; the
+  slide itself stays exactly as authored, because its background is your data
+  and someone proofing at midnight still needs to see what will be projected.
+  The presenter window stays dark in both themes — you present in a dark room.
+
+  The theme is a viewer preference, stored on your machine and never written
+  into the file, so it never travels to whoever you send a deck to. Same rule
+  the interface language and reduced motion already follow.
 
 - **Hide a slide from the show.** Toggle *Hide slide* in the Slide panel and it
   stays in the deck, fully editable, but drops out of the walk: arrow keys pass
@@ -80,6 +81,20 @@ pre-1.0.
   struck through, or replaced by a dash when it has none — because a slide you
   have forgotten you hid is a slide you find out about mid-presentation.
 
+- **A deck that is being shared now says so before an agent reads it.** A file
+  with live collaboration switched on carries the keys to its own session —
+  that is what makes sharing work without accounts, and it means anything
+  receiving the file receives the room: a chat, a ticket, an agent harness.
+  Nothing about a document looks like a credential, so this was easy to do by
+  accident.
+
+  The agent guide and the packaged skill now open by checking for it and
+  saying so, and `window.bento.validate()` reports it as
+  `collab-secrets-present` — only when private key material is actually there,
+  so a read-only copy stays quiet. Removing the keys afterwards does not
+  retract them; if a shared deck has already gone somewhere, *Share → Rotate
+  keys* is the remedy.
+
 - **Fix: a live session could crash when two people created the same element at
   the same moment.** Sharing an element id across slides is the morph idiom —
   it is what id continuity is *for* — so two collaborators inserting one
@@ -91,24 +106,6 @@ pre-1.0.
   around a value that can legitimately be absent — and it is now pinned by a
   test with a deterministic trigger rather than left to a random rig's depth.
 
-- **Fix: choosing a custom slide size now reveals its width and height.** The
-  page-size picker rebuilt the properties panel before recording any custom
-  state, so a preset-sized deck immediately snapped back to its preset and the
-  two inputs never appeared. Custom mode now reveals the existing controls
-  without changing the document until a dimension is actually edited.
-
-- **A dark interface, if you want one.** *About → Appearance* offers Match my
-  system, Light or Dark. It follows your machine by default and changes as your
-  machine does, so a laptop that dims at sunset takes the editor with it.
-
-  **Your deck does not invert.** Dark dims the chrome around the slide; the
-  slide itself stays exactly as authored, because its background is your data
-  and someone proofing at midnight still needs to see what will be projected.
-  The presenter window stays dark in both themes — you present in a dark room.
-
-  The theme is a viewer preference, stored on your machine and never written
-  into the file, so it never travels to whoever you send a deck to. Same rule
-  the interface language and reduced motion already follow.
 - **Fix: the end of the toolbar could be cut off the right edge.** Between
   roughly 1200 and 1250 pixels wide, the buttons on the right ran past the
   window while their labels were still showing — the bar collapsed to icons at
@@ -124,6 +121,12 @@ pre-1.0.
   layer, and that layer was ranked below the panel — so nothing the menu itself
   could do would bring it forward. The toolbar now sits above the panels, where
   a menu that escapes it belongs.
+
+- **Fix: choosing a custom slide size now reveals its width and height.** The
+  page-size picker rebuilt the properties panel before recording any custom
+  state, so a preset-sized deck immediately snapped back to its preset and the
+  two inputs never appeared. Custom mode now reveals the existing controls
+  without changing the document until a dimension is actually edited.
 
 - **Fix: the toolbar keeps its height as you resize the window.** Narrowing
   past 760px used to shave 4px off it and then, below 700px, add 14px back for

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version stamp and release-note ordering for 1.0.17.

## Version

`slides/package.json` 1.0.16 → 1.0.17 (single source of truth for `APP_VERSION` and the manifest version), and `## [Unreleased]` → `## [1.0.17] — 2026-08-10` with a fresh empty Unreleased header kept above it, matching the shape at every previous tag.

## Note ordering

The first **six** bold lead-ins become the `notes` inside the signed manifest — all a reader sees in the About dialog while deciding whether to update — and re-signing a version is refused by the monotonicity check. So this is the one artifact with no way back.

They were sitting in merge order, which RELEASING warns against: two minor fixes outranked the headline feature and "dark interface" fell 6th. Now:

| # | signed note |
|---|---|
| 1 | Security: update this file. A deck could run code hidden in its own content. |
| 2 | A dark interface, if you want one. |
| 3 | Hide a slide from the show. |
| 4 | A deck that is being shared now says so before an agent reads it. |
| 5 | Fix: a live session could crash when two people created the same element at the same moment. |
| 6 | Fix: the end of the toolbar could be cut off the right edge. |

Security first because it is why the release exists, then the two features, then the security-adjacent change, then the crash, then the most visible UI fix. The custom-slide-size fix, the ⋯ menu fix and the toolbar-height fix drop below the fold.

## Checks

- `release.mjs --app slides --print-notes` reports **v1.0.17** with exactly those six.
- The reorder is a verified **pure permutation** — every non-blank line of the section preserved exactly, only order and headers changed. Done with a script that refuses to write if the block set changes, rather than by hand.
- `test-release-apps.mjs` 40/40, build + splice conformance gate clean.

## Every entry describes a bug that actually shipped

RELEASING says to drop entries for bugs introduced *and* fixed inside the same cycle, since announcing them tells people about breakage they never had. Checked against tag `v1.0.16`:

| entry | evidence it shipped |
|---|---|
| toolbar cut off | `max-width: 1200px` breakpoint present at the tag |
| ⋯ menu unclickable | `.ed-topbar { z-index: 20 }` present at the tag |
| toolbar height | tighter vertical padding present at the tag |
| custom slide size | custom page-size UI present at the tag |
| live-session crash | the buggy `dbg()` line present at `v1.0.16:slides/src/sync/crdt.ts:862`; tag 2026-08-03, fix (#249) 2026-08-06 |

So none are drop candidates.