### PR TITLE
slides: restore mobile Save button outline and fix dark toast text contrast

### DIFF
--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -765,7 +765,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   left: 50%;
   bottom: 26px;
   transform: translate(-50%, 12px);
-  background: var(--ink);
+  background: #1e2a3a;
   color: #fff;
   font-size: 13px;
   padding: 9px 16px;
@@ -776,9 +776,8 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   pointer-events: none;
 }
 :root[data-theme="dark"] .ed-toast {
-  background: var(--chrome-2);
-  color: var(--ink);
-  border: 1px solid var(--line);
+  background: #fff;
+  color: #1e2a3a;
 }
 .ed-toast.show { opacity: 1; transform: translate(-50%, 0); }
 

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -775,6 +775,11 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   z-index: 2000;
   pointer-events: none;
 }
+:root[data-theme="dark"] .ed-toast {
+  background: var(--chrome-2);
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
 .ed-toast.show { opacity: 1; transform: translate(-50%, 0); }
 
 /* ————— present overlay ————— */
@@ -2052,6 +2057,11 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
    set of buttons and is the least-used half. The list it opens is not lost —
    editor.ts appends it to the bottom of ⋯ while the fold is on. */
 .ed-topbar.ed-bar-fold .ed-split-caret { display: none; }
+.ed-topbar.ed-bar-fold .ed-split > .ed-btn:first-child {
+  border-start-end-radius: 8px;
+  border-end-end-radius: 8px;
+  border-inline-end: 1px solid var(--line);
+}
 /* ⋯ carries the demoted buttons AND that list, so it can outgrow the
    screen in BOTH directions.
    Down: without a bound it runs off the bottom, and a dropdown is absolutely

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -766,7 +766,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   bottom: 26px;
   transform: translate(-50%, 12px);
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
   font-size: 13px;
   padding: 9px 16px;
   border-radius: 999px;
@@ -774,11 +774,6 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   transition: all 0.25s ease;
   z-index: 2000;
   pointer-events: none;
-}
-:root[data-theme="dark"] .ed-toast {
-  background: var(--chrome-2);
-  color: var(--ink);
-  border: 1px solid var(--line);
 }
 .ed-toast.show { opacity: 1; transform: translate(-50%, 0); }
 

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -241,7 +241,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .ed-btn-primary {
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
   padding: 6px 14px;
 }
 .ed-btn-primary:hover { background: var(--ink-2); }
@@ -461,7 +461,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-setchip:hover { background: var(--chrome-2); }
 .ed-setchip.active {
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
 }
 
 /* ————— slide surface (shared by canvas, thumbs, present) ————— */


### PR DESCRIPTION
## What & why

This PR fixes four small editor UI issues:

1. **Mobile Save button outline**

   Below 700px, the save-as dropdown caret element is hidden, but Save retained the styling making it still look like the left half of a split button. This PR restores the missing right border and corner radii so Save renders as a complete button.

2. **Toast text contrast**

   In dark mode, toast backgrounds switch through the theme while their fixed white text did not. Toast text now uses `var(--surface)` so it remains readable in both themes.

3. **Primary button text contrast**

   `.ed-btn-primary` uses `var(--ink)` as its background. Since `--ink` changes from dark in light mode to light in dark mode, a fixed white text color becomes unreadable in dark mode. Its text now uses `var(--surface)`.

4. **Active set-chip text contrast**

   `.ed-setchip.active` has the same inverted theme treatment and the same fixed-white-text issue. Its text now also uses `var(--surface)`.

## UI comparisons

### Mobile Save button

<img width="900" height="585" alt="Mobile Save button outline before and after" src="https://github.com/user-attachments/assets/b761cd1e-b0d6-4d2e-8169-ef9da3988dd1" />

### Toast

<img width="780" height="366" alt="Dark-mode toast text contrast before and after" src="https://github.com/user-attachments/assets/503012f3-bbdd-4612-a7ce-5e627382e391" />

### Primary Share action

<img width="484" height="366" alt="primary-share-action-text-contrast-in-dark-theme" src="https://github.com/user-attachments/assets/308fac1b-2332-4497-bd51-555aeb06f251" />

### Active hover-set chip

<img width="2564" height="366" alt="active-hover-set-chip-in-the-real-editor-on-dark-theme" src="https://github.com/user-attachments/assets/1c96e7dc-a6d9-4713-8915-9a5b2a81f3a1" />

## Verification

- Typecheck passed
- `npm run build:single` passed
- Browser-tested the folded topbar at 390px
- Browser-tested the toast in light and dark modes
- Browser-tested the primary Share action in dark mode
- Browser-tested the active hover-set chip in dark mode

## Checklist

- [x] Read the relevant repository guidance before making changes
- [x] `npm run build:single` succeeds from `slides/`
- [x] No sync code was changed
- [x] No new UI strings were added
- [x] No document-format changes were made
- [x] Did not bump the version or cut a release