### PR TITLE
spaces: one command runs the rigs, including the two node cannot load

### DIFF
--- a/scripts/test-spaces-invite.ts
+++ b/scripts/test-spaces-invite.ts
@@ -3,13 +3,13 @@
 // Copyright (c) 2026 The Bento authors
 // bento/spaces share-copy rig — what an invite carries, and what it must not.
 //
-//   slides/node_modules/.bin/esbuild scripts/test-spaces-invite.ts --bundle \
-//     --platform=node --format=esm --outfile=$TMP/test-spaces-invite.mjs
-//   node $TMP/test-spaces-invite.mjs
+//   node scripts/test-spaces.mjs invite      # or just: node scripts/test-spaces.mjs
 //
 // (Bundled, not run directly: the kernel transport uses TypeScript parameter
-// properties, which node's strip-only loader refuses. Same reason the spaces
-// undo rig is bundled.)
+// properties, which node's strip-only loader refuses. Handing this file straight
+// to node fails in a way that looks like a broken product rather than a missing
+// build step — the runner above bundles it the way CI does. Same reason the
+// spaces undo rig is bundled.)
 //
 // WHAT THIS PROVES, and why it is a rig rather than a code review.
 //

--- a/scripts/test-spaces-undo.ts
+++ b/scripts/test-spaces-undo.ts
@@ -3,11 +3,13 @@
 // Copyright (c) 2026 The Bento authors
 // Undo: depth on a real document, and correctness across mixed scopes.
 //
-//   esbuild scripts/test-spaces-undo.ts --bundle --platform=node --format=esm …
+//   node scripts/test-spaces.mjs undo        # or just: node scripts/test-spaces.mjs
 //
 // (Bundled rather than run directly because store.ts imports './model' without
-// an extension, which node's ESM resolver cannot follow. Same pattern as the
-// autosave and validate rigs.)
+// an extension, which node's ESM resolver cannot follow. Handing this file
+// straight to node fails with ERR_MODULE_NOT_FOUND, which reads like a broken
+// product rather than a missing build step — the runner above does what CI
+// does. Same pattern as the autosave and validate rigs.)
 //
 // WHY. Every checkpoint used to stringify the WHOLE document. Measured on a
 // 200-page, 2.5 MB handbook: fifty edits left an undo depth of NINE, because

--- a/scripts/test-spaces.mjs
+++ b/scripts/test-spaces.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Run every bento/spaces rig the way CI runs it.
+//
+//   node scripts/test-spaces.mjs [name…]      # all, or just the ones named
+//
+// WHY THIS EXISTS. Two of the spaces rigs cannot be handed to node directly:
+// store.ts imports './model' without an extension and the kernel transport uses
+// parameter properties, neither of which node's strip-only TypeScript loader
+// will follow. CI knows that and bundles them through esbuild first. Run one of
+// those two by hand and you get ERR_MODULE_NOT_FOUND — a stack trace that looks
+// exactly like a broken product and nothing like a missing build step. That has
+// already cost one wrong bug report in this repo: a rig that passes in CI was
+// written up as a red test.
+//
+// So the fix is not to bend the app's imports around node. It is to give the
+// suite one local entry point that does what CI does, and to make the failure
+// legible when it is real.
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const esbuild = join(root, 'slides/node_modules/.bin/esbuild')
+
+// The timezone lists are not decoration. A date test that only runs in one
+// timezone has not been run: Kiritimati is UTC+14 and Lord Howe is a half-hour
+// DST offset, which is where "add 86,400,000 ms" stops being "add a day".
+const TZS_JOURNAL = ['UTC', 'Europe/Berlin', 'America/Los_Angeles', 'Pacific/Kiritimati', 'Australia/Lord_Howe']
+const TZS_CALC = ['UTC', 'Europe/Berlin', 'America/Los_Angeles', 'Pacific/Kiritimati']
+
+const RIGS = [
+  { name: 'model',   file: 'scripts/test-spaces-model.ts' },
+  { name: 'agent',   file: 'scripts/test-spaces-agent.ts' },
+  { name: 'journal', file: 'scripts/test-spaces-journal.ts', tzs: TZS_JOURNAL },
+  { name: 'calc',    file: 'scripts/test-spaces-calc.ts', tzs: TZS_CALC },
+  { name: 'undo',    file: 'scripts/test-spaces-undo.ts', bundle: true },
+  { name: 'invite',  file: 'scripts/test-spaces-invite.ts', bundle: true },
+  { name: 'size',    file: 'scripts/test-spaces-size.mjs' },
+]
+
+// A rig that exists but is not listed here would never run locally, and the
+// silence would look exactly like passing. Discovering the files and comparing
+// is two lines; noticing the omission by eye, months later, is not.
+const onDisk = readdirSync(join(root, 'scripts'))
+  .filter((f) => /^test-spaces-.*\.(ts|mjs)$/.test(f))
+  .map((f) => f.replace(/^test-spaces-/, '').replace(/\.(ts|mjs)$/, ''))
+const missing = onDisk.filter((n) => !RIGS.some((r) => r.name === n))
+if (missing.length) {
+  console.error(`these spaces rigs exist but this runner does not list them: ${missing.join(', ')}`)
+  console.error('Add them to RIGS (with bundle:true if node cannot load them directly).')
+  process.exit(2)
+}
+
+const only = process.argv.slice(2)
+const picked = only.length ? RIGS.filter((r) => only.includes(r.name)) : RIGS
+const unknown = only.filter((n) => !RIGS.some((r) => r.name === n))
+if (unknown.length) {
+  console.error(`unknown rig(s): ${unknown.join(', ')}`)
+  console.error(`known: ${RIGS.map((r) => r.name).join(' ')}`)
+  process.exit(2)
+}
+
+let tmp = null
+function bundled(file) {
+  if (!existsSync(esbuild)) {
+    console.error(`\nesbuild is missing at ${esbuild}`)
+    console.error('This rig has to be bundled before node can load it. Run `npm install` in slides/ first.')
+    process.exit(2)
+  }
+  tmp ??= mkdtempSync(join(tmpdir(), 'bento-spaces-rigs-'))
+  const out = join(tmp, `${file.replace(/.*\//, '')}.mjs`)
+  const r = spawnSync(esbuild, [file, '--bundle', '--platform=node', '--format=esm', `--outfile=${out}`],
+    { cwd: root, encoding: 'utf8' })
+  if (r.status !== 0) {
+    console.error(r.stderr || r.stdout)
+    return null
+  }
+  return out
+}
+
+function run(file, env) {
+  const r = spawnSync(process.execPath, [file], { cwd: root, env: { ...process.env, ...env }, encoding: 'utf8' })
+  process.stdout.write(r.stdout ?? '')
+  if (r.status !== 0) process.stderr.write(r.stderr ?? '')
+  return r.status === 0
+}
+
+const failed = []
+for (const rig of picked) {
+  const target = rig.bundle ? bundled(rig.file) : rig.file
+  if (!target) { failed.push(rig.name); console.log(`\n=== spaces/${rig.name} — DID NOT BUILD`); continue }
+  for (const tz of rig.tzs ?? [null]) {
+    console.log(`\n=== spaces/${rig.name}${tz ? ` — ${tz}` : ''}`)
+    if (!run(target, tz ? { TZ: tz } : {})) failed.push(tz ? `${rig.name} (${tz})` : rig.name)
+  }
+}
+
+if (tmp) rmSync(tmp, { recursive: true, force: true })
+
+console.log('')
+if (failed.length) {
+  console.log(`FAILED: ${failed.join(', ')}`)
+  process.exit(1)
+}
+console.log(`all spaces rigs passed (${picked.map((r) => r.name).join(', ')})`)


### PR DESCRIPTION
The undo and invite rigs cannot be handed to node directly — `store.ts` imports `./model` without an extension, and the kernel transport uses parameter properties, neither of which the strip-only TypeScript loader will follow. CI knows this and bundles them through esbuild first, and **they pass there**. Run either by hand and you get `ERR_MODULE_NOT_FOUND`: a stack trace that looks like a broken product and nothing like a missing build step.

That is not hypothetical — it cost a wrong bug report earlier today. I reported `test-spaces-undo.ts` as failing on main on the strength of the crash alone. It was not failing; I was running it wrong.

**What this does not do:** change the app imports. There are 76 extensionless relative imports in `spaces/src`, which is the ordinary Vite idiom; bending them around node’s loader to suit a test would be the wrong trade.

**What it does:** `scripts/test-spaces.mjs` runs all seven spaces rigs the way CI does —

```bash
node scripts/test-spaces.mjs           # everything
node scripts/test-spaces.mjs undo      # just one
```

- bundles `undo` and `invite` through esbuild, into a temp dir it cleans up
- runs `journal` and `calc` across the same 5 and 4 timezones CI uses (Kiritimati at UTC+14, Lord Howe on a half-hour DST offset)
- exits non-zero naming the rigs that failed
- refuses to start if a `test-spaces-*` file exists that it does not list — a rig that never runs locally is indistinguishable from one that passes
- says plainly to run `npm install` in `slides/` if esbuild is missing, rather than dying obscurely

The two bundled rigs now point at the runner in their headers, so the file that springs the trap says how to avoid it.

**Verified by sabotage rather than by watching it go green:** flipping one assertion to false gives `24/25`, `FAILED: undo`, exit 1. Adding an unlisted `test-spaces-zzz.ts` gives exit 2 and names it. Clean, all seven pass, exit 0.

CI is left alone — its per-rig steps carry the rationale for each one and give granular failure reporting, which a single step would lose.