### PR TITLE
The update card loses its accent stripe

### DIFF
--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -714,8 +714,14 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   flex-direction: column;
   gap: 8px;
   padding: 11px 13px;
+  /* An even 1px rule, like every other surface in this dialog. The card used
+     to carry a 3px peach stripe down its leading edge — the generic
+     "callout" tic, and the only accent stripe anywhere in the app (the two
+     other thick borders are a CSS triangle and a quiet neutral rule on
+     .ed-lang-warn). It was redundant as well as out of place: the heading
+     names the version and the primary button already carries the accent. It
+     was also a hard-coded #FF9E8A, so it ignored the theme tokens. */
   border: 1px solid var(--line);
-  border-inline-start: 3px solid #FF9E8A;
   border-radius: 10px;
 }
 .ed-about-release {


### PR DESCRIPTION
The "Version X is available" card in the About dialog carried a 3px peach rule down its leading edge (`styles.css:718`, `border-inline-start: 3px solid #FF9E8A`).

It reads as the generic coloured-callout tic, and it is **the only accent stripe anywhere in the app** — the only other thick borders in the stylesheet are a CSS triangle (a disclosure arrow) and a quiet 2px neutral rule on `.ed-lang-warn`. So it was not part of the design language.

It was redundant as well as out of place: the card already announces itself with a heading naming the version and a primary button carrying the accent. The stripe was a third emphasis on a card nobody could miss.

And being a hard-coded hex, it ignored the theme tokens — it stayed peach in dark mode while everything around it moved.

## After

An even 1px `var(--line)` like every other surface in the dialog, and it themes with them:

| theme | border colour | uniform on all sides |
|---|---|---|
| light | `rgb(227, 232, 239)` | yes |
| dark | `rgb(51, 58, 69)` | yes |

Verified by rendering the real card markup inside the About dialog in a built shell and reading computed styles in both themes. The peach now appears only on the "Update this file…" button.

For the next release — 1.0.17 is already out.