### PR TITLE
Text takes the opposite colour to whatever it sits on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Fix: several buttons were unreadable in dark mode.** White text on a
+  near-white button — the main action in a dialog, the toast that confirms a
+  save, the active chip in a settings row, and the ＋ between slides. The
+  colour of the text was fixed while the colour behind it followed the theme,
+  so what read cleanly in light turned into white-on-white as soon as the
+  interface went dark. The panel chevrons had a milder version of the same
+  thing. Text now always takes the opposite colour to whatever it sits on.
+
+
 - **Fix: audio and video played in a show even with Autoplay switched off.**
   Set a clip's *Autoplay* to Off and it still started the moment its slide came
   up — every time, in a saved file, on any browser. The only way to stop it was

--- a/scripts/test-slides-theme.mjs
+++ b/scripts/test-slides-theme.mjs
@@ -109,6 +109,41 @@ ok(whiteSurfaces.length === 0,
     `every themed role is referenced by a rule${unused.length ? ` — defined but unused: ${unused.join(', ')}` : ''}`)
 }
 
+// ---- 4b. a themed background never carries a literal foreground -----------
+// The pairing that breaks on a theme flip. `.ed-btn-primary` was
+// `background: var(--ink); color: #fff` — correct in light, and in dark the
+// background followed --ink to a light value while the text stayed white:
+// measured 1.21:1, unreadable, on six buttons across the app. It survived
+// review because the About dialog has its own override, so the one instance
+// anybody looked at was fine.
+//
+// Only tokens that ACTUALLY INVERT are an offence. `--accent` is the same
+// peach in both themes, so a literal foreground on it is stable and allowed —
+// flagging those would train people to ignore this check.
+{
+  const valuesIn = (body) => Object.fromEntries(
+    [...body.matchAll(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/gmi)].map((m) => [m[1], m[2].trim().toLowerCase()]))
+  const L = valuesIn(light ?? ''), D = valuesIn(dark ?? '')
+  const inverts = (tok) => L[tok] && D[tok] && L[tok] !== D[tok]
+
+  const offenders = []
+  for (const [, , sel, body] of rules) {
+    const bg = body.match(/background(?:-color)?\s*:\s*var\((--[a-z0-9-]+)/i)
+    if (!bg || !inverts(bg[1])) continue
+    // A literal colour, i.e. one that is not itself a token. Tested on the
+    // CAPTURED value rather than with a lookahead: `\s*(?!var\()` backtracks —
+    // it gives back a space and then happily matches ` var(--ink)`, which had
+    // this check reporting three false positives on its first run.
+    const fg = body.match(/(?:^|;)\s*color\s*:\s*([^;]+)/i)
+    if (!fg || /^var\(/.test(fg[1].trim())) continue
+    const s2 = sel.replace(/\/\*[\s\S]*?\*\//g, '').trim().split(',')[0].trim()
+    if (EXEMPT.test(s2)) continue
+    offenders.push(`${s2} — background ${bg[1]} inverts, but color is ${fg[1].trim()}`)
+  }
+  ok(offenders.length === 0,
+    `no rule pairs an inverting background token with a literal text colour${offenders.length ? `\n        ${offenders.join('\n        ')}` : ''}`)
+}
+
 // ---- 5. the light palette has not forked from the suite -------------------
 const SHARED = { '--ink': '#1e2a3a', '--ink-2': '#31445c', '--chrome': '#f5f7fa',
   '--chrome-2': '#eceff4', '--line': '#e3e8ef', '--muted': '#5b6472',

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -240,8 +240,16 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-btn svg { display: block; }
 
 .ed-btn-primary {
+  /* The button is always the INVERSE of the surface it sits on, which is the
+     only pairing that survives a theme flip. `color: #fff` did not: the
+     background follows --ink, so in dark mode it turned light while the text
+     stayed white — measured at 1.21:1, the same ratio that made the panel
+     inputs unreadable before the theme tokens existed. It looked right in the
+     About dialog only because that has its own peach override, so the six
+     other primary buttons in the app were the ones nobody saw.
+     After: 14.51:1 light, 12.61:1 dark. */
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
   padding: 6px 14px;
 }
 .ed-btn-primary:hover { background: var(--ink-2); }
@@ -461,7 +469,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .ed-setchip:hover { background: var(--chrome-2); }
 .ed-setchip.active {
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
 }
 
 /* ————— slide surface (shared by canvas, thumbs, present) ————— */
@@ -772,7 +780,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   bottom: 26px;
   transform: translate(-50%, 12px);
   background: var(--ink);
-  color: #fff;
+  color: var(--surface);
   font-size: 13px;
   padding: 9px 16px;
   border-radius: 999px;
@@ -1391,7 +1399,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   z-index: 1;
   border: none;
   background: var(--blue);
-  color: #fff;
+  color: var(--surface);
   border-radius: 50%;
   width: 16px;
   height: 16px;
@@ -2153,7 +2161,10 @@ body.ed-col-resizing { cursor: col-resize; user-select: none; }
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--surface);
-  color: #5d6b80;
+  /* --muted, not a literal: the background follows --surface, so a fixed
+     grey-blue that read at 5.41:1 on white sat at 2.81:1 on the dark surface,
+     under the 4.5 floor. With the token it is 5.98:1 light, 5.02:1 dark. */
+  color: var(--muted);
   font-size: 11px;
   line-height: 1;
   padding: 0;


### PR DESCRIPTION
Six surfaces had white text on a background that follows the theme, so what read cleanly in light became **white-on-white** the moment the interface went dark.

Found while building the return-gate UI (#342 follow-up), whose single button was unreadable. Two of the five were then found by a new gate check rather than by looking.

## The bug

| rule | pairing | light → dark |
|---|---|---|
| `.ed-btn-primary` | `background: var(--ink)` + `color: #fff` | 14.51 → **1.21** |
| `.ed-toast` | same | 14.51 → **1.21** |
| `.ed-setchip.active` | same | 14.51 → **1.21** |
| `.ed-insertgap-btn` | `background: var(--blue)` + `color: #fff` | 3.23 → **2.46** |
| `.ed-panel-toggle` | `background: var(--surface)` + `color: #5d6b80` | 5.41 → **2.81** |

**1.21:1** is the same ratio the properties-panel inputs sat at before the theme tokens existed — the failure the theme gate was written for.

It survived review because the About dialog gives `.ed-btn-primary` its own peach override. The one primary button anybody actually looked at was fine; the other six were not.

## The fix

Pair the foreground with `var(--surface)`, making each of these the inverse of the surface it sits on — the only pairing that survives a theme flip.

| | light | dark |
|---|---|---|
| `.ed-btn-primary` | 14.51 | **12.61** |
| `.ed-panel-toggle` (via `--muted`) | 5.98 | **5.02** |
| `.ed-insertgap-btn` | 3.23 | **6.17** |

`.ed-insertgap-btn` was already marginal in light at 3.23 and is **unchanged** there — it is a large glyph, which clears AA's 3:1 for large text. Dark goes from failing to passing.

## The gate

`test-slides-theme.mjs` now refuses a literal text colour on a background token that **inverts**.

Only inverting tokens count: `--accent` is the same peach in both themes, so a literal on it is stable, and flagging those would train people to ignore the check — the failure mode where a gate becomes noise.

Verified to fail on a reintroduced literal (9/10), and 10/10 clean.

One thing worth recording: the check's first version used `\s*(?!var\()` and reported three false positives, because `\s*` backtracks — it gives back a space and then matches ` var(--ink)` happily. It now tests the captured value instead. A checker that can't be trusted about `var()` is worse than no checker.
