### PR TITLE
Release 1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.18] — 2026-08-15
+
 - **Security: offline mode did not block everything it promised.** The switch
   says "nothing leaves this computer", and five things still went out with it
   on: a manual *Check for updates* called the release server, *Manage

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump and changelog date for 1.0.18. No code.

**Security release.** Offline mode did not block everything it promised (GHSA-5c3x-xqp6-g94r, fixed in #305), and one of the leaking paths is the update check itself — so users on 1.0.17 with the switch on cannot reach the fix without doing the thing they turned it on to prevent.

Signed notes verified with `--print-notes` before tagging:

```
• Security: offline mode did not block everything it promised.
• Updating a file no longer interrupts you.
• Fix: Share opened cut in half on a narrow window.
• The update card drops its peach stripe.
• Security: update this file. A deck could run code hidden in its own content.  (1.0.17)
• A dark interface, if you want one.  (1.0.17)
```

The four 1.0.18 lead-ins lead; the two 1.0.17 entries follow so anyone who skipped a release still sees what they missed.

Gates green on this tree: splice conformance, offline 33/33, preview 28/28, layouts 9/9, i18n current and complete.