### PR TITLE
spaces: the block gutter stretches in every browser, not just Chrome

### DIFF
--- a/spaces/src/styles.css
+++ b/spaces/src/styles.css
@@ -370,7 +370,11 @@ option { background: var(--field); color: var(--ink); }
 /* Desktop gutters sit outside the prose. Phone gutters join the block flow,
    so their sizing and spacing stay with the phone rules below. */
 @media (min-width: 821px) {
-  .sp-gutter { top: 0; height: stretch; padding-top: inherit; }
+  /* bottom:0, not height:stretch — an abspos box stretches the same way
+     and `stretch` is Chrome-only (Firefox has none, Safari needs
+     -webkit-fill-available), where it would silently drop back to the
+     24px intrinsic height and lose the full-block hover/focus target. */
+  .sp-gutter { top: 0; bottom: 0; padding-top: inherit; }
   .sp-b-h2 > .sp-gutter { align-items: center; margin-bottom: 2px; }
   .sp-b-number > .sp-gutter { inset-inline-start: -68px; }
   .sp-b-bullet > .sp-gutter { inset-inline-start: -64px; }


### PR DESCRIPTION
Follow-up to #328.

That PR gave the desktop gutter a full-block-height hover/focus target with `height: stretch`. Only Chrome understands `stretch` unprefixed — Firefox has no equivalent, Safari wants `-webkit-fill-available` — so everywhere else the declaration is dropped and the gutter falls back to its 24px intrinsic height, quietly losing the thing the rule is for.

For an absolutely positioned box `bottom: 0` does the same job and has worked since CSS 2.

Verified by measuring both builds at 1400px across every block kind (paragraph, h2, todo, bullet, number, code, callout, quote, toggle, divider) — identical top, left and height to a tenth of a pixel. shell-gate and the size gate pass (253,146 B, 96.6% of budget).