### PR TITLE
spaces: a link in a table cell is a link

### DIFF
--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -2719,5 +2719,46 @@ function fsTable(f: string): string {
 }
 
 
+// ---- A LINK IN A TABLE CELL IS A LINK --------------------------------------
+// A table keeps its content in `rows` and mirrors it into `html`; writeTable is
+// the one writer that keeps the two in step. So a table the EDITOR produced
+// back-links from its cells, and a table that arrives any other way — hand
+// written, an agent calling updateBlock, an import — does not: the link works
+// when clicked and appears in no "Linked from". Silent, and exactly the one
+// failure a backlink index can have.
+//
+// `rows` is read ONLY when `html` is absent. Extending this to always scan
+// `rows` was tried during the starter work and reverted, because with both
+// fields present every cell link is counted twice.
+{
+  const cell = '<a href="#p/b">B</a>'
+  const docWith = (blk: Record<string, unknown>) => ({
+    format: FORMAT, version: 1, docId: 'd', title: 't', home: 'a',
+    theme: {}, pages: [
+      { id: 'a', title: 'A', blocks: [blk] },
+      { id: 'b', title: 'B', blocks: [] },
+    ],
+  }) as unknown as SpacesDoc
+  const backlinksToB = (blk: Record<string, unknown>) =>
+    (buildIndex(docWith(blk)).backlinks?.get('b') ?? []).length
+
+  ok(backlinksToB({ id: 'k', type: 'table', rows: [['x', cell]] }) === 1,
+    'a hand-authored table cell back-links, with no html fallback present')
+
+  const written: Record<string, unknown> = { id: 'k', type: 'table' }
+  writeTable(written as never, tableOf({ ...written, rows: [['x', cell]] } as never))
+  ok(backlinksToB(written) === 1, 'a table written by the editor back-links exactly once')
+
+  ok(backlinksToB({ id: 'k', type: 'table', rows: [[cell]], html: cell }) === 1,
+    '…and with BOTH fields present the same link is not counted twice')
+
+  // buildIndex runs on documents nobody has validated yet
+  let threw = false
+  try { backlinksToB({ id: 'k', type: 'table', rows: ['not-a-row', [null, 7, cell]] }) }
+  catch { threw = true }
+  ok(!threw, 'a malformed rows array does not take the index down')
+}
+
+
 console.log(`\n${checks - failures}/${checks} checks passed`)
 if (failures) process.exit(1)

--- a/spaces/src/model.ts
+++ b/spaces/src/model.ts
@@ -550,6 +550,23 @@ export interface SpaceIndex {
   backlinks: Map<string, Array<{ pageId: string; blockId: string }>>
 }
 
+/**
+ * A table's cells as one string, for scanning only.
+ *
+ * Deliberately not `tableFallbackHtml`: this is never written anywhere, so it
+ * needs no separator, no escaping and no shape — it exists so one regex can
+ * find hrefs in cells the same way it finds them in prose. Tolerant of a
+ * malformed `rows` because it runs on documents nobody has validated yet.
+ */
+function tableCellsText(rows: unknown[]): string {
+  let out = ''
+  for (const row of rows) {
+    if (!Array.isArray(row)) continue
+    for (const cell of row) if (typeof cell === 'string') out += cell + '\n'
+  }
+  return out
+}
+
 /** Every `#p/<id>` href in a block's html. */
 const LINK_RE = /href="#p\/([^"]+)"/g
 
@@ -649,8 +666,25 @@ export function buildIndex(doc: SpacesDoc): SpaceIndex {
     pushInto(children, p.parent && page.has(p.parent) ? p.parent : '', p)
     for (const b of p.blocks) {
       block.set(b.id, { block: b, pageId: p.id })
-      if (b.html) {
-        for (const m of b.html.matchAll(LINK_RE)) {
+      // WHERE A BLOCK'S LINKS LIVE. Normally in `html`. A table keeps its
+      // content in `rows` and mirrors it into `html` as a readable fallback,
+      // and `writeTable` is the one writer that keeps the two in step — so for
+      // a table the editor produced, scanning `html` finds the cells' links.
+      //
+      // It does not for a table that arrives any other way. A hand-written
+      // document, an agent calling updateBlock, an import: `rows` is set,
+      // `html` is absent, and a link in a cell then WORKS WHEN CLICKED and
+      // appears in no "Linked from" — the one failure a backlink index has,
+      // and silent. Measured before this: 0 backlinks, against 1 for the same
+      // table through writeTable.
+      //
+      // `rows` is read ONLY when `html` is absent. With both present they are
+      // the same links by construction, and scanning both would report every
+      // cell link twice — which is why extending this to always scan `rows`
+      // was tried during the starter work and reverted.
+      const linkSrc = b.html || (Array.isArray(b.rows) ? tableCellsText(b.rows) : '')
+      if (linkSrc) {
+        for (const m of linkSrc.matchAll(LINK_RE)) {
           pushInto(backlinks, linkTarget(m[1], page), { pageId: p.id, blockId: b.id })
         }
       }


### PR DESCRIPTION
A table keeps its content in `rows` and mirrors it into `html` as a readable fallback. `writeTable` is the one writer that keeps the two in step, and every path in the editor goes through it — so a table you make **in the app** back-links from its cells, and always has.

A table that arrives any other way does not. A hand-written document, an agent calling `updateBlock`, an import: `rows` is set, `html` is absent, and `buildIndex` only ever read `html`.

The link then **works when clicked and appears in no "Linked from"** — the one failure a backlink index can have, and it is silent.

```
rows only, no html   ->  0 backlinks
through writeTable   ->  1 backlink
```

## The condition is the design

`rows` is read **only when `html` is absent**. Extending this to always scan `rows` was tried during the starter work and reverted: with both fields present they hold the same links by construction, so every cell link is counted twice.

`tableCellsText` is deliberately not `tableFallbackHtml` — nothing here is written anywhere, so it needs no separator, no escaping and no shape. It tolerates a malformed `rows`, because `buildIndex` runs on documents nobody has validated yet and an index that throws takes the page list with it.

## Verified

In the built shell, clean load: a table pushed onto Inbox with `rows` and no `html` made **Inbox** appear in Writing's "Linked from", where it had not been a moment before.

```
before:  Welcome · Tables, pictures and clips · Pages and links
after:   Welcome · Tables, pictures and clips · Pages and links · Inbox
```

## Gates

model **754/754** — four new: the hand-authored case, the `writeTable` case, the both-present case that must not double, and a malformed `rows` array · agent 175 · calc 90 · journal 45 · undo 25 · sync-session 48 · i18n 530 × 8 · shell-gate OK. 253,058 B, no ceiling change.