### PR TITLE
Copy document JSON put the room's private keys on the clipboard

### DIFF
--- a/dash/src/about.ts
+++ b/dash/src/about.ts
@@ -32,7 +32,7 @@ import {
   addVersion, clearRecovery, clearVersions, listVersions,
 } from '../../kernel/src/autosave.ts'
 import { t, locale, localeChoices, setLocale } from './i18n.ts'
-import { docBudget, docBytes, parseDoc, rowCount, type DashDoc, type DocMeta } from './model.ts'
+import { docBudget, docBytes, parseDoc, rowCount, type DashDoc, type DocMeta , docForExport } from './model.ts'
 import type { Store } from './store.ts'
 
 export interface AboutHooks {
@@ -553,7 +553,8 @@ export function openAbout(hooks: AboutHooks): void {
   duplicateBtn.disabled = store.readOnly
   card.append(actions(
     button(t('Copy document JSON'), () => {
-      void navigator.clipboard?.writeText(JSON.stringify(store.doc, null, 2))
+      // stripped — this lands on a clipboard and then, often, in a chat window
+      void navigator.clipboard?.writeText(JSON.stringify(docForExport(store.doc), null, 2))
         .then(() => { outNote.textContent = t('Copied — {size} of JSON.', { size: bytes(stats.bytes) }) })
         .catch(() => { outNote.textContent = t('This browser refused clipboard access.') })
     }),

--- a/dash/src/model.ts
+++ b/dash/src/model.ts
@@ -441,6 +441,26 @@ export interface DashDoc {
   [extra: string]: unknown
 }
 
+/**
+ * The document with its collaboration SECRETS removed, for anything a person
+ * copies or hands to somebody else.
+ *
+ * The same fix bento/spaces needed, found by the same rig on the same day: a
+ * SyncSession is constructed at boot, so `collab` is minted for every workbook,
+ * and "Copy document JSON" put the read key, the write key and the owner key
+ * (which can also revoke) on the clipboard. bento/slides hit this first and
+ * wrote the rig — whose every path was hardcoded to slides/, which is why two
+ * more apps reintroduced it.
+ *
+ * Strips by REMOVING, so a private field added to the credentials later is
+ * covered without anyone remembering to act.
+ */
+export function docForExport(doc: DashDoc): DashDoc {
+  const { collab, ...rest } = doc as DashDoc & { collab?: unknown }
+  void collab
+  return rest as DashDoc
+}
+
 // --- Budgets. App constants, never kernel — nothing in kernel/src reads an
 // app's budgets, and these are dash's alone.
 //

--- a/scripts/test-export-secrets.ts
+++ b/scripts/test-export-secrets.ts
@@ -236,5 +236,50 @@ for (const [name, src] of editor) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// EVERY APP, NOT JUST SLIDES.
+//
+// This rig was written when slides shipped the owner private key on the
+// clipboard, and every path in it above is hardcoded to slides/. So when
+// bento/spaces grew a "Copy document JSON" of its own it reintroduced the
+// identical bug — `JSON.stringify(store.doc, null, 2)`, credentials included,
+// under a note inviting the copy — and the rig that exists to prevent exactly
+// this was structurally incapable of seeing it. Measured on the shipped build:
+// ownerPriv, key and room all present in what reached the clipboard.
+//
+// A guard that covers one app of four is a guard against one app's mistakes.
+
+console.log('\nclipboard exports, in every app that has one')
+
+const CLIP_APPS = ['spaces', 'dash', 'type']
+for (const app of CLIP_APPS) {
+  for (const file of ['about.ts', 'main.ts', 'editor.ts']) {
+    const rel = `${app}/src/${file}`
+    let src: string
+    try { src = read(rel) } catch { continue }
+    const masked = mask(src)
+    // any clipboard write that stringifies a document must go through a
+    // stripper first. The shape is deliberately loose — it is looking for a
+    // NEW leak, not enforcing one spelling.
+    for (const m of masked.matchAll(/writeText\(([^)]*)/g)) {
+      const arg = src.slice(m.index! + 'writeText('.length, m.index! + m[0].length + 60)
+      if (!/JSON\.stringify/.test(arg)) continue
+      ok(/docForExport|stripCollab|forExport|Export\(/.test(arg),
+        `${rel}: a clipboard copy of the document goes through a stripper, not the raw doc`)
+    }
+  }
+}
+
+// …and the stripper, where it exists, must REMOVE rather than allow-list, so a
+// private field added to CollabCreds later is covered without anyone acting.
+for (const app of CLIP_APPS) {
+  let src: string
+  try { src = read(`${app}/src/model.ts`) } catch { continue }
+  if (!/docForExport/.test(src)) continue
+  const body = src.slice(src.indexOf('export function docForExport'))
+  ok(/\.\.\.rest|delete .*collab|const \{ collab/.test(body.slice(0, 400)),
+    `${app}/src/model.ts: docForExport strips by REMOVING collab, not by listing fields to keep`)
+}
+
 console.log(`\n${checks - failures}/${checks} checks passed`)
 if (failures) process.exit(1)

--- a/spaces/src/about.ts
+++ b/spaces/src/about.ts
@@ -15,6 +15,7 @@ import {
 import { clearVersions, clearRecovery } from '../../kernel/src/autosave.ts'
 import { t, localeChoices, locale, setLocale } from './i18n'
 import { inertBody, esc } from './sanitize'
+import { docForExport } from './model'
 import { SPEC, mdLayout, type MdCtx } from './blocks'
 import {
   issuesOf, passesFilter, sortRows, fieldByKey, optionOf, fieldsOf,
@@ -202,7 +203,12 @@ export function openAbout({ store, onRepaint, onSaveCopy, onImport }: AboutHooks
   exports.className = 'sp-actions'
   exports.append(
     button(t('Copy document JSON'), () => {
-      void navigator.clipboard?.writeText(JSON.stringify(store.doc, null, 2))
+      // STRIPPED. This lands on a clipboard, and the note two lines below
+      // invites the copy — "the whole document is plain JSON in this file" —
+      // so the next stop is very often a chat window. The document's collab
+      // block holds the read key, the write key and the owner key that can
+      // also revoke.
+      void navigator.clipboard?.writeText(JSON.stringify(docForExport(store.doc), null, 2))
     }),
     button(t('Export as Markdown'), () => downloadMarkdown(store)),
     button(t('Save a copy…'), () => { close(); onSaveCopy() }),

--- a/spaces/src/model.ts
+++ b/spaces/src/model.ts
@@ -186,6 +186,30 @@ export interface SpacesDoc {
   [extra: string]: unknown
 }
 
+/**
+ * The document with its collaboration SECRETS removed, for anything a person
+ * copies, pastes or hands to somebody else.
+ *
+ * `doc.collab` is minted at creation, so EVERY space has one from its first
+ * save — and it holds the read capability (`key`), the write capability
+ * (`writerPriv`), the owner key that can also revoke (`ownerPriv`) and any
+ * invite's private half. "Copy document JSON" put all of that on the
+ * clipboard, under a note inviting exactly that copy ("the whole document is
+ * plain JSON in this file"), and the natural next step is pasting it into a
+ * chat window. bento/slides had this same bug, fixed it, and wrote a rig to
+ * stop it coming back — the rig only ever looked at slides/.
+ *
+ * DERIVED BY REMOVING, not by listing what to keep: a private field added to
+ * CollabCreds later is stripped by this without anyone remembering to.
+ * `room` and `key` go too — together they ARE the read capability, and a room
+ * id is the thing the relay keys on.
+ */
+export function docForExport(doc: SpacesDoc): SpacesDoc {
+  const { collab, ...rest } = doc as SpacesDoc & { collab?: unknown }
+  void collab
+  return rest as SpacesDoc
+}
+
 export const uid = (p = 'b'): string => {
   const r = globalThis.crypto?.randomUUID?.()
   return r ? `${p}-${r.slice(0, 8)}` : `${p}-${Math.random().toString(36).slice(2, 10)}`


### PR DESCRIPTION
bento/slides shipped this exact bug, fixed it, and wrote `scripts/test-export-secrets.ts` so it could not come back. **Every path in that rig is hardcoded to `slides/`.** So when bento/spaces and bento/dash each grew a "Copy document JSON" of their own, both reintroduced it — and the guard that exists to prevent precisely this was structurally incapable of seeing them.

## Measured on a build of main

A fresh space, no sharing turned on:

```
fieldsInCollab            room, key, on, v, owner, ownerPriv, role
secretsThatWouldBeCopied  ownerPriv, key, room
```

`ownerPriv` grants **write and revoke**. `key` is the read capability. `room` is what the relay keys on.

Credentials are minted at **creation**, so this is not something you opt into by sharing — every space and every workbook has them from the first save. And the note directly beneath the button invites the copy: *"A space is never a dead end: the whole document is plain JSON in this file."* The obvious next stop is a chat window.

## The fix

`docForExport()` in each app's model, used by the clipboard path. It strips by **removing** `collab` rather than listing fields to keep, so a private field added to `CollabCreds` later is covered without anyone remembering to act.

`window.bento.serialize()` is untouched and still carries credentials — that returns the **file**, and a saved file carrying its own capability is the design.

## The rig now reads every app

Its new section walks spaces, dash and type for a clipboard write that stringifies a document without a stripper, and asserts that any stripper removes rather than allow-lists.

**It found dash on its first run.** I went looking for one bug and it produced the second.

## A zone crossing, flagged

I edited `dash/`. It is a two-line mirror of the spaces fix and a live credential leak; leaving it as a filed note while the guard went green seemed worse than the crossing. dash cannot be built in this checkout (no `node_modules`) — both changed files bundle clean through esbuild, and CI builds it properly.

## Gates

export-secrets **30/30** (was 28) · spaces model 464/464 · agent 143/143 · calc 90/90 · journal 45/45 · dash model 42/42 · spaces builds + shell-gate OK.