### PR TITLE
spaces: fixes gutter positioning (non-mobile)

### DIFF
--- a/spaces/src/styles.css
+++ b/spaces/src/styles.css
@@ -144,6 +144,17 @@ select, input, textarea, [contenteditable='true'] { -webkit-user-select: auto; u
   display: flex; gap: 1px; opacity: 0; transition: opacity .12s;
 }
 .sp-b:hover > .sp-gutter, .sp-gutter:focus-within { opacity: 1; }
+
+/* Desktop gutters sit outside the prose. Phone gutters join the block flow,
+   so their sizing and spacing stay with the phone rules below. */
+@media (min-width: 821px) {
+  .sp-gutter { top: 0; height: stretch; padding-top: inherit; }
+  .sp-b-h2 > .sp-gutter { align-items: center; margin-bottom: 2px; }
+  .sp-b-number > .sp-gutter { inset-inline-start: -68px; }
+  .sp-b-bullet > .sp-gutter { inset-inline-start: -64px; }
+  .sp-b-code > .sp-gutter { margin: 6px 0; }
+}
+
 .sp-ghost {
   display: inline-flex; align-items: center; justify-content: center;
   width: 22px; height: 24px; padding: 0; border: 0; border-radius: 5px;


### PR DESCRIPTION
## What & why

This PR fixes block gutter positioning in bento/spaces at desktop widths:

1. **Block alignment**

   Gutters now inherit the block's top padding, keeping the controls aligned with paragraph, list, and other block content. The H2 gutter is vertically centered, while code gutters follow the code block's existing vertical spacing.

2. **List positioning and RTL**

   Bullet and numbered-list gutters use type-specific logical start offsets so they sit clear of the list markers. Using `inset-inline-start` also mirrors their positioning for RTL documents.

> [!NOTE]
> The adjustments are scoped to widths above 820px. Phone gutters retain their existing static, in-flow sizing and spacing.

## UI comparison

### Example visual: Bullet gutter

<img width="788" height="366" alt="bullet-gutter-close-up" src="https://github.com/user-attachments/assets/a53f7dd0-15e0-456d-90c7-a675b6222f33" />

## Verification

- `npm run build` passed from `spaces/`
- `git diff --check` passed
- Browser-tested paragraph, H2, bullet, numbered-list, and code gutters at 1400px
- Browser-tested both LTR and RTL documents
- Confirmed gutter positioning mirrors in RTL
- Confirmed the existing mobile gutter layout is unchanged at 600px
- Compared the hovered bullet gutter against `main` with PR UI Compare

## Checklist

- [x] Read the relevant repository guidance before making changes
- [x] `npm run build` succeeds from `spaces/`
- [x] No new UI strings were added
- [x] No document-format changes were made
- [x] Did not bump the version or cut a release