### PR TITLE
A demoted widget's popover opens inside the ⋯ menu, not through it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,6 +603,19 @@ names provisional.
    never fix this; only the ceiling moves. Same trap for any future chrome that
    must escape the bar. Diagnose with `document.elementsFromPoint()` — the menu
    sat fourth in the stack under its own coordinates.
+10. **`overflow-y: auto` also clips HORIZONTALLY.** There is no such thing as
+   scrolling one axis while the other still overflows visibly: set either axis
+   to a non-`visible` value and the browser computes the other to `auto`. So
+   the moment `.ed-topbar.ed-bar-fold .ed-menu` gained `max-height` +
+   `overflow-y: auto` (so a long ⋯ menu could scroll), that menu became a
+   CLIPPING BOX for everything positioned inside it. Phone chrome demotes whole
+   dropdown widgets (Share, Language) into ⋯, and `.ed-share-pop` is a 250px
+   popover anchored to its parent's end — inside the 200px menu it hung 55px
+   off the left and 69px below, both silently cut, and the properties panel
+   underneath showed through the gap so the popover looked interleaved with it.
+   A floating child can never escape a scroll container: inside ⋯ these render
+   `position: static`, as a section of the list. Anything else demoted into a
+   menu must do the same.
 
 - **Compressed shell (Phase 1)**: `scripts/postbuild-compress.mjs` (runs in
   build:single) deflates runtime JS+CSS into base64 `bento/deflate-b64` script

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2068,6 +2068,34 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
+/* A demoted widget's own popover opens INLINE, inside the ⋯ list.
+   The rule above bounds the height of a menu that can outgrow the screen, and
+   `overflow-y: auto` cannot be had on its own — a browser computes
+   `overflow-x` to `auto` too, so that menu silently became a CLIPPING box for
+   anything positioned inside it. Share is the case that showed it: phone
+   chrome demotes the whole dropdown into ⋯, and `.ed-share-pop` is a 250px
+   popover anchored to its parent's end, so inside a 200px menu it hung 55px
+   off the left edge and 69px below the bottom. Both overhangs were cut away,
+   and since the properties panel sits under exactly that strip, the panel
+   showed THROUGH the gap — the popover looked interleaved with the panel
+   behind it.
+   A floating child cannot escape a scroll container, so it stops floating:
+   inside ⋯ these render as a section of the list, scrolling with it and
+   taking its width. Nothing can be clipped because nothing overhangs. */
+.ed-topbar.ed-bar-fold .ed-menu .ed-menu {
+  position: static;
+  min-width: 0;
+  max-width: none;
+  max-height: none;
+  overflow: visible;
+  box-shadow: none;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  border-block: 1px solid var(--line);
+  margin-block: 3px;
+  padding-inline: 6px;
+}
 
 /* --- phones proper: viewport-scoped chrome that is about TOUCH and small
    screens, not about whether the bar fits, so it stays a media query */


### PR DESCRIPTION
Reported against 1.0.17: opening **Share** from ⋯ on a narrow window with the properties panel open draws the popover interleaved with the panel — rows cut off down their left edge, panel labels showing through the gap.

Not a stacking bug this time (that was #286). This one is clipping.

## Cause

`.ed-topbar.ed-bar-fold .ed-menu` carries `max-height` + `overflow-y: auto` so a ⋯ menu that can outgrow the screen scrolls — correct, and well argued in the comment above it.

But **`overflow-y: auto` cannot be had on its own.** Set either axis to a non-`visible` value and the browser computes the other to `auto`. So that menu quietly became a *clipping box* for everything positioned inside it.

Phone chrome demotes whole dropdown widgets (Share, Language) into ⋯, and `.ed-share-pop` is a 250px popover anchored to its parent's end (`inset-inline-end: 0`). Inside the 200px menu it hangs off both edges. Measured at a 660px viewport:

| | rect |
|---|---|
| ⋯ menu | 454–654 × 54–650 |
| Share popover | **399**–649 × 239–**719** |
| properties panel | 424–660 |

55px off the left, 69px below the bottom — both clipped away. The properties panel sits under exactly that strip, which is why the panel showed *through* where the popover had been cut.

## Fix

A floating child can never escape a scroll container, so it stops floating. Inside ⋯, a nested menu renders `position: static` — a section of the list, taking its width and scrolling with it. Nothing overhangs, so nothing can be clipped, and it works the same on a phone where a 250px popover had nowhere to go anyway.

## Verified

At the same 660px viewport:

| | before | after |
|---|---|---|
| Share popover | 399–649, hanging 55px past the menu | 443–649, inside menu 438–654 |
| Share rows escaping the menu | left column cut | **0 of 7** |
| Language rows escaping | — | **0 of 10** |
| popover position | `absolute` | `static`, in the scroll flow |

Desktop unaffected — at 1400px the fold class is absent, so the popover is still `absolute`, `min-width: 250px`, shadowed, and fully on screen. Screenshot of the fixed narrow layout shows Share expanding cleanly as a section of the ⋯ list.

Adds the `overflow-y` trap to CLAUDE.md's hard-won list — it is invisible at desktop widths and the obvious reading of the CSS is wrong.

Not for 1.0.17 (already released); this is for the next one.