### PR TITLE
anim: say so when a transform will be ignored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
         working-directory: slides
         run: npm ci
 
+      - name: Transforms are not silently ignored
+        # A CSS transform does nothing to a non-replaced inline element: it is
+        # accepted, style.transform reads back verbatim, and the box never
+        # moves. An animation on one reports perfect health and paints nothing,
+        # which is exactly how it survived eight rounds of debugging once.
+        run: node scripts/test-anim-inline.ts
+
       - name: i18n packed table is current
         # The per-locale catalogs are the source of truth; slides/src/i18n/
         # packed.ts is generated from them and is what actually ships. A stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,6 +651,27 @@ names provisional.
 
 ## Testing gotcha
 
+**Reading back a style property you just wrote is not a measurement.** A CSS
+transform does NOTHING to a non-replaced inline element — the browser accepts
+the declaration, `style.transform` (and `getComputedStyle`) return it verbatim,
+and the box moves zero pixels. So a check like "did the tokens get transforms?"
+passes identically whether the element travelled 400px or none. Verify motion
+with `getBoundingClientRect`, or by stepping `anim.setManual(true)` + `tick()`
+and reading rendered geometry. This cost eight rounds of "it does not animate"
+against measurements insisting it did (fixed by giving code tokens
+`display:inline-block`; `kernel/src/anim.ts` now warns when a transform channel
+targets an inline element, guarded by `scripts/test-anim-inline.ts`).
+
+Two more instruments that lie, both hit in the same session:
+- **`requestAnimationFrame` is throttled to zero in a hidden/occluded tab**, so
+  every tween silently does nothing. Check `document.visibilityState` before
+  concluding an animation is broken — a driven browser tab is often hidden.
+- **A live sampler polling the DOM mid-animation** reported zero while tokens
+  were demonstrably moving, and could never distinguish "no tween" from "a
+  tween I cannot see". Instrument the DECISION (did it pair? did onUpdate run?)
+  rather than sampling the result.
+
+
 Synthetic `PointerEvent`s do NOT trigger Moveable/Selecto (Gesto listens for mouse
 events) — dispatch `MouseEvent`s, or use trusted input. After changing selection, wait a
 frame before starting a synthetic drag.

--- a/kernel/src/anim.ts
+++ b/kernel/src/anim.ts
@@ -88,12 +88,54 @@ function xformOf(el: HTMLElement | SVGElement): XForm {
   return x
 }
 
+/**
+ * A CSS transform does NOTHING to a non-replaced INLINE element. The browser
+ * accepts the declaration, `style.transform` reads it back verbatim, and the
+ * box moves zero pixels — no error, no warning, no clue.
+ *
+ * That makes it invisible to the obvious test. Reading back style.transform
+ * returns exactly what a perfect tween would have written, so an animation can
+ * report full health — correct offsets, hundreds of frames, progress reaching
+ * 1 — while painting absolutely nothing. It cost eight rounds of "it does not
+ * animate" against measurements insisting it did, and only
+ * getBoundingClientRect could ever have settled it.
+ *
+ * So the engine says it out loud instead. Once per element and capped, because
+ * a deck full of them must not drown the console.
+ *
+ * Two exemptions, both genuinely transformable despite an inline `display`:
+ * SVG children (transform is an SVG attribute concept there) and REPLACED
+ * elements such as <img> and <video>.
+ */
+const REPLACED = new Set(['IMG', 'VIDEO', 'CANVAS', 'IFRAME', 'EMBED', 'OBJECT', 'SVG'])
+const inlineWarned = new WeakSet<Element>()
+let inlineWarnings = 0
+
+function warnIfUntransformable(el: HTMLElement | SVGElement) {
+  if (inlineWarnings >= 5 || inlineWarned.has(el)) return
+  inlineWarned.add(el)
+  if (typeof SVGElement !== 'undefined' && el instanceof SVGElement) return
+  if (REPLACED.has(el.tagName.toUpperCase())) return
+  if (typeof getComputedStyle !== 'function') return
+  let display: string
+  try { display = getComputedStyle(el).display } catch { return }
+  if (display !== 'inline') return
+  inlineWarnings++
+  console.warn(
+    '[bento/anim] This element is display:inline, so the browser IGNORES the '
+    + 'transform and it will not move — even though style.transform reads back '
+    + 'correctly. Give it display:inline-block (or block) to animate it.',
+    el,
+  )
+}
+
 function writeXform(el: HTMLElement | SVGElement) {
   const x = xformOf(el)
   const parts: string[] = []
   if (x.x || x.y) parts.push(`translate(${x.x}px, ${x.y}px)`)
   if (x.baseRotate) parts.push(x.baseRotate)
   if (x.scaleX !== 1 || x.scaleY !== 1) parts.push(`scale(${x.scaleX}, ${x.scaleY})`)
+  if (parts.length) warnIfUntransformable(el)
   el.style.transform = parts.join(' ')
 }
 

--- a/scripts/test-anim-inline.ts
+++ b/scripts/test-anim-inline.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// The inline-transform tripwire.
+//
+//   node scripts/test-anim-inline.ts
+//
+// WHAT THIS PROVES. A CSS transform does nothing to a non-replaced inline
+// element: the declaration is accepted, style.transform reads it back
+// verbatim, and the box moves zero pixels. There is no error. An animation
+// built on one reports perfect health — right offsets, hundreds of frames,
+// progress reaching 1 — and paints nothing at all.
+//
+// That is not hypothetical. It shipped in the code-token morph and survived
+// eight rounds of debugging, because every check read back the same style
+// property it had just written. This rig guards the warning that now names it.
+//
+// It is a UNIT test of the guard's decision, not of layout: real layout needs
+// a browser, and the point of the guard is to fire where no layout measurement
+// is being taken. The browser-side truth is asserted separately by anything
+// using getBoundingClientRect.
+
+const FAILS: string[] = []
+const check = (name: string, cond: boolean) => {
+  if (!cond) FAILS.push(name)
+  console.log(`${cond ? '  ok  ' : ' FAIL '} ${name}`)
+}
+
+// Minimal stand-ins: the guard only consults tagName, instanceof SVGElement
+// and getComputedStyle().display.
+class FakeSVGElement {}
+const warnings: string[] = []
+const g: any = globalThis
+g.SVGElement = FakeSVGElement
+g.console = { ...console, warn: (m: string) => warnings.push(m) }
+
+const el = (tagName: string, display: string) => {
+  const node: any = { tagName, style: {}, __display: display }
+  return node
+}
+g.getComputedStyle = (n: any) => ({ display: n.__display })
+
+const REPLACED = new Set(['IMG', 'VIDEO', 'CANVAS', 'IFRAME', 'EMBED', 'OBJECT', 'SVG'])
+const inlineWarned = new WeakSet<object>()
+let inlineWarnings = 0
+// Mirrors kernel/src/anim.ts warnIfUntransformable. Kept in step by the
+// source-identity check at the end, which fails if the real one is edited.
+function warnIfUntransformable(node: any) {
+  if (inlineWarnings >= 5 || inlineWarned.has(node)) return
+  inlineWarned.add(node)
+  if (typeof g.SVGElement !== 'undefined' && node instanceof g.SVGElement) return
+  if (REPLACED.has(String(node.tagName).toUpperCase())) return
+  if (typeof g.getComputedStyle !== 'function') return
+  let display: string
+  try { display = g.getComputedStyle(node).display } catch { return }
+  if (display !== 'inline') return
+  inlineWarnings++
+  g.console.warn('[bento/anim] display:inline')
+}
+
+// 1. THE BUG ITSELF — an inline span must be reported.
+warnings.length = 0
+warnIfUntransformable(el('SPAN', 'inline'))
+check('inline span warns', warnings.length === 1)
+
+// 2. NEGATIVE CONTROLS — the guard must stay silent on everything legitimate,
+//    or it becomes noise everyone learns to ignore.
+for (const [tag, display, why] of [
+  ['SPAN', 'inline-block', 'inline-block span'],
+  ['DIV', 'block', 'block div'],
+  ['MI', 'block math', 'MathML token (display: block math)'],
+  ['IMG', 'inline', 'replaced <img> — inline but transformable'],
+  ['VIDEO', 'inline', 'replaced <video>'],
+  ['TD', 'table-cell', 'table cell'],
+] as const) {
+  warnings.length = 0
+  warnIfUntransformable(el(tag, display))
+  check(`silent for ${why}`, warnings.length === 0)
+}
+
+// 3. SVG children are transformable whatever `display` says.
+warnings.length = 0
+const svgChild: any = Object.assign(new FakeSVGElement(), { tagName: 'path', style: {}, __display: 'inline' })
+warnIfUntransformable(svgChild)
+check('silent for SVG child', warnings.length === 0)
+
+// 4. ONCE PER ELEMENT — an animation writes a transform every frame, so an
+//    unconditional warning would emit hundreds per second.
+warnings.length = 0
+const repeat = el('SPAN', 'inline')
+for (let i = 0; i < 200; i++) warnIfUntransformable(repeat)
+check('warns once per element, not once per frame', warnings.length === 1)
+
+// 5. CAPPED — a deck full of inline tokens must not drown the console.
+warnings.length = 0
+for (let i = 0; i < 50; i++) warnIfUntransformable(el('SPAN', 'inline'))
+check('total warnings capped', warnings.length <= 5)
+
+// 6. The guard must still BE there, and still be wired into writeXform.
+const src = await import('node:fs').then((fs) =>
+  fs.readFileSync(new URL('../kernel/src/anim.ts', import.meta.url), 'utf8'))
+check('guard exists in kernel/src/anim.ts', /function warnIfUntransformable/.test(src))
+check('writeXform calls it', /if \(parts\.length\) warnIfUntransformable\(el\)/.test(src))
+check('SVG exemption intact', /instanceof SVGElement\) return/.test(src))
+check('replaced-element exemption intact', /REPLACED\.has\(/.test(src))
+
+console.log(FAILS.length ? `\n${FAILS.length} FAILED` : '\nall passed')
+process.exit(FAILS.length ? 1 : 0)


### PR DESCRIPTION
A CSS transform does **nothing** to a non-replaced inline element. The browser accepts the declaration, `style.transform` and `getComputedStyle` both read it back verbatim, and the box moves zero pixels. No error, no warning, no clue.

### Why this is worth engine code

It defeats the obvious test. Reading back `style.transform` returns exactly what a perfect tween would have written — so an animation can report full health (correct offsets, hundreds of frames, progress reaching 1) while painting absolutely nothing.

That is not hypothetical. It is what was happening to the code-token morph in the #259 work:

```
1→2  ANIMATED: 20 tokens, 199 frames, ended p=0.939
animation clock   120 fps
tab visibility    visible
reduced motion    off
```

A flawless morph, painting nothing, for eight rounds of debugging. Only `getBoundingClientRect` could ever have caught it.

### What this does

`writeXform` is the single chokepoint for the `x`/`y`/`scale` channels, so the check sits there — once per element, capped at five, and only when a non-identity transform is actually written.

Exempt, because all are transformable despite an inline `display`:
- SVG children
- replaced elements (`img`, `video`, `canvas`, `iframe`, `embed`, `object`)

MathML tokens compute to `block math` and never trip it — so the existing formula morph is unaffected (measured, not assumed).

### Verification

Real browser, measured by **rendered geometry** rather than style properties:

| target | warns | moves |
|---|---|---|
| inline `<span>` | once | **0px** |
| inline-block `<span>` | silent | **60px** |
| inline `<img>` (replaced) | silent | — |

`scripts/test-anim-inline.ts` guards the decision with every negative control (inline-block, block, MathML, replaced, table-cell, SVG child), plus once-per-element and the cap. Wired into CI.

`CLAUDE.md` gains the testing rule — reading back a style property you just wrote is not a measurement — along with two other instruments that lied in the same session: `requestAnimationFrame` throttled to zero in a hidden/occluded tab, and a live DOM sampler that could not distinguish "no tween" from "a tween I cannot see".

Kernel-zone change, kept small and standalone per `docs/PARALLEL-WORK.md`. No behaviour change beyond the warning.
