### PR TITLE
The offline policy covers every app by discovering them

### DIFF
--- a/scripts/test-offline.ts
+++ b/scripts/test-offline.ts
@@ -93,12 +93,38 @@ function walk(dir: string, out: string[] = []): string[] {
   return out
 }
 
-const sources = ['kernel/src', 'slides/src', 'dash/src', 'spaces/src']
-  .flatMap((d) => walk(join(root, d)))
+/**
+ * Every app, DISCOVERED rather than listed. A hand-written list is the same
+ * hazard as a hand-written call-site audit, one level up: the app that is
+ * missing from it is exempt from the policy, and nothing says so. bento/type
+ * was about to arrive as a fourth app with a model, an editor and a sync
+ * binding, and it would have been silently outside this scan — which matters
+ * most for exactly that app, because fetching a font or a remote image is an
+ * obvious feature for a word processor and neither reads as "networking" when
+ * you write it.
+ *
+ * So: any top-level directory with a src/ is in scope, and a new app joins the
+ * policy by existing.
+ */
+const APP_DIRS = readdirSync(root)
+  .filter((d) => !d.startsWith('.') && d !== 'node_modules')
+  .filter((d) => { try { return statSync(join(root, d, 'src')).isDirectory() } catch { return false } })
+  .sort()
+
+const sources = APP_DIRS
+  .flatMap((d) => walk(join(root, d, 'src')))
   .map((p) => relative(root, p))
   .filter((p) => p !== CHOKEPOINT)
 
-ok(sources.length > 50, `the policy scan actually found sources to scan (${sources.length} files)`)
+ok(sources.length > 50, `the policy scan actually found sources to scan (${sources.length} files in ${APP_DIRS.length} apps: ${APP_DIRS.join(', ')})`)
+// Discovery that silently finds nothing is the failure this rig exists to
+// prevent, one level up — a green run over an empty list looks identical to a
+// green run over the whole repo.
+for (const known of ['kernel', 'slides']) {
+  ok(APP_DIRS.includes(known), `discovery found the ${known} sources — it has not silently stopped matching`)
+}
+ok(!APP_DIRS.includes('docs') && !APP_DIRS.includes('scripts'),
+  'discovery does not sweep in directories that are not apps')
 
 const offenders: string[] = []
 for (const rel of sources) {


### PR DESCRIPTION
Follow-up to #305, raised by the bento/type session while checking the rig's scan scope against its kernel lift.

## The gap

`scripts/test-offline.ts` had a hand-written scan list:

```
const sources = ['kernel/src', 'slides/src', 'dash/src', 'spaces/src']
```

That is the same hazard as a hand-written call-site audit, one level up: **the app missing from the list is exempt from the policy, and nothing says so.**

`bento/type` is arriving as a fourth app — model, store, editor, pagination, redlining, signing, and now a sync binding to the kernel session — and it would have landed silently outside the scan. It matters most for that app in particular: fetching a font or a remote image is an obvious feature for a word processor, and neither reads as "networking" when you write it.

It is clean today (zero primitives in `type/src`), which is the argument for fixing it now rather than after the first violation, at which point nothing would report it.

## The fix

Any top-level directory with a `src/` is in scope, so a new app joins the policy **by existing** rather than by someone remembering.

Discovery has its own failure mode, and it is the one this whole rig exists to prevent one level up: a green run over an empty list is indistinguishable from a green run over the repo. So it now asserts that discovery still finds the known apps, and that it does not sweep in directories that are not apps.

## Result

```
ok  the policy scan actually found sources to scan (138 files in 4 apps: dash, kernel, slides, spaces)
ok  discovery found the kernel sources — it has not silently stopped matching
ok  discovery found the slides sources — it has not silently stopped matching
ok  discovery does not sweep in directories that are not apps

33/33 checks passed
```

Cannot fail the build today and cannot conflict — one file, and `type/src` is not yet on main, so the change is purely forward-looking.
