### PR TITLE
spaces: typing `[` put no character in the block and closed the page list

### DIFF
--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -1628,5 +1628,36 @@ for (const [label, input, err] of [
     'Store.tree carries a visited set')
 }
 
+// ---- A BARE-KEY SHORTCUT MUST NOT EAT A CHARACTER ---------------------------
+// `[` collapses the page list. It was unguarded, and the text path that would
+// have claimed the key first sits ~90 lines BELOW it — so every `[` typed in a
+// block was preventDefault()ed into a sidebar toggle. `[[` is how this app
+// makes links and is what the starter space tells you to type; it could not be
+// typed at all. Shipped since #237, found while building the properties panel.
+{
+  const fs = await import('node:fs')
+  const ed = fs.readFileSync(new URL('../spaces/src/editor.ts', import.meta.url), 'utf8')
+
+  ok(/if \(!mod && e\.key === '\[' && !this\.editingText\(\)\)/.test(ed),
+    'the bare `[` shortcut is guarded by whether text is being edited')
+  ok(/private editingText\(\): boolean/.test(ed), 'and that guard exists')
+  ok(/el\.isContentEditable/.test(ed) && /tag === 'INPUT' \|\| tag === 'TEXTAREA'/.test(ed),
+    '…covering block hosts, the page title, table cells and plain inputs alike')
+
+  // the general rule, so the next bare-key shortcut cannot reintroduce this:
+  // every unmodified single-character binding in onKey must ask the guard.
+  const onKey = ed.slice(ed.indexOf('private onKey('), ed.indexOf('private onKey(') + 4000)
+  // NB the tail is captured up to the line end, not up to the first ')': the
+  // guard's own parentheses are inside it, and a lazier pattern silently
+  // matched nothing and failed its own assertion.
+  const bare = [...onKey.matchAll(/if \(!mod && e\.key === '(.)'(.*)$/gm)]
+  for (const m of bare) {
+    ok(/editingText/.test(m[2]),
+      `the bare \`${m[1]}\` binding asks editingText() before it swallows the key`)
+  }
+  ok(bare.length > 0, 'and there is at least one such binding to check')
+}
+
+
 console.log(`\n${checks - failures}/${checks} checks passed`)
 if (failures) process.exit(1)

--- a/spaces/src/editor.ts
+++ b/spaces/src/editor.ts
@@ -518,6 +518,22 @@ export class Editor {
     try { localStorage.setItem('bento-sp-pane-closed', this.paneClosed ? '1' : '0') } catch { /* storage can throw */ }
   }
 
+  /**
+   * Is the caret somewhere text is being typed?
+   *
+   * Bare-key shortcuts must not fire while somebody is writing. `blockAt`
+   * covers block hosts; the page title and any other contentEditable (a table
+   * cell, a comment box) are covered by the editable check, because a
+   * shortcut that eats a character is worse than a shortcut that is missing.
+   */
+  private editingText(): boolean {
+    const el = document.activeElement as HTMLElement | null
+    if (!el) return false
+    if (el.isContentEditable) return true
+    const tag = el.tagName
+    return tag === 'INPUT' || tag === 'TEXTAREA'
+  }
+
   private isDrawer(): boolean {
     return window.matchMedia('(max-width: 820px)').matches
   }
@@ -2150,10 +2166,23 @@ export class Editor {
     if (mod && e.key.toLowerCase() === 'f') { e.preventDefault(); this.openFind(); return }
     if (mod && e.altKey && e.key.toLowerCase() === 'n') { e.preventDefault(); this.newPage(); return }
     if (mod && e.shiftKey && e.key.toLowerCase() === 'j') { e.preventDefault(); this.openJournal(); return }
-    // `[` collapses the page list, as in slides. Bare, not modified: it only
-    // reaches here when nothing is being edited (the text path returns above,
-    // where `[` is the page-link trigger).
-    if (!mod && e.key === '[') { e.preventDefault(); this.togglePane(); return }
+    // `[` collapses the page list, as in slides — but ONLY when nothing is
+    // being edited.
+    //
+    // The comment here used to claim "the text path returns above". It does
+    // not: the text path is ~90 lines BELOW this, so every bare `[` was
+    // caught here first, preventDefault()ed, and turned into a sidebar toggle.
+    // Typing `[` in a block put no character in the block and collapsed the
+    // page list instead — which meant `[[`, the way this app makes links and
+    // the thing the starter space tells you to type, could not be typed at
+    // all. Shipped since #237.
+    //
+    // The guard is the same question the text path asks: is the caret in a
+    // block? blockAt(activeElement) answers it, and answers it for the page
+    // TITLE too, which is equally editable and equally deserves its brackets.
+    if (!mod && e.key === '[' && !this.editingText()) {
+      e.preventDefault(); this.togglePane(); return
+    }
     if (mod && e.shiftKey && e.key.toLowerCase() === 'i') { e.preventDefault(); this.newIssue(); return }
     if (mod && e.key.toLowerCase() === 'z') {
       e.preventDefault()


### PR DESCRIPTION
`[` collapses the page list, as in slides. The comment beside it said it only reached there when nothing was being edited, because *"the text path returns above"*. **The text path is about ninety lines below it.** So every bare `[` was caught by the shortcut first, `preventDefault()`ed, and turned into a sidebar toggle — the character never arrived.

Which means **`[[` could not be typed at all.** That is how this app makes links, and the starter space tells you to do it in as many words: *"Type `[[` anywhere to search your pages and drop a link in"* — on a page that then demonstrates the result. Shipped since #237.

## Measured, before and after

On a build of `main`, before changing anything:

| | |
|---|---|
| `defaultPrevented` | **true** |
| block text | unchanged |
| `.sp-side` | gained `sp-pane-closed` |

After the fix: the character arrives, the sidebar does not move, and `[` with nothing focused still toggles the panel as it always did.

## The guard

It asks the same question the text path asks, and asks it about **any editable target** rather than only a block host — the page title, a table cell and a comment box all deserve their brackets. A shortcut that eats a character is worse than one that is missing.

## Pinned twice

The specific binding, and a **rule**: every unmodified single-character binding in `onKey` must consult the guard, so the next bare-key shortcut cannot reintroduce this.

That second assertion failed against itself first — `[^)]*` stopped at the parenthesis inside `editingText()`, so it matched nothing and passed vacuously. It reads to end-of-line now.

## Provenance

Found by the agent building the properties panel, which correctly left it alone as not its concern.

Gates: model 469/469 · agent 143/143 · calc 90/90 · journal 45/45 · undo 18/18 · i18n complete · shell-gate OK. No size change worth the name.