### PR TITLE
Clamp fraction digits so formatValue keeps its never-throws contract

### DIFF
--- a/dash/src/format.ts
+++ b/dash/src/format.ts
@@ -62,7 +62,10 @@ export function formatValue(v: unknown, col: Pick<Column, 'type' | 'format'>): s
   const p = readPattern(col.format)
   const isPct = p.pct || t === 'percent'
   const shown = isPct ? n * 100 : n
-  const dp = p.dp ?? (t === 'money' ? 2 : isPct ? 0 : shown % 1 === 0 ? 0 : 2)
+  // Intl.NumberFormat throws for more than 100 fraction digits, so a format
+  // string like "0.000…" (long enough) would break the never-throws contract.
+  const rawDp = p.dp ?? (t === 'money' ? 2 : isPct ? 0 : shown % 1 === 0 ? 0 : 2)
+  const dp = Math.max(0, Math.min(100, rawDp))
 
   // Intl does the punctuation, so the VIEWER's separators apply to the
   // AUTHOR's precision — the split this file exists to make.


### PR DESCRIPTION
`formatValue` is documented "Never mutates, never throws", but it throws a `RangeError` on a format string with a long fractional part:

```js
formatValue(1234.5, { type: "number", format: "0." + "0".repeat(101) })
// RangeError: minimumFractionDigits value is out of range.
```

`readPattern` takes the decimal count straight from the pattern, so `0.` followed by enough zeros yields a fraction-digit count above 100, and `Intl.NumberFormat` rejects anything over 100. Since `format` is document data and this runs for every cell, one pathological pattern crashes the render. I clamp the count into Intl's accepted range; valid patterns (`#,##0.00`, `0.0%`, etc.) are unchanged.
