### PR TITLE
spaces: a status message never moves the buttons under your pointer

### DIFF
--- a/spaces/src/editor.ts
+++ b/spaces/src/editor.ts
@@ -433,7 +433,14 @@ export class Editor {
     const right = el('div', 'sp-group sp-group-right')
     right.append(insert, search, ...inlineSecondary, inspB, this.liveSlot, more, saveGroup)
 
-    bar.append(pagesB, mark, title, this.statusEl, history, right)
+    // The status goes AFTER undo/redo, never before. It is transient text that
+    // grows from nothing to a whole sentence, and anything downstream of it in
+    // the flex flow gets shoved sideways every time it changes — measured at
+    // 36px on a plain edit and 246px entering reading view, which is more than
+    // a button's width, so undo lands where redo just was. Past the history
+    // group it grows into the slack the right group's margin-auto already
+    // holds, and nothing before it can move. Reported against slides as #300.
+    bar.append(pagesB, mark, title, history, this.statusEl, right)
 
     // Drive the fit now, and again whenever the bar's size or its CONTENT
     // changes. The ResizeObserver is the primary width signal — it fires for

--- a/spaces/src/styles.css
+++ b/spaces/src/styles.css
@@ -1382,8 +1382,12 @@ button.sp-callout-chip:hover { text-decoration: underline; text-underline-offset
 }
 
 /* Belt and braces at every width: a status message can shrink and clip, but it
-   can never be the reason a control leaves the bar. */
-.sp-status { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+   can never be the reason a control leaves the bar — nor the reason the bar
+   changes tier. Basis 0 keeps the message out of the bar's intrinsic width, so
+   text arriving cannot push fitTopbar into hiding labels and resizing buttons
+   under the pointer; grow lets it use whatever slack is going, and it
+   ellipsises when there is none. */
+.sp-status { flex: 1 1 0; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 
 /* Hit targets: a 30px button is a miss on a touch screen. */
 @media (pointer: coarse) {


### PR DESCRIPTION
Issue #300 is filed against slides: the `Backed up in this browser` message appears in the top bar and shifts `Undo`/`Redo` right, so you click the wrong button. Spaces has the same defect, and worse — its status span sits between the document title and undo/redo, in flow, `nowrap`, auto basis.

Measured before:

| status | undo/redo shift |
| --- | --- |
| `Edited` | **36px** |
| `Reading view — press Esc or the eye to edit` | **246px** |

36px is wider than a button, so undo lands where redo just was.

**Two halves to the fix.**

1. The span moves after the history group in the flex flow. Nothing clickable is downstream of it, and the right group stays pinned by its `margin-inline-start: auto`.
2. The belt-and-braces `.sp-status` rule that already existed gets `flex: 1 1 0`. Basis 0 keeps the message out of the bar’s intrinsic width — without it, text arriving pushes `fitTopbar` down a tier, which hides labels and resizes the buttons even though none of them move. (My first attempt added a duplicate rule higher up the file that this one silently overrode; consolidated into the one that wins.)

**Verified** across 1400/1200/1100/1000/900/760/600/420 and all three messages: zero undo shift, zero save shift, zero width change, no tier change, no overflow. Fold mode is unaffected — the status is `position: absolute` there and ignores flex. The full sentence still reads unclipped at 1400.

Gates: shell-gate passes, size 253,146 B (96.6%), tsc clean, spaces model 754/754, calc 90/90, agent 175/175. `test-spaces-undo.ts` fails identically on clean main (extensionless import node cannot resolve without bundling) — pre-existing, untouched here.

Does not fix #300 itself, which is the same bug in the slides topbar.