### PR TITLE
spaces: the topbar fits itself by measuring, not by px breakpoints

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -14,6 +14,44 @@ Decision. Why. Pointers.
 
 ---
 
+## 2026-08-18 — The spaces topbar fits itself by measuring, not by px breakpoints
+
+The bar folded at 820px and again at 600px. Those numbers moved once already
+(720 → 820, because at 768 the save caret still ended 27px off the screen) and
+they would have moved again, because a px guess cannot answer the question
+being asked. The same buttons need different room at the same viewport width
+depending on browser zoom, OS text scaling, live content, and — this is the one
+that matters here — the reader's language.
+
+MEASURED on the shipped shell at a 1600px viewport: the control group is 568px
+in English and 618px in German. Fifty pixels the 820 threshold was never
+calibrated for, in a file that ships eight catalogs so that any reader can open
+it in their own language. The English-calibrated breakpoint was the only
+calibration there was.
+
+Three tiers now, applied by `fitTopbar()` stepping down while the bar still
+overflows its own box: `sp-bar-compact` drops the button words, `sp-bar-tight`
+drops the wordmark, `sp-bar-fold` moves whole controls into ⋯. A ResizeObserver
+is the primary signal; a MutationObserver catches the content that changes
+width at a fixed viewport (the people count arriving when somebody joins a
+session). The observer must NOT watch `class` — fitTopbar's own tier flips are
+class changes on that element.
+
+THE SECOND COPY OF THE NUMBER IS GONE, which is the real win. `isPhone()` was
+`matchMedia('(max-width: 600px)')` with a comment saying the number was
+duplicated from the stylesheet on purpose; it decided what the ⋯ menu carried,
+and when it disagreed with the CSS the symptom was a menu offering Undo while
+Undo sat in the bar two centimetres away. It is `isFolded()` now and it reads
+the tier off the bar — there is nothing left to disagree with.
+
+The drawer breakpoint STAYS a media query (820px). Whether the page list is a
+column or an overlay is a layout mode, not a question about whether things fit,
+and slides keeps its own for the same reason.
+
+Follows bento/slides #239, which settled this first.
+
+---
+
 ## 2026-08-18 — Presence in a space is a page, shown in the tree
 
 bento/slides paints collaborator cursors on its canvas, because a deck IS a

--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -387,36 +387,71 @@ for (const [label, input, err] of [
   ok(/secondary\.map\(/.test(ed), '…the inline row is built from that list')
   ok(/for \(const a of secondary\)/.test(ed), '…and the ⋯ menu is built from the SAME list')
 
-  // Which TIER a rule lives in is the thing worth pinning: the numbers moved
-  // once already (720 → 820) because at 768 the save caret still ended 27px off
-  // the screen, and they will move again.
-  const tierOf = (sel: RegExp): number => {
-    const i = css.search(sel)
-    if (i < 0) return -1
-    const opener = [...css.slice(0, i).matchAll(/@media \(max-width: (\d+)px\)/g)].pop()
-    return opener ? Number(opener[1]) : 0
+  // WHICH TIER a rule lives in is the thing worth pinning — but the tiers are
+  // no longer px media queries. They were (820 and 600), and the numbers moved
+  // once already (720 -> 820, because at 768 the save caret still ended 27px
+  // off the screen). They moved because a px guess cannot answer the question:
+  // the same buttons need different room at the same viewport width depending
+  // on browser zoom, OS text scaling, and the reader's language. Measured on
+  // the shipped shell: the control group is 568px in English and 618px in
+  // German — 50px the old threshold was never calibrated for, and eight
+  // catalogs ship inside every file.
+  //
+  // So the tiers are CLASSES now, applied by measuring, and what is worth
+  // pinning is that each control is dropped by the right tier.
+  const inTier = (tier: string, sel: RegExp): boolean => {
+    const re = new RegExp('\\.sp-bar-' + tier + '\\s+' + sel.source)
+    return re.test(css)
   }
-  ok(tierOf(/\.sp-sec \{ display: none/) === 820, 'the inline secondary row folds at the drawer breakpoint')
-  ok(tierOf(/\.sp-more \{ display: inline-flex/) === 820, '…which is where the ⋯ menu appears')
+  ok(inTier('compact', /\.sp-btnlabel \{ display: none/), 'compact drops the button words')
+  ok(inTier('compact', /\.sp-primary span\.sp-savelabel \{ display: none/), "…including Save's")
+  ok(inTier('tight', /\.sp-mark-word \{ display: none/), 'tight drops the wordmark, keeping the mark')
+  ok(inTier('fold', /\.sp-sec \{ display: none/), 'fold moves the secondary row into ⋯')
+  ok(inTier('fold', /\.sp-more \{ display: inline-flex/), '…which is where ⋯ appears')
+  ok(inTier('fold', /\.sp-mark \{ display: none/), '…and the mark goes (About is in ⋯)')
+  ok(inTier('fold', /\.sp-group-history \{ display: none/), '…and the history pair')
+  ok(inTier('fold', /\.sp-split \.sp-caret \{ display: none/), '…and the save caret')
+  ok(/\.sp-bar-fold \.sp-status \{\n\s*position: absolute/.test(css),
+    'the status message leaves the flow when folded, so it cannot move Save')
 
-  // THE PHONE TIER. Folding the six secondary actions was not enough: measured
-  // on a 390×844 viewport with a coarse pointer, the bar still laid out 467px
-  // wide and Save's right edge landed at x = 426 — 36px off the screen. So a
-  // phone also gives up the wordmark, the history pair and the save caret, and
-  // the ⋯ menu picks them up.
-  ok(tierOf(/\.sp-mark \{ display: none/) === 600, 'a phone drops the wordmark (About is in ⋯)')
-  ok(tierOf(/\.sp-group-history \{ display: none/) === 600, '…and the history pair')
-  ok(tierOf(/\.sp-split \.sp-caret \{ display: none/) === 600, '…and the save caret')
-  // The status line is a nowrap span: left in the flow, one long message pushes
-  // Save back off the screen for as long as it is up.
-  ok(tierOf(/\.sp-status \{\n\s*position: absolute/) === 600,
-    'the status message is out of the flow on a phone, so it cannot move Save')
-  // The JS gate that decides what the ⋯ menu carries MUST agree with the CSS
-  // tier, or the menu offers Undo while Undo is also sitting in the bar.
-  const isPhone = ed.match(/isPhone\(\): boolean \{[\s\S]{0,120}?matchMedia\('\(max-width: (\d+)px\)'\)/)
-  ok(!!isPhone && Number(isPhone![1]) === 600, 'isPhone() uses the same breakpoint as the phone tier')
-  ok(/if \(this\.isPhone\(\)\)/.test(ed) && /t\('Undo \(⌘Z\)'\)/.test(ed) && /t\('Redo \(⇧⌘Z\)'\)/.test(ed),
-    '…and the ⋯ menu picks up undo/redo there')
+  // NO px query may govern the fold any more. A stray one would re-introduce
+  // exactly the disagreement this replaced: CSS folding at one width while the
+  // menu decides its contents at another.
+  const foldSelectors = [/\.sp-sec \{ display: none/, /\.sp-mark \{ display: none/,
+    /\.sp-group-history \{ display: none/, /\.sp-split \.sp-caret \{ display: none/]
+  for (const sel of foldSelectors) {
+    const i = css.search(sel)
+    const opener = i < 0 ? null : [...css.slice(0, i).matchAll(/@media \(max-width: (\d+)px\)/g)].pop()
+    const closer = i < 0 ? -1 : css.lastIndexOf('\n}', i)
+    const inQuery = !!opener && closer < (opener.index ?? 0)
+    ok(!inQuery, `${sel.source.slice(0, 28)} is not inside a width query`)
+  }
+
+  // The bar is sized by MEASUREMENT, and the measurement is the overflow of
+  // the bar's own box — not a number written down twice.
+  ok(/private fitTopbar\(\): void \{/.test(ed), 'fitTopbar exists')
+  ok(/bar\.scrollWidth - bar\.clientWidth/.test(ed), '…and it measures overflow rather than matching a width')
+  ok(/new ResizeObserver\(\(\) => this\.fitTopbar\(\)\)/.test(ed), 'a ResizeObserver drives it on viewport change')
+  ok(/new MutationObserver\(\(\) => this\.fitTopbar\(\)\)/.test(ed),
+    '…and a MutationObserver for content that changes width at a fixed viewport')
+  ok(/attributeFilter: \['style', 'hidden'\]/.test(ed),
+    "…which does NOT watch 'class', or its own tier flips would feed it")
+  ok(/this\.barMO\?\.takeRecords\(\)/.test(ed), '…and it drops the records its own mutations queue')
+
+  // THE JS GATE ASKS THE DOM. It used to be matchMedia with the phone number
+  // written down a second time, and the comment beside it admitted as much;
+  // when the two disagreed the symptom was a menu offering Undo while Undo sat
+  // in the bar two centimetres away.
+  ok(/isFolded\(\): boolean \{[\s\S]{0,160}?classList\.contains\('sp-bar-fold'\)/.test(ed),
+    'isFolded() reads the tier off the bar instead of re-deriving it from a width')
+  // Comments STRIPPED before this one: the doc comment above isFolded quotes
+  // the expression it replaced, and an assertion that reads prose is an
+  // assertion that fails when somebody explains themselves.
+  const edCode = ed.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+  ok(!/matchMedia\('\(max-width: 600px\)'\)/.test(edCode),
+    'no phone breakpoint is duplicated in the editor CODE')
+  ok(/if \(this\.isFolded\(\)\)/.test(ed) && /t\('Undo \(⌘Z\)'\)/.test(ed) && /t\('Redo \(⇧⌘Z\)'\)/.test(ed),
+    '…and the ⋯ menu picks up undo/redo exactly when the bar has folded them away')
 
   // the bar must never become a scroller — that hides the same controls, just
   // less honestly, and it is the fix everyone reaches for first

--- a/spaces/CHANGELOG.md
+++ b/spaces/CHANGELOG.md
@@ -14,6 +14,11 @@ Versions follow `0.MINOR.PATCH` while pre-1.0.
 
 ## [Unreleased]
 
+- **The toolbar fits itself.** It used to fold at two fixed widths that were
+  measured in English; German needs 50px more for the same buttons, and eight
+  languages ship in every file. It now measures itself and steps down when it
+  actually runs out of room — at any zoom level, text size or language.
+
 - **You can see who else is here.** A coloured initial sits on the page each
   person is reading, so a shared space shows at a glance where everyone is
   working. Click somebody in the people panel to go to them.

--- a/spaces/src/editor.ts
+++ b/spaces/src/editor.ts
@@ -216,7 +216,7 @@ export class Editor {
       // (35px) and the save caret (48px) are what a phone gives up so that the
       // document title beside them is still wide enough to read. Nothing is
       // lost: they are all one tap away, here.
-      if (this.isPhone()) {
+      if (this.isFolded()) {
         menu.append(this.menuItem('undo', t('Undo (⌘Z)'), '', () => {
           close(); this.store.undo(); this.repaint()
         }, { off: !this.store.canUndo }))
@@ -227,7 +227,7 @@ export class Editor {
       for (const a of secondary) {
         menu.append(this.menuItem(a.icon, a.label, a.hint, () => { close(); a.run() }))
       }
-      if (this.isPhone()) {
+      if (this.isFolded()) {
         menu.append(this.menuItem('copy', t('Save a copy…'), t('A second file — the original is left alone'), () => {
           close(); void this.saveAs('copy')
         }))
@@ -285,6 +285,30 @@ export class Editor {
     right.append(insert, search, ...inlineSecondary, this.liveSlot, more, saveGroup)
 
     bar.append(pagesB, mark, title, this.statusEl, history, right)
+
+    // Drive the fit now, and again whenever the bar's size or its CONTENT
+    // changes. The ResizeObserver is the primary width signal — it fires for
+    // every viewport change, including a phone rotating, where matchMedia
+    // change events are unreliable under a driven viewport. The MutationObserver
+    // catches the constant-width case: the people count appearing when someone
+    // joins, the "Saved" tag flashing, the update chip arriving. Each of those
+    // clipped the end of the bar under the old breakpoints.
+    this.topbar = bar
+    this.barRO?.disconnect()
+    this.barRO = new ResizeObserver(() => this.fitTopbar())
+    this.barRO.observe(bar)
+    this.barMO?.disconnect()
+    this.barMO = new MutationObserver(() => this.fitTopbar())
+    this.barMO.observe(bar, {
+      childList: true, subtree: true, characterData: true,
+      // NOT 'class': fitTopbar's own tier flips are class changes on this very
+      // element, and observing them makes the fix for the loop (takeRecords)
+      // the only thing standing between here and a spin. Slides omits it for
+      // the same reason.
+      attributes: true, attributeFilter: ['style', 'hidden'],
+    })
+    // …and once the bar is actually in the document and has a width to measure
+    queueMicrotask(() => this.fitTopbar())
 
     this.sidebar = el('nav', 'sp-side')
     this.sidebar.setAttribute('aria-label', t('Pages'))
@@ -499,14 +523,59 @@ export class Editor {
   }
 
   /**
-   * A PHONE, not merely a narrow window: the width below which the topbar has
-   * dropped the wordmark, the history pair and the save caret (styles.css, the
-   * "phone topbar" block). The number is duplicated between here and the
-   * stylesheet on purpose — the alternative is a menu that offers Undo while
-   * Undo is also sitting in the bar two centimetres away.
+   * Has the bar FOLDED — are undo/redo and the save caret currently inside ⋯
+   * rather than in the bar?
+   *
+   * This used to be `matchMedia('(max-width: 600px)')`, with a comment saying
+   * the number was duplicated from the stylesheet on purpose. It is not needed
+   * at all now: fitTopbar puts the tier on the bar as a class, so the menu can
+   * ASK what is on screen instead of re-deriving it from a width and hoping
+   * the two agree. When they disagreed the symptom was a menu offering Undo
+   * while Undo sat in the bar two centimetres away.
    */
-  private isPhone(): boolean {
-    return window.matchMedia('(max-width: 600px)').matches
+  private isFolded(): boolean {
+    return !!this.topbar?.classList.contains('sp-bar-fold')
+  }
+
+  /**
+   * Size the topbar by MEASURING it, not by width breakpoints.
+   *
+   * A px guess cannot answer the question being asked. The same buttons need
+   * different room at the same viewport width depending on browser zoom, OS
+   * text scaling, and how long the labels are in the reader's language — eight
+   * catalogs ship inside every file, and "Insert" is 76px in English and
+   * nothing like that in German. The bar's own CONTENT changes width too, at a
+   * fixed viewport: the people count appears when somebody joins a session.
+   * Each of those cases clipped the end of the bar under the old 820/600
+   * breakpoints. Slides settled this first (#239); this is its pattern.
+   *
+   * Start from the widest layout, step down a tier while the bar still
+   * overflows its own box.
+   */
+  private fitTopbar(): void {
+    const bar = this.topbar
+    if (!bar || !bar.isConnected) return
+    const tiers = ['sp-bar-compact', 'sp-bar-tight', 'sp-bar-fold']
+    // Re-fitting starts by UNFOLDING, which would slam shut a menu somebody is
+    // reading — and the ⋯ menu's contents depend on the tier, so rebuilding it
+    // mid-read would change it under them. The next resize runs this again.
+    if (this.overlay) return
+    // scrollWidth counts content sticking out of the padding box even with
+    // overflow visible, so this IS the clipped-controls condition. 1px of
+    // slack absorbs subpixel rounding at fractional zoom.
+    const overflow = () => bar.scrollWidth - bar.clientWidth > 1
+    // The title is the only shrinkable thing in the bar, so flexbox crushes it
+    // toward its floor before anything overflows. Waiting for hard overflow
+    // would mean full labels beside an unreadable document title.
+    const title = bar.querySelector<HTMLElement>('.sp-doctitle')
+    const cramped = () => overflow() || (!!title && title.getBoundingClientRect().width < 110)
+    bar.classList.remove(...tiers)
+    if (cramped()) bar.classList.add('sp-bar-compact')
+    if (cramped()) bar.classList.add('sp-bar-tight')
+    if (cramped()) bar.classList.add('sp-bar-fold')
+    // the class flips above queued mutation records of their own; drop them,
+    // or the observer re-runs this forever
+    this.barMO?.takeRecords()
   }
 
   /**
@@ -1970,6 +2039,9 @@ export class Editor {
 
   private collab: import('./collabui.ts').CollabUi | null = null
   private liveSlot!: HTMLElement
+  private topbar: HTMLElement | null = null
+  private barRO: ResizeObserver | null = null
+  private barMO: MutationObserver | null = null
   private treeTimer: ReturnType<typeof setTimeout> | undefined
   private paintTreeSoon(): void {
     clearTimeout(this.treeTimer)

--- a/spaces/src/styles.css
+++ b/spaces/src/styles.css
@@ -660,15 +660,50 @@ button.sp-callout-chip:hover { text-decoration: underline; text-underline-offset
    the page list is already an overlay rather than a column, which is exactly the
    band where the bar is competing with the document for width. One breakpoint,
    one meaning. */
-@media (max-width: 820px) {
-  .sp-sec { display: none; }
-  .sp-more { display: inline-flex; }
-  /* Save keeps its icon; the word costs 44px and says nothing the icon doesn't */
-  .sp-bar .sp-primary span.sp-savelabel { display: none; }
-  /* …and so does Insert's: measured 76.6px labelled against 40px as an icon. */
-  .sp-bar .sp-btnlabel { display: none; }
-  .sp-bar { gap: 2px; }
-  .sp-doctitle { font-size: 13px; }
+/* ————— the topbar fits itself by MEASURING —————
+   These three tiers are applied by editor.ts fitTopbar(), which steps down
+   while the bar still overflows its own box. They were px media queries (820
+   and 600) until it became clear a px guess cannot answer the question being
+   asked: the same buttons need different room at the same viewport width
+   depending on browser zoom, OS text scaling, how long the labels are in the
+   reader's language — eight catalogs ship in every file — and live content
+   like the people count appearing when somebody joins. Slides settled this
+   first (#239); this is its pattern, with this app's controls. */
+
+/* compact: the words beside the icons go. Measured: Insert 76.6px labelled
+   against 40px as an icon; Save's word costs 44px and says nothing the icon
+   does not. */
+.sp-bar-compact .sp-primary span.sp-savelabel { display: none; }
+.sp-bar-compact .sp-btnlabel { display: none; }
+.sp-bar-compact { gap: 2px; }
+.sp-bar-compact .sp-doctitle { font-size: 13px; }
+
+/* tight: the wordmark loses its word, keeping the mark — which is the route
+   to About, and the corner every app in the suite puts it in. */
+.sp-bar-tight .sp-mark-word { display: none; }
+
+/* fold: whole controls move into ⋯. Nothing is lost, everything is one tap
+   away, and the editor asks the DOM which tier is live rather than re-deriving
+   it from a width — see fitTopbar. */
+.sp-bar-fold .sp-sec { display: none; }
+.sp-bar-fold .sp-more { display: inline-flex; }
+.sp-bar-fold .sp-mark { display: none; }
+.sp-bar-fold .sp-group-history { display: none; }
+.sp-bar-fold .sp-split .sp-caret { display: none; }
+/* with the caret gone Save is one button again, not the left half of two */
+.sp-bar-fold .sp-split > .sp-btn:first-child {
+  border-start-end-radius: 8px; border-end-end-radius: 8px;
+  padding-inline-end: 14px;
+}
+/* THE STATUS LINE LEAVES THE FLOW. It is a nowrap span, so a long message
+   ("Reading view — press Esc or the eye to edit" is ~250px) would shove the
+   bar into overflow for the 1.8s it is up and put Save off-screen again.
+   Overlaid on the title strip it says its piece and costs no width. */
+.sp-bar-fold { position: relative; }
+.sp-bar-fold .sp-status {
+  position: absolute; z-index: 2; pointer-events: none;
+  inset-inline: 46px 96px; bottom: 2px; text-align: center;
+  overflow: hidden; text-overflow: ellipsis; background: var(--bg);
 }
 
 /* Belt and braces at every width: a status message can shrink and clip, but it
@@ -755,34 +790,6 @@ button.sp-callout-chip:hover { text-decoration: underline; text-underline-offset
    Save itself never moves. Measured after, coarse pointer, scrollWidth ==
    clientWidth at every one: 320 (Save's right edge 308), 375 (363), 390 (378),
    768 (725, and the rightmost control at 756). */
-@media (max-width: 600px) {
-  .sp-mark { display: none; }
-  .sp-group-history { display: none; }
-  .sp-split .sp-caret { display: none; }
-  /* with the caret gone Save is one button again, not the left half of two */
-  .sp-split > .sp-btn:first-child {
-    border-start-end-radius: 8px; border-end-end-radius: 8px;
-    padding-inline-end: 14px;
-  }
-  /* THE STATUS LINE LEAVES THE FLOW. It is a nowrap span, so a long message
-     ("Reading view — press Esc or the eye to edit" is ~250px) would shove the
-     bar into overflow for the 1.8s it is up and put Save off-screen again.
-     Overlaid on the title strip it says its piece and costs no width. */
-  .sp-bar { position: relative; }
-  .sp-status {
-    position: absolute; z-index: 2; pointer-events: none;
-    inset-inline: 46px 96px; bottom: 2px; text-align: center;
-    overflow: hidden; text-overflow: ellipsis; background: #fff;
-  }
-}
-
-@media (max-width: 820px) {
-  /* on a tablet the mark stays — it is the route to About — but loses its
-     word. On a PHONE it goes too; see the phone-topbar block above, which must
-     therefore not be out-specified from here. */
-  .sp-mark-word { display: none; }
-}
-
 /* About opens with the suite's mark, as slides does — a dialog that starts on a
    section heading does not say what you are looking at. */
 .sp-about-head { margin-bottom: 4px; }


### PR DESCRIPTION
The bar folded at 820px and again at 600px. Those numbers had already moved once — 720 → 820, because at 768 the save caret still ended 27px off the screen — and they would have moved again, because **a px guess cannot answer the question being asked.**

## The measurement that settles it

At a 1600px viewport, on the shipped shell:

| language | control group |
|---|---|
| English | 568px |
| German | **618px** |

Fifty pixels the 820 threshold was never calibrated for — in a file that ships **eight catalogs** precisely so any reader can open it in their own language. The English calibration was the only calibration there was.

Browser zoom and OS text scaling do the same thing, and so does live content: the people count that #321 just added appears at a *fixed* viewport width, which a media query cannot see at all.

## Three tiers, applied by measuring

`fitTopbar()` steps down while the bar still overflows its own box:

| tier | drops |
|---|---|
| `sp-bar-compact` | the words beside the icons (Insert: 76.6px → 40px) |
| `sp-bar-tight` | the wordmark's word, keeping the mark |
| `sp-bar-fold` | whole controls, into ⋯ |

A `ResizeObserver` is the primary signal; a `MutationObserver` catches content that changes width at a fixed viewport. It must **not** watch `class` — `fitTopbar`'s own tier flips are class changes on that element, and watching them makes `takeRecords()` the only thing between here and a spin.

## The second copy of the number is gone

This is the real win. `isPhone()` was `matchMedia('(max-width: 600px)')`, with a comment admitting the number was duplicated from the stylesheet on purpose. It decided what the ⋯ menu carried — so when the two disagreed, the symptom was a menu offering Undo while Undo sat in the bar two centimetres away.

It is `isFolded()` now, reading the tier off the bar. There is nothing left to disagree with.

**The drawer breakpoint stays a media query** (820px). Whether the page list is a column or an overlay is a layout mode, not a question about whether things fit; slides keeps its own for the same reason.

## The rig

It pinned the old numbers *by value*, so it was rewritten to pin what now matters: which tier drops which control, that no width query governs the fold, that the fit measures overflow, that the observer does not watch its own class, and that the JS gate reads the DOM.

One assertion had to strip comments first — it was matching the doc comment that *quotes* the expression it replaced. An assertion that reads prose fails when somebody explains themselves.

## Verified

In a real browser at 1400 / 1000 / 900 / 860 / 600 / 320 and in two languages: no overflow at any width, Save inside the viewport at every one (311px of 320), the tier stepping compact → tight → fold as room runs out, **zero class changes while idle**, and none when the ⋯ menu is opened and closed.

| gate | |
|---|---|
| model | 454/454 (was 440; topbar section rewritten) |
| agent · calc · journal · spaces-session · undo | 143 · 90 · 45 · 48 · 18 |
| i18n · shell-gate | complete · OK |

Size 172,470 of 176,128 — **no ceiling change**.

Follows bento/slides #239, which settled this first.
