### PR TITLE
Starter deck: the same trick on code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,16 @@ names provisional.
 - `src/model.ts` — the `bento/slides` JSON document model. This is the format.
 - `src/starterdeck.ts` — the showcase starter deck (what a fresh build opens
   with): four 'sd-tile-*' elements morph through EVERY slide (the id-continuity
-  demo), one deliberate 'fade' beat exists because entrance staggers/count-ups
-  only run on non-morph entries, charts slide + hidden pie state demo the
-  bar⇄pie data morph, speaker notes double as the feature tour. Gotchas learned
+  demo) — only the title arrives by 'fade', so nothing interrupts that thread.
+  The stats beat used to fade too, on the belief that entrance staggers and
+  count-ups needed a non-morph arrival; that has been FALSE since #197 (runMorph
+  gives every unpartnered element its fx.enter, and runMorphArrivalCountUps
+  counts up anything not carried from the previous slide), and the fade was
+  costing the deck its best tile moment — the four scattered tiles collapsing
+  into the row of chips. Verified by measurement, not belief: on that morph
+  arrival all four tiles travel, 13 elements stagger in, and the count-up runs
+  0→100%. Charts slide + hidden pie state demo the bar⇄pie data morph, speaker
+  notes double as the feature tour. Gotchas learned
   building it: line shapes take their color from `fill` (not `stroke` — the
   stroke attr is what morphs tween), and the renderer draws lines horizontally
   across the element box (vertical lines = rotation), keep 96px side margins

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5440,46 +5440,40 @@ asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
 
-## 2026-08-25 — the square root: STIX draws it short, and Chrome picks STIX
+## 2026-08-25 — the square root: a Chromium regression, not ours and not the font
 
-**The symptom.** The radical's hook stops short of its overbar, leaving a step
-where the two should be one stroke.
+**The symptom.** In a formula, the radical's hook does not meet its overbar —
+a visible step where the two should be one stroke.
 
-**The cause.** Chromium draws the square-root sign short of its own rule when
-the maths font is **STIX Two Math**. Every other candidate joins cleanly — the
-plain serif fallback, Noto Sans Math, four STIX variants with patched MATH
-constants, and a hand-built radical — and STIX breaks in Chromium 148 and 151
-alike, so it is the font, not a version regression.
+**The answer, after a long and badly-run investigation: it is the browser.**
 
-It reaches our decks because Chrome resolves the GENERIC `math` family to STIX
-on macOS. Measured: generic and STIX return identical metrics (521.9x139.1)
-while the serif fallback returns 450.9x121.6. A deck therefore lands on the one
-bad face without ever naming a font. Other engines resolve `math` differently
-and look correct — the embedded viewer used during this investigation falls
-back to plain serif — which is why the fault appears in Chrome and nowhere else.
+| engine | radical |
+|---|---|
+| Chromium 148 | perfect |
+| Chromium 151 | broken |
 
-**The fix** (styles.css, two rules):
+Same machine, same fonts, same device pixel ratio, same markup. Every font
+tested breaks in 151 and every one is clean in 148: the generic `math` family,
+STIX Two Math explicitly, four STIX variants with patched MATH constants, an
+embedded Noto Sans Math, a non-math serif, and a hand-built radical made from a
+stretchy operator plus a CSS border. Chromium's tracker carries the related
+long-standing note that msqrt "doesn't stretch vertically to enclose all its
+argument".
 
-    .bento-el math msqrt   { font-family: 'Cambria Math', 'Latin Modern Math', serif; }
-    .bento-el math msqrt * { font-family: math; }
+**Nothing in Bento causes it and nothing in Bento can fix it.** Not the font
+stack, not temml, not our data-sym tagging, not the template round-trip, not
+the stage transform, not `contain: layout style`, not the box-sizing reset, not
+font size, and not the fraction context. All were tested and all are innocent.
 
-Naming real maths fonts first means this changes nothing except where STIX
-would have been chosen: Windows keeps Cambria Math, a TeX install keeps Latin
-Modern Math, macOS lands on serif. Windows and Linux are unverified, but they
-are unchanged BY CONSTRUCTION rather than by assumption.
+**Do not "fix" this by naming a math font.** That was tried and reverted twice.
+On this machine Chrome resolves the generic `math` family to STIX Two Math
+anyway — measured: generic and STIX give byte-identical metrics (711.7x189.7)
+while a nonsense font name gives 614.9x165.8 — so naming STIX changes nothing
+and only costs the deck its typography.
 
-**Why it is scoped to msqrt.** `serif` has no MATH table. Applied to a whole
-formula it stops brackets stretching around a fraction — measured, a stretchy
-`(` collapses from 315px to 94px and no longer encloses its fraction — and
-shrinks the large operators. Scoping to the msqrt box takes only its glyph and
-rule from the fallback; the second rule puts the radicand back so the
-letterforms inside still match the rest of the formula. Verified: brackets
-still stretch to 315px, the sum stays 145.7, the radicand keeps its height, and
-only the msqrt box changes, 139.1 -> 131.6.
-
-**How this went wrong, which outlived the bug.** Six or more confident wrong
-answers were reported before the right one, and every single one came from an
-instrument that lied:
+**How this went wrong, which is the part worth keeping.** Six or more confident
+wrong answers were reported before the right one, every one from an instrument
+that lied:
 
 - `document.fonts.check()` returns true for fonts that are NOT installed, so a
   four-font comparison was three fallbacks wearing different labels. Control: a
@@ -5487,18 +5481,21 @@ instrument that lied:
 - A "step size" metric compared the bar against the ink just left of it, which
   is the diagonal, not the flag. It scored a perfect radical as broken and
   returned an identical 21px for every variant.
-- An SVG foreignObject rasteriser silently ignores `font-family`, proven when
+- An SVG foreignObject rasteriser ignores `font-family` entirely, proven when
   `NoSuchFontXYZ` produced byte-identical output to STIX.
-- And the costliest: **every test page was judged in a different browser engine
-  from the one showing the fault.** The reviewer was reading them in an
-  embedded viewer (Chromium 148, which falls back to serif and looks perfect)
-  while the screenshots of the fault came from Chrome. Nine consecutive
-  matrices came back "all fine", each clearing a suspect that had never been
-  exercised.
+- And the one that cost the most: **every test page was judged in a different
+  browser engine from the one showing the bug.** The reviewer was looking at
+  Chromium 148 in an embedded viewer; the screenshots of the fault came from
+  Chrome 151. Nine test matrices came back "all fine" for that reason alone.
 
-**The rules worth keeping.** Pin and record the engine, version and resolved
-font in the test artefact itself — "it looks fine here" is worthless until
-"here" is named. Give every font probe a nonsense-name control. And when the
-tooling keeps producing plausible answers that a human keeps rejecting, stop
-refining the tooling and hand the human the artefact: a nine-row page answered
-in one exchange what hours of measurement had not.
+**The lesson: pin the environment before trusting any comparison.** Record the
+engine and version in the test artefact itself. A rendering bug reproduced in
+one engine cannot be investigated in another, and "it looks fine here" is not
+evidence until "here" is named.
+
+**Status: accepted, unfixed, not ours.** Readers on affected Chromium versions
+see a small step in square roots. If it becomes worth working around, the only
+route that bypasses the engine's radical painting is drawing the hook and bar
+ourselves as one SVG path — but note that even the hand-built approximation
+tested here still showed problems in 151, so that would need verifying in the
+affected engine first.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5440,36 +5440,91 @@ asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
 
-## 2026-08-25 — the square root: a Chromium regression, not ours and not the font
+## 2026-08-25 — the square root: Chromium's radical join, accepted unfixed
 
 **The symptom.** In a formula, the radical's hook does not meet its overbar —
 a visible step where the two should be one stroke.
 
-**The answer, after a long and badly-run investigation: it is the browser.**
+**Status: accepted, unfixed.** Formulas keep the generic `math` family. There
+is a mitigation that helps on macOS and it is written down below, deliberately
+not shipped. This waits for an upstream fix.
 
-| engine | radical |
-|---|---|
-| Chromium 148 | perfect |
-| Chromium 151 | broken |
+**Every font tested breaks.** Measured on the affected engine, not inferred:
 
-Same machine, same fonts, same device pixel ratio, same markup. Every font
-tested breaks in 151 and every one is clean in 148: the generic `math` family,
-STIX Two Math explicitly, four STIX variants with patched MATH constants, an
-embedded Noto Sans Math, a non-math serif, and a hand-built radical made from a
-stretchy operator plus a CSS border. Chromium's tracker carries the related
-long-standing note that msqrt "doesn't stretch vertically to enclose all its
-argument".
+| platform | what generic `math` picks | radical join |
+|---|---|---|
+| macOS | STIX Two Math | broken |
+| Windows | Cambria Math | broken, same way |
+| Windows, forced `serif` | Times New Roman | smaller break, still broken |
 
-**Nothing in Bento causes it and nothing in Bento can fix it.** Not the font
-stack, not temml, not our data-sym tagging, not the template round-trip, not
-the stage transform, not `contain: layout style`, not the box-sizing reset, not
-font size, and not the fraction context. All were tested and all are innocent.
+Three fonts, three breaks. That is what rules the font out as the cause: a
+defect belonging to STIX would not follow us to Cambria Math and Times New
+Roman, on another operating system, in another font family.
 
-**Do not "fix" this by naming a math font.** That was tried and reverted twice.
-On this machine Chrome resolves the generic `math` family to STIX Two Math
-anyway — measured: generic and STIX give byte-identical metrics (711.7x189.7)
-while a nonsense font name gives 614.9x165.8 — so naming STIX changes nothing
-and only costs the deck its typography.
+**It is not a version regression.** An earlier version of this entry claimed
+Chromium 148 was clean and 151 broken. That table was wrong and is the reason
+this entry was rewritten. The "clean" engine was an embedded browser that ships
+almost no fonts, so it silently fell back to a plain serif and never rendered
+STIX at all. It was not a newer engine breaking a radical; it was two engines
+drawing two different fonts. STIX breaks in 148 too.
+
+**What the mechanism appears to be.** Chromium paints the arm of the radical
+from the font's glyph and then draws the overbar itself as a rule, and the
+break is those two disagreeing by a fraction of a pixel. Two measurements
+support this. Sweeping the radicand height from 10px to 200px, the glyph's
+advance width never moves off 109.1px, so the radical stretches by a glyph
+assembly rather than by wider size variants — the engine is compositing, not
+picking one drawn glyph. And the size of the break tracks the font's arm
+thickness rather than anything about the formula. It follows that the mismatch
+is resolution-dependent, which is why Windows breaks *differently* rather than
+not at all, and why zoom level can change the verdict on a given row.
+
+**The radicand's height is not the cause, so do not try to fix this by making
+formulas shorter.** Tested directly, because it is the intuitive suspect. In
+the starter deck's own quadratic formula the `b²` raises the radicand from
+64.4px to 84.3px, but the msqrt box stays at 113.8px — the *minimum*,
+single-glyph size — exactly as it is for a flat `b − 4ac` and for four other
+radicands. Same glyph, same size, same position, same bar. Only a fraction
+inside the root (radicand 159.7px, box 220.3px) actually stretches it. The
+radical in `√(b²−4ac)` is pixel-identical to the one in `√(b−4ac)`, so the
+exponent cannot be raising the bar.
+
+**The mitigation, documented and not shipped.** Scoping a non-maths font to the
+radical only, and putting the contents back:
+
+```css
+.bento-el math msqrt { font-family: serif; }
+.bento-el math msqrt * { font-family: math; }
+```
+
+The second rule is what makes it viable: it keeps the whole formula in the
+maths font and swaps only the glyph that is drawn wrong. A blanket `serif` on
+the formula is not an option — it collapses stretchy delimiters (a tall `(`
+measured 315px in the maths font and 94px in serif) and shrinks large
+operators.
+
+Verified clean on macOS/Chrome, where it swaps STIX's radical for the serif
+one. **It is not shipped because it does not hold on Windows**, where `serif`
+is Times New Roman and the break is smaller but still there. It trades one
+rounding mismatch for another, and a fix that only works on the author's own
+machine is worse than a known defect. If a font is ever found that joins
+cleanly on both platforms, this rule is the shape the fix should take — scoped
+to `msqrt`, contents restored to `math`. Note also that the stack matters: on
+Windows `'Cambria Math', serif` selects what generic `math` already selects, so
+that variant is a no-op there.
+
+`slides/dist-single/radical-windows-test.html` is the cross-platform test rig:
+one row per candidate font applying exactly the rule above, each row reporting
+whether the font actually resolved, and a paste-back block carrying platform,
+UA and DPR.
+
+**If it ever becomes worth fixing on our side**, the only route that bypasses
+the engine's radical painting is drawing the hook and bar ourselves — an
+`<mo>√</mo>` plus a CSS rule for the bar, overlapped so the join cannot
+separate at any DPI. That costs the semantic `msqrt` (accessibility, and the
+morph would need the bar tagged as its own symbol), and an earlier hand-built
+approximation still showed problems, so it needs verifying in the affected
+engine before anyone commits to it.
 
 **How this went wrong, which is the part worth keeping.** Six or more confident
 wrong answers were reported before the right one, every one from an instrument
@@ -5483,19 +5538,13 @@ that lied:
   returned an identical 21px for every variant.
 - An SVG foreignObject rasteriser ignores `font-family` entirely, proven when
   `NoSuchFontXYZ` produced byte-identical output to STIX.
-- And the one that cost the most: **every test page was judged in a different
-  browser engine from the one showing the bug.** The reviewer was looking at
-  Chromium 148 in an embedded viewer; the screenshots of the fault came from
-  Chrome 151. Nine test matrices came back "all fine" for that reason alone.
+- And the one that cost the most: **every test page was judged in a browser
+  that resolved the fonts differently from the one showing the bug.** Nine test
+  matrices came back "all fine" for that reason alone, each one clearing a
+  suspect that had never actually been rendered.
 
-**The lesson: pin the environment before trusting any comparison.** Record the
-engine and version in the test artefact itself. A rendering bug reproduced in
-one engine cannot be investigated in another, and "it looks fine here" is not
-evidence until "here" is named.
-
-**Status: accepted, unfixed, not ours.** Readers on affected Chromium versions
-see a small step in square roots. If it becomes worth working around, the only
-route that bypasses the engine's radical painting is drawing the hook and bar
-ourselves as one SVG path — but note that even the hand-built approximation
-tested here still showed problems in 151, so that would need verifying in the
-affected engine first.
+**The lesson: pin the environment before trusting any comparison, and prove the
+thing under test is really on screen.** Record engine, version and *resolved*
+font in the test artefact itself — a named font that silently fell back is not
+a test of that font. "It looks fine here" is not evidence until "here" is
+named.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5439,3 +5439,62 @@ language: "An update check is the only network this app makes on its own. It
 asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
+
+## 2026-08-25 — no embedded math font, and why the square root looks the way it does
+
+**The symptom.** In a formula, the radical's hook does not quite meet its
+overbar: at large sizes there is a visible step where the two should form one
+stroke. Reported against the starter deck's quadratic formula.
+
+**What it is NOT**, each checked rather than reasoned about:
+
+- Not the morph. At rest the radical carries no inline colour, transform or
+  animation state.
+- Not temml's missing stylesheet. Temml ships CSS we never import, which sets
+  `math { line-height: normal; font-style: normal; … }` — but those computed
+  values are already correct via the UA stylesheet, and applying temml's resets
+  renders identically.
+- Not reachable from CSS. `border-top` is `0px` on every node in the subtree and
+  there is no `::before`; Chromium paints the radical rule internally as part of
+  MathML layout. There is no handle to move it.
+- Not about stretching. `√x`, `√(b−4)` and `√(b²−4)` all show it, so it is not
+  tall content forcing a stretched glyph.
+
+**What it IS.** The rule's position comes from the font's MATH constants
+(`RadicalRuleThickness`, `RadicalVerticalGap`, `RadicalExtraAscender`) versus
+where the stretched glyph's own top flag lands, and Chromium's arithmetic does
+not reconcile the two. **It therefore varies by font** — magnified side by side,
+STIX Two Math shows a clear notch and Noto Sans Math is very nearly continuous.
+
+**A trap worth recording.** An early comparison of four families "proved" the
+font made no difference. It proved nothing: this machine has exactly ONE font
+with a MATH table, so three of the four silently resolved to the same fallback.
+`document.fonts.check()` returns true for fonts that are not installed. Measure
+a nonsense font name as a control — every fallback returns the identical width.
+
+**The decision: do not embed a math font.** Measured costs, all with the MATH
+table intact and OFL-licensed (which matters, since a font would ship inside
+every user's file):
+
+| | practical subset | one deck | full |
+|---|---|---|---|
+| Noto Sans Math | 22KB | 5KB | 264KB |
+| STIX Two Math | 58KB | 8KB | 539KB |
+
+22KB on every saved deck forever, to close a hairline in one glyph that most
+decks never use, is out of proportion. Embedding was verified NOT to fix it
+anyway on its own — an embedded subset renders identically to the same font
+installed; only *changing* the font helps.
+
+**What we did instead** (`.bento-el math`, styles.css): name real math fonts
+ahead of the generic `math` family. That is zero bytes and gets a proper math
+font where the viewer has one. It does NOT fix the radical and does NOT make
+formulas identical across machines — a deck with maths still renders in
+whatever math font the reader owns, which is a real gap against "the file is
+the software", left open deliberately.
+
+**If it is ever worth fixing properly**, two routes, in cost order: embed
+Noto Sans Math (22KB, best join of the fonts tested, but sans-serif, so
+formulas stop looking like TeX); or stop letting the browser paint the radical
+at all — post-process temml's `<msqrt>` into a stretchy `√` plus a bar we draw
+ourselves, which is what KaTeX does and is the only route that is exact.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5440,53 +5440,62 @@ asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
 
-## 2026-08-25 — the square root: it was the font we chose, and we un-chose it
+## 2026-08-25 — the square root: a Chromium regression, not ours and not the font
 
-**The symptom.** In the starter deck's quadratic formula, the radical's hook did
-not meet its overbar: a visible step where the two should form one stroke.
+**The symptom.** In a formula, the radical's hook does not meet its overbar —
+a visible step where the two should be one stroke.
 
-**The cause was ours, and it was recent.** A commit earlier the same day added
-`.bento-el math { font-family: 'STIX Two Math', 'Cambria Math', … , math }`,
-meaning to improve formula rendering by preferring a real math font over the
-generic `math` family. On macOS that selects STIX Two Math — and STIX is the
-one face that renders this join badly. Tested across nine variants, STIX was
-the ONLY one showing the break: the browser's default face, three fonts with
-patched MATH constants, and a hand-built radical all join cleanly, in a bare
-root, inside a fraction, and in the deck's exact markup.
+**The answer, after a long and badly-run investigation: it is the browser.**
 
-The fix is the revert: no `font-family` on `math` at all. Verified by geometry
-rather than by eye — the deck's radical now measures 204.6x55.2, identical to
-the generic default and distinct from STIX's 236.9x63.1.
+| engine | radical |
+|---|---|
+| Chromium 148 | perfect |
+| Chromium 151 | broken |
 
-**What this cost, and the lesson.** Roughly six wrong conclusions were reported
-before the right one, every single one from an instrument that lied:
+Same machine, same fonts, same device pixel ratio, same markup. Every font
+tested breaks in 151 and every one is clean in 148: the generic `math` family,
+STIX Two Math explicitly, four STIX variants with patched MATH constants, an
+embedded Noto Sans Math, a non-math serif, and a hand-built radical made from a
+stretchy operator plus a CSS border. Chromium's tracker carries the related
+long-standing note that msqrt "doesn't stretch vertically to enclose all its
+argument".
+
+**Nothing in Bento causes it and nothing in Bento can fix it.** Not the font
+stack, not temml, not our data-sym tagging, not the template round-trip, not
+the stage transform, not `contain: layout style`, not the box-sizing reset, not
+font size, and not the fraction context. All were tested and all are innocent.
+
+**Do not "fix" this by naming a math font.** That was tried and reverted twice.
+On this machine Chrome resolves the generic `math` family to STIX Two Math
+anyway — measured: generic and STIX give byte-identical metrics (711.7x189.7)
+while a nonsense font name gives 614.9x165.8 — so naming STIX changes nothing
+and only costs the deck its typography.
+
+**How this went wrong, which is the part worth keeping.** Six or more confident
+wrong answers were reported before the right one, every one from an instrument
+that lied:
 
 - `document.fonts.check()` returns true for fonts that are NOT installed, so a
-  four-font comparison was three fallbacks wearing different labels. Control:
-  measure a nonsense font name; every fallback returns identical metrics.
-- A "step size" metric compared the bar against the ink just left of it — which
-  is the diagonal, not the flag. It would score a perfect radical as broken,
-  and duly returned an identical 21px for every variant.
-- An SVG foreignObject rasteriser ignores `font-family` entirely. Confirmed by
-  `NoSuchFontXYZ` producing byte-identical output to STIX. Every font
-  conclusion drawn from it was void.
-- Repeated side-by-side visual calls, on strips too small to judge or whose
-  differing metrics put the junctions in different places.
+  four-font comparison was three fallbacks wearing different labels. Control: a
+  nonsense font name — every fallback returns identical metrics.
+- A "step size" metric compared the bar against the ink just left of it, which
+  is the diagonal, not the flag. It scored a perfect radical as broken and
+  returned an identical 21px for every variant.
+- An SVG foreignObject rasteriser ignores `font-family` entirely, proven when
+  `NoSuchFontXYZ` produced byte-identical output to STIX.
+- And the one that cost the most: **every test page was judged in a different
+  browser engine from the one showing the bug.** The reviewer was looking at
+  Chromium 148 in an embedded viewer; the screenshots of the fault came from
+  Chrome 151. Nine test matrices came back "all fine" for that reason alone.
 
-The chain of wrong answers — "not the font", "not fixable", "embed 22KB", "draw
-it ourselves" — all rested on those. The thing that actually settled it was
-rendering the nine candidates large, in one page, and asking a human which
-looked right. **When an instrument keeps producing plausible answers and the
-human keeps disagreeing, stop refining the instrument and hand over the
-artefact.**
+**The lesson: pin the environment before trusting any comparison.** Record the
+engine and version in the test artefact itself. A rendering bug reproduced in
+one engine cannot be investigated in another, and "it looks fine here" is not
+evidence until "here" is named.
 
-**Embedding a math font was costed and is NOT needed.** For the record, since
-the numbers took work to obtain: a practical subset with the MATH table intact
-is 22KB for Noto Sans Math or 58KB for STIX Two Math; the full faces are 264KB
-and 539KB. None of it buys anything here.
-
-**Still true, and left open deliberately:** with no font named, formulas render
-in whatever math face the reader's OS supplies, so a deck with maths does not
-look identical on every machine. That is a real gap against "the file is the
-software" — but closing it means embedding a font, and the one font we know
-renders this glyph badly is the one macOS would have supplied.
+**Status: accepted, unfixed, not ours.** Readers on affected Chromium versions
+see a small step in square roots. If it becomes worth working around, the only
+route that bypasses the engine's radical painting is drawing the hook and bar
+ourselves as one SVG path — but note that even the hand-built approximation
+tested here still showed problems in 151, so that would need verifying in the
+affected engine first.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5486,13 +5486,15 @@ decks never use, is out of proportion. Embedding was verified NOT to fix it
 anyway on its own — an embedded subset renders identically to the same font
 installed; only *changing* the font helps.
 
-**What we do instead: nothing — deliberately.** Naming real math fonts ahead
-of the generic family was tried and REVERTED. On macOS it selects STIX Two
-Math, and STIX is the face that notches; the browser's own default joins the
-hook to the overbar cleanly. Measured side by side at 300px, with each
-junction positioned from its own measured box so the comparison is fair.
-Preferring a "proper" math font made the most visible glyph in a formula
-worse, which is the opposite of the intent.
+**What we do instead: nothing — the notch is not fixable from here.** Naming
+real math fonts ahead of the generic family was tried and REVERTED, but not
+because reverting fixes anything: rendered through the app at 150px, the
+default face steps too. BOTH faces available on a stock Mac show it. The
+revert simply restores the prior behaviour rather than swapping one notching
+font for another and changing the typography as a side effect.
+
+Of the fonts tested, only Noto Sans Math joins cleanly — and it is not
+installed anywhere by default, so using it means embedding it.
 
 So `math` is left alone. Formulas still render in whatever face the reader's
 OS supplies, and still differ between machines — a real gap against "the file
@@ -5500,8 +5502,20 @@ is the software", left open deliberately because closing it costs 22KB on
 every saved deck (see the table above) to fix a hairline most decks never
 show.
 
-**If it is ever worth fixing properly**, two routes, in cost order: embed
-Noto Sans Math (22KB, best join of the fonts tested, but sans-serif, so
-formulas stop looking like TeX); or stop letting the browser paint the radical
-at all — post-process temml's `<msqrt>` into a stretchy `√` plus a bar we draw
-ourselves, which is what KaTeX does and is the only route that is exact.
+**If it is ever worth fixing properly**, three routes, in cost order. Keep
+radicals out of the showcase deck, so the one glyph Chromium renders poorly is
+not the flagship's centrepiece (zero bytes, does not fix anything for authors).
+Embed Noto Sans Math (22KB, the only face tested that joins cleanly, but
+sans-serif, so formulas stop looking like TeX). Or stop letting the browser
+paint the radical at all — post-process temml's `<msqrt>` into a stretchy `√`
+plus a bar we draw ourselves, which is what KaTeX does and is the only route
+that is exact for every font.
+
+**A note on how this was investigated, because it went badly.** Four separate
+visual calls on this junction were wrong before one was right: a clone the CSS
+rule never applied to, a four-font comparison where three resolved to the same
+fallback, and twice judging a "clean join" from strips whose differing metrics
+put the junctions in different places. Eyeballing two renders side by side is
+not a measurement when the two things being compared are not positioned
+identically. The reliable check is to render through the app's own pipeline,
+large, and look at the deck's own element.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5440,102 +5440,53 @@ asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
 
-## 2026-08-25 — no embedded math font, and why the square root looks the way it does
+## 2026-08-25 — the square root: it was the font we chose, and we un-chose it
 
-**The symptom.** In a formula, the radical's hook does not quite meet its
-overbar: at large sizes there is a visible step where the two should form one
-stroke. Reported against the starter deck's quadratic formula.
+**The symptom.** In the starter deck's quadratic formula, the radical's hook did
+not meet its overbar: a visible step where the two should form one stroke.
 
-**What it is NOT**, each checked rather than reasoned about:
+**The cause was ours, and it was recent.** A commit earlier the same day added
+`.bento-el math { font-family: 'STIX Two Math', 'Cambria Math', … , math }`,
+meaning to improve formula rendering by preferring a real math font over the
+generic `math` family. On macOS that selects STIX Two Math — and STIX is the
+one face that renders this join badly. Tested across nine variants, STIX was
+the ONLY one showing the break: the browser's default face, three fonts with
+patched MATH constants, and a hand-built radical all join cleanly, in a bare
+root, inside a fraction, and in the deck's exact markup.
 
-- Not the morph. At rest the radical carries no inline colour, transform or
-  animation state.
-- Not temml's missing stylesheet. Temml ships CSS we never import, which sets
-  `math { line-height: normal; font-style: normal; … }` — but those computed
-  values are already correct via the UA stylesheet, and applying temml's resets
-  renders identically.
-- Not reachable from CSS. `border-top` is `0px` on every node in the subtree and
-  there is no `::before`; Chromium paints the radical rule internally as part of
-  MathML layout. There is no handle to move it.
-- Not about stretching. `√x`, `√(b−4)` and `√(b²−4)` all show it, so it is not
-  tall content forcing a stretched glyph.
+The fix is the revert: no `font-family` on `math` at all. Verified by geometry
+rather than by eye — the deck's radical now measures 204.6x55.2, identical to
+the generic default and distinct from STIX's 236.9x63.1.
 
-**What it IS.** The rule's position comes from the font's MATH constants
-(`RadicalRuleThickness`, `RadicalVerticalGap`, `RadicalExtraAscender`) versus
-where the stretched glyph's own top flag lands, and Chromium's arithmetic does
-not reconcile the two. **It therefore varies by font** — magnified side by side,
-STIX Two Math shows a clear notch and Noto Sans Math is very nearly continuous.
+**What this cost, and the lesson.** Roughly six wrong conclusions were reported
+before the right one, every single one from an instrument that lied:
 
-**A trap worth recording.** An early comparison of four families "proved" the
-font made no difference. It proved nothing: this machine has exactly ONE font
-with a MATH table, so three of the four silently resolved to the same fallback.
-`document.fonts.check()` returns true for fonts that are not installed. Measure
-a nonsense font name as a control — every fallback returns the identical width.
+- `document.fonts.check()` returns true for fonts that are NOT installed, so a
+  four-font comparison was three fallbacks wearing different labels. Control:
+  measure a nonsense font name; every fallback returns identical metrics.
+- A "step size" metric compared the bar against the ink just left of it — which
+  is the diagonal, not the flag. It would score a perfect radical as broken,
+  and duly returned an identical 21px for every variant.
+- An SVG foreignObject rasteriser ignores `font-family` entirely. Confirmed by
+  `NoSuchFontXYZ` producing byte-identical output to STIX. Every font
+  conclusion drawn from it was void.
+- Repeated side-by-side visual calls, on strips too small to judge or whose
+  differing metrics put the junctions in different places.
 
-**The decision: do not embed a math font.** Measured costs, all with the MATH
-table intact and OFL-licensed (which matters, since a font would ship inside
-every user's file):
+The chain of wrong answers — "not the font", "not fixable", "embed 22KB", "draw
+it ourselves" — all rested on those. The thing that actually settled it was
+rendering the nine candidates large, in one page, and asking a human which
+looked right. **When an instrument keeps producing plausible answers and the
+human keeps disagreeing, stop refining the instrument and hand over the
+artefact.**
 
-| | practical subset | one deck | full |
-|---|---|---|---|
-| Noto Sans Math | 22KB | 5KB | 264KB |
-| STIX Two Math | 58KB | 8KB | 539KB |
+**Embedding a math font was costed and is NOT needed.** For the record, since
+the numbers took work to obtain: a practical subset with the MATH table intact
+is 22KB for Noto Sans Math or 58KB for STIX Two Math; the full faces are 264KB
+and 539KB. None of it buys anything here.
 
-22KB on every saved deck forever, to close a hairline in one glyph that most
-decks never use, is out of proportion. Embedding was verified NOT to fix it
-anyway on its own — an embedded subset renders identically to the same font
-installed; only *changing* the font helps.
-
-**What we do instead: nothing — the notch is not fixable from here.** Naming
-real math fonts ahead of the generic family was tried and REVERTED, but not
-because reverting fixes anything: rendered through the app at 150px, the
-default face steps too. BOTH faces available on a stock Mac show it. The
-revert simply restores the prior behaviour rather than swapping one notching
-font for another and changing the typography as a side effect.
-
-Of the fonts tested, Noto Sans Math *appeared* to join cleanly — but that
-reading is not trustworthy, see the note on method below. It is also installed
-nowhere by default, so using it would mean embedding it.
-
-**Ruled out by measurement, not by eye:**
-
-- **Our layout.** The rule-plus-gap to radical-height ratio is 0.1449 both
-  inside the app and in an isolated render of the identical markup. temml, the
-  data-sym tagging, our CSS, display style and the fraction context all leave
-  the radical's geometry untouched.
-- **The stage scale.** Both the editor canvas and Reveal render the slide and
-  then apply a fractional `transform: scale()`, which was the last plausible
-  app-side cause — a resampled hairline would explain a step exactly. It is not
-  that: the artefact is unchanged at 100% and 200% editor zoom.
-
-What remains is Chromium's own MathML radical painting, which we cannot reach.
-
-So `math` is left alone. Formulas still render in whatever face the reader's
-OS supplies, and still differ between machines — a real gap against "the file
-is the software", left open deliberately because closing it costs 22KB on
-every saved deck (see the table above) to fix a hairline most decks never
-show.
-
-**If it is ever worth fixing properly**, three routes, in cost order. Keep
-radicals out of the showcase deck, so the one glyph Chromium renders poorly is
-not the flagship's centrepiece (zero bytes, does not fix anything for authors).
-Embed Noto Sans Math (22KB, the only face tested that joins cleanly, but
-sans-serif, so formulas stop looking like TeX). Or stop letting the browser
-paint the radical at all — post-process temml's `<msqrt>` into a stretchy `√`
-plus a bar we draw ourselves, which is what KaTeX does and is the only route
-that is exact for every font.
-
-**A note on how this was investigated, because it went badly.** Repeated
-visual calls on this junction were wrong: a clone the CSS rule never applied
-to; a four-font comparison where three faces silently resolved to the same
-fallback; and several "that one looks clean" verdicts on strips too small, or
-whose differing metrics put the junctions in different places. The likeliest
-reading of the whole episode is that the step is present in every context and
-most of the "clean" observations were simply unreliable.
-
-Two lessons worth more than the finding. Comparing two renders side by side is
-not a measurement unless the compared things are positioned identically and
-large enough to judge — and `document.fonts.check()` will happily report a
-font that is not installed, so always measure a nonsense font name as a
-control. Where a human can see the artefact and the tooling keeps producing
-plausible-but-wrong verdicts, hand them the artefact and let them look.
+**Still true, and left open deliberately:** with no font named, formulas render
+in whatever math face the reader's OS supplies, so a deck with maths does not
+look identical on every machine. That is a real gap against "the file is the
+software" — but closing it means embedding a font, and the one font we know
+renders this glyph badly is the one macOS would have supplied.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5440,40 +5440,46 @@ asks the release server for a signed manifest and sends nothing about you or
 this document — no ids, no telemetry." Live collaboration is network too, but
 it is network the reader started.
 
-## 2026-08-25 — the square root: a Chromium regression, not ours and not the font
+## 2026-08-25 — the square root: STIX draws it short, and Chrome picks STIX
 
-**The symptom.** In a formula, the radical's hook does not meet its overbar —
-a visible step where the two should be one stroke.
+**The symptom.** The radical's hook stops short of its overbar, leaving a step
+where the two should be one stroke.
 
-**The answer, after a long and badly-run investigation: it is the browser.**
+**The cause.** Chromium draws the square-root sign short of its own rule when
+the maths font is **STIX Two Math**. Every other candidate joins cleanly — the
+plain serif fallback, Noto Sans Math, four STIX variants with patched MATH
+constants, and a hand-built radical — and STIX breaks in Chromium 148 and 151
+alike, so it is the font, not a version regression.
 
-| engine | radical |
-|---|---|
-| Chromium 148 | perfect |
-| Chromium 151 | broken |
+It reaches our decks because Chrome resolves the GENERIC `math` family to STIX
+on macOS. Measured: generic and STIX return identical metrics (521.9x139.1)
+while the serif fallback returns 450.9x121.6. A deck therefore lands on the one
+bad face without ever naming a font. Other engines resolve `math` differently
+and look correct — the embedded viewer used during this investigation falls
+back to plain serif — which is why the fault appears in Chrome and nowhere else.
 
-Same machine, same fonts, same device pixel ratio, same markup. Every font
-tested breaks in 151 and every one is clean in 148: the generic `math` family,
-STIX Two Math explicitly, four STIX variants with patched MATH constants, an
-embedded Noto Sans Math, a non-math serif, and a hand-built radical made from a
-stretchy operator plus a CSS border. Chromium's tracker carries the related
-long-standing note that msqrt "doesn't stretch vertically to enclose all its
-argument".
+**The fix** (styles.css, two rules):
 
-**Nothing in Bento causes it and nothing in Bento can fix it.** Not the font
-stack, not temml, not our data-sym tagging, not the template round-trip, not
-the stage transform, not `contain: layout style`, not the box-sizing reset, not
-font size, and not the fraction context. All were tested and all are innocent.
+    .bento-el math msqrt   { font-family: 'Cambria Math', 'Latin Modern Math', serif; }
+    .bento-el math msqrt * { font-family: math; }
 
-**Do not "fix" this by naming a math font.** That was tried and reverted twice.
-On this machine Chrome resolves the generic `math` family to STIX Two Math
-anyway — measured: generic and STIX give byte-identical metrics (711.7x189.7)
-while a nonsense font name gives 614.9x165.8 — so naming STIX changes nothing
-and only costs the deck its typography.
+Naming real maths fonts first means this changes nothing except where STIX
+would have been chosen: Windows keeps Cambria Math, a TeX install keeps Latin
+Modern Math, macOS lands on serif. Windows and Linux are unverified, but they
+are unchanged BY CONSTRUCTION rather than by assumption.
 
-**How this went wrong, which is the part worth keeping.** Six or more confident
-wrong answers were reported before the right one, every one from an instrument
-that lied:
+**Why it is scoped to msqrt.** `serif` has no MATH table. Applied to a whole
+formula it stops brackets stretching around a fraction — measured, a stretchy
+`(` collapses from 315px to 94px and no longer encloses its fraction — and
+shrinks the large operators. Scoping to the msqrt box takes only its glyph and
+rule from the fallback; the second rule puts the radicand back so the
+letterforms inside still match the rest of the formula. Verified: brackets
+still stretch to 315px, the sum stays 145.7, the radicand keeps its height, and
+only the msqrt box changes, 139.1 -> 131.6.
+
+**How this went wrong, which outlived the bug.** Six or more confident wrong
+answers were reported before the right one, and every single one came from an
+instrument that lied:
 
 - `document.fonts.check()` returns true for fonts that are NOT installed, so a
   four-font comparison was three fallbacks wearing different labels. Control: a
@@ -5481,21 +5487,18 @@ that lied:
 - A "step size" metric compared the bar against the ink just left of it, which
   is the diagonal, not the flag. It scored a perfect radical as broken and
   returned an identical 21px for every variant.
-- An SVG foreignObject rasteriser ignores `font-family` entirely, proven when
+- An SVG foreignObject rasteriser silently ignores `font-family`, proven when
   `NoSuchFontXYZ` produced byte-identical output to STIX.
-- And the one that cost the most: **every test page was judged in a different
-  browser engine from the one showing the bug.** The reviewer was looking at
-  Chromium 148 in an embedded viewer; the screenshots of the fault came from
-  Chrome 151. Nine test matrices came back "all fine" for that reason alone.
+- And the costliest: **every test page was judged in a different browser engine
+  from the one showing the fault.** The reviewer was reading them in an
+  embedded viewer (Chromium 148, which falls back to serif and looks perfect)
+  while the screenshots of the fault came from Chrome. Nine consecutive
+  matrices came back "all fine", each clearing a suspect that had never been
+  exercised.
 
-**The lesson: pin the environment before trusting any comparison.** Record the
-engine and version in the test artefact itself. A rendering bug reproduced in
-one engine cannot be investigated in another, and "it looks fine here" is not
-evidence until "here" is named.
-
-**Status: accepted, unfixed, not ours.** Readers on affected Chromium versions
-see a small step in square roots. If it becomes worth working around, the only
-route that bypasses the engine's radical painting is drawing the hook and bar
-ourselves as one SVG path — but note that even the hand-built approximation
-tested here still showed problems in 151, so that would need verifying in the
-affected engine first.
+**The rules worth keeping.** Pin and record the engine, version and resolved
+font in the test artefact itself — "it looks fine here" is worthless until
+"here" is named. Give every font probe a nonsense-name control. And when the
+tooling keeps producing plausible answers that a human keeps rejecting, stop
+refining the tooling and hand the human the artefact: a nine-row page answered
+in one exchange what hours of measurement had not.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5493,8 +5493,22 @@ default face steps too. BOTH faces available on a stock Mac show it. The
 revert simply restores the prior behaviour rather than swapping one notching
 font for another and changing the typography as a side effect.
 
-Of the fonts tested, only Noto Sans Math joins cleanly — and it is not
-installed anywhere by default, so using it means embedding it.
+Of the fonts tested, Noto Sans Math *appeared* to join cleanly — but that
+reading is not trustworthy, see the note on method below. It is also installed
+nowhere by default, so using it would mean embedding it.
+
+**Ruled out by measurement, not by eye:**
+
+- **Our layout.** The rule-plus-gap to radical-height ratio is 0.1449 both
+  inside the app and in an isolated render of the identical markup. temml, the
+  data-sym tagging, our CSS, display style and the fraction context all leave
+  the radical's geometry untouched.
+- **The stage scale.** Both the editor canvas and Reveal render the slide and
+  then apply a fractional `transform: scale()`, which was the last plausible
+  app-side cause — a resampled hairline would explain a step exactly. It is not
+  that: the artefact is unchanged at 100% and 200% editor zoom.
+
+What remains is Chromium's own MathML radical painting, which we cannot reach.
 
 So `math` is left alone. Formulas still render in whatever face the reader's
 OS supplies, and still differ between machines — a real gap against "the file
@@ -5511,11 +5525,17 @@ paint the radical at all — post-process temml's `<msqrt>` into a stretchy `√
 plus a bar we draw ourselves, which is what KaTeX does and is the only route
 that is exact for every font.
 
-**A note on how this was investigated, because it went badly.** Four separate
-visual calls on this junction were wrong before one was right: a clone the CSS
-rule never applied to, a four-font comparison where three resolved to the same
-fallback, and twice judging a "clean join" from strips whose differing metrics
-put the junctions in different places. Eyeballing two renders side by side is
-not a measurement when the two things being compared are not positioned
-identically. The reliable check is to render through the app's own pipeline,
-large, and look at the deck's own element.
+**A note on how this was investigated, because it went badly.** Repeated
+visual calls on this junction were wrong: a clone the CSS rule never applied
+to; a four-font comparison where three faces silently resolved to the same
+fallback; and several "that one looks clean" verdicts on strips too small, or
+whose differing metrics put the junctions in different places. The likeliest
+reading of the whole episode is that the step is present in every context and
+most of the "clean" observations were simply unreliable.
+
+Two lessons worth more than the finding. Comparing two renders side by side is
+not a measurement unless the compared things are positioned identically and
+large enough to judge — and `document.fonts.check()` will happily report a
+font that is not installed, so always measure a nonsense font name as a
+control. Where a human can see the artefact and the tooling keeps producing
+plausible-but-wrong verdicts, hand them the artefact and let them look.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5513,7 +5513,7 @@ to `msqrt`, contents restored to `math`. Note also that the stack matters: on
 Windows `'Cambria Math', serif` selects what generic `math` already selects, so
 that variant is a no-op there.
 
-`slides/dist-single/radical-windows-test.html` is the cross-platform test rig:
+`slides/probe/radical-join.html` is the cross-platform test rig:
 one row per candidate font applying exactly the rule above, each row reporting
 whether the font actually resolved, and a paste-back block carrying platform,
 UA and DPR.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5486,12 +5486,19 @@ decks never use, is out of proportion. Embedding was verified NOT to fix it
 anyway on its own — an embedded subset renders identically to the same font
 installed; only *changing* the font helps.
 
-**What we did instead** (`.bento-el math`, styles.css): name real math fonts
-ahead of the generic `math` family. That is zero bytes and gets a proper math
-font where the viewer has one. It does NOT fix the radical and does NOT make
-formulas identical across machines — a deck with maths still renders in
-whatever math font the reader owns, which is a real gap against "the file is
-the software", left open deliberately.
+**What we do instead: nothing — deliberately.** Naming real math fonts ahead
+of the generic family was tried and REVERTED. On macOS it selects STIX Two
+Math, and STIX is the face that notches; the browser's own default joins the
+hook to the overbar cleanly. Measured side by side at 300px, with each
+junction positioned from its own measured box so the comparison is fair.
+Preferring a "proper" math font made the most visible glyph in a formula
+worse, which is the opposite of the intent.
+
+So `math` is left alone. Formulas still render in whatever face the reader's
+OS supplies, and still differ between machines — a real gap against "the file
+is the software", left open deliberately because closing it costs 22KB on
+every saved deck (see the table above) to fix a hairline most decks never
+show.
 
 **If it is ever worth fixing properly**, two routes, in cost order: embed
 Noto Sans Math (22KB, best join of the fonts tested, but sans-serif, so

--- a/scripts/test-codediff.ts
+++ b/scripts/test-codediff.ts
@@ -148,5 +148,19 @@ const toksOf = (states: State[] | undefined) =>
     inserts.every((v: string) => !/\S/.test(v)))
 }
 
+// 9. A WORD THAT CHANGES CLASS KEEPS ITS IDENTITY — `render(` is classed a
+//    call, `.then(render)` a plain reference. The tokenizer flips the class
+//    exactly when a refactor changes style, so keying identity on the class
+//    made the word die and respawn instead of travelling. The audience pairs
+//    tokens by their glyphs; the key buckets call/identifier together and
+//    rendering still colours by the true class.
+{
+  const states = new HeckelDiff(codeDoc(['render(deck)\nship()', 'queue(render)\nship()'])).computeDiffs('g')
+  const t0 = toksOf(states.get(0)), t1 = toksOf(states.get(1))
+  const a = t0.find((t: any) => t.content === 'render')
+  const b = t1.find((t: any) => t.content === 'render')
+  check('call -> plain reference keeps identity', !!a && !!b && a.morphId() === b.morphId())
+}
+
 console.log(FAILS.length ? `\n${FAILS.length} FAILED` : '\nall passed')
 process.exit(FAILS.length ? 1 : 0)

--- a/slides/probe/README.md
+++ b/slides/probe/README.md
@@ -1,0 +1,23 @@
+# slides/probe
+
+Manual browser rigs. Not run by CI — these exist for defects that only a
+human eye, on a specific engine and platform, can judge.
+
+## radical-join.html
+
+The square root's hook not meeting its overbar. Open it directly (no server
+needed) on each platform you care about.
+
+One row per candidate font, each applying the fix in its real shape — the
+font on `msqrt` only, contents put back to `math`. Every row reports whether
+that font ACTUALLY resolved, by measuring `√` against a font name that cannot
+exist: a named font that silently fell back is not a test of that font, and
+believing otherwise cost this investigation nine "all fine" test matrices.
+
+Judge the point where the diagonal meets the bar. Check 150% and 200% zoom
+too — the mismatch is sub-pixel, so zoom can change the verdict.
+
+Known results (2026-08-28): macOS/Chrome picks STIX Two Math and breaks;
+Windows/Chrome picks Cambria Math and breaks the same way; forcing serif is
+clean on macOS and still broken (smaller) on Windows as Times New Roman.
+Background in docs/DECISIONS.md, 2026-08-25.

--- a/slides/probe/radical-join.html
+++ b/slides/probe/radical-join.html
@@ -1,0 +1,133 @@
+<!doctype html><html><head><meta charset="utf-8">
+<title>Bento — radical join test (run me on Windows)</title>
+<style>
+ body{background:#fff;color:#111;margin:0;padding:24px 28px 60px;
+      font-family:system-ui,'Segoe UI',sans-serif}
+ h1{font-size:16px;margin:0 0 6px}
+ .intro{font-size:13px;color:#444;max-width:80ch;line-height:1.55;margin:0 0 4px}
+ .intro b{color:#000}
+ #env{font-size:12px;font-family:ui-monospace,Consolas,monospace;color:#555;
+      background:#F4F6F8;border:1px solid #DDE3EA;border-radius:6px;
+      padding:8px 10px;margin:14px 0 20px;white-space:pre-wrap}
+ .row{border-top:1px solid #E4E9EF;padding:14px 0;display:flex;align-items:center;gap:18px}
+ .meta{width:250px;flex:none;text-align:right;line-height:1.4}
+ .name{font-size:12px;font-weight:700;font-family:ui-monospace,Consolas,monospace}
+ .got{font-size:11px;margin-top:3px}
+ .yes{color:#1B7F4B}.no{color:#B3261E}.gen{color:#8A6D00}
+ .art{flex:1;min-width:0}
+ math{font-size:74px;line-height:1.5}
+ textarea{width:100%;box-sizing:border-box;height:150px;margin-top:10px;
+   font-family:ui-monospace,Consolas,monospace;font-size:12px;padding:10px;
+   border:1px solid #C9D2DC;border-radius:6px}
+ .foot{border-top:2px solid #111;margin-top:26px;padding-top:16px}
+ kbd{background:#EEF1F5;border:1px solid #CCD4DE;border-radius:4px;padding:1px 5px;font-size:11px}
+</style></head><body>
+
+<h1>Radical join test — which font joins the bar cleanly?</h1>
+<p class="intro">Each row applies one font to <code>msqrt</code> only (contents stay in the
+maths font), which is the exact shape of the fix. <b>Look at the point where the diagonal of the
+√ meets the horizontal bar.</b> A good row has one unbroken stroke; a bad row has a step, a gap,
+or a doubled edge there. Row 1 is the control — it's what Bento ships today.</p>
+<p class="intro">Please also try it at <kbd>Ctrl</kbd>+<kbd>+</kbd> zoom 150% and 200%: this
+defect is a sub-pixel rounding mismatch, so zoom can change the verdict, and that matters.</p>
+<p class="intro"><b>Ignore any row marked “font missing”</b> — it silently fell back and tells
+us nothing.</p>
+
+<div id="env"></div>
+<div id="rows"></div>
+
+<div class="foot">
+  <b style="font-size:13px">Paste this back:</b>
+  <p class="intro">Type the row numbers that join cleanly, then copy the whole box.</p>
+  <textarea id="report"></textarea>
+</div>
+
+<script>
+const CANDIDATES = [
+  ['math',                        'CONTROL — what ships today'],
+  ['serif',                       'generic serif'],
+  ['"Times New Roman", serif',    'Windows default serif'],
+  ['Georgia, serif',              ''],
+  ['"Palatino Linotype", serif',  'Windows'],
+  ['Cambria, serif',              'the TEXT face, not Cambria Math'],
+  ['"Cambria Math"',              'Windows maths font'],
+  ['"STIX Two Math"',             'what macOS picks for generic math'],
+  ['"Latin Modern Math"',         'usually absent unless TeX installed'],
+  ['"DejaVu Serif"',              'usually Linux'],
+  ['"Segoe UI Symbol"',           'Windows'],
+  ['sans-serif',                  'generic sans'],
+  ['Arial',                       ''],
+  ['Consolas, monospace',         '']
+];
+
+// Does the font actually supply a radical glyph? Compare the width of U+221A
+// against a font name that cannot exist. Identical width == it fell back.
+// (document.fonts.check() reports true for fonts that are not installed.)
+function radicalResolves(stack){
+  const mk = (ff) => {
+    const s = document.createElement('span');
+    s.textContent = '√';
+    s.style.cssText = 'position:absolute;left:-9999px;top:0;font-size:200px;'
+                    + 'white-space:pre;font-family:' + ff;
+    document.body.appendChild(s);
+    const w = s.getBoundingClientRect().width; s.remove(); return w;
+  };
+  const bogus = mk('NoSuchFontXYZ123');
+  return Math.abs(mk(stack) - bogus) > 0.5;
+}
+const isGeneric = (s) => /^(serif|sans-serif|monospace|math|system-ui)$/.test(s.trim());
+
+const FORMULA = `<math display="block"><mrow>
+  <mi>x</mi><mo>=</mo>
+  <mfrac>
+    <mrow><mo>−</mo><mi>b</mi><mo>±</mo>
+      <msqrt><mrow><msup><mi>b</mi><mn>2</mn></msup>
+        <mo>−</mo><mn>4</mn><mi>a</mi><mi>c</mi></mrow></msqrt>
+    </mrow>
+    <mrow><mn>2</mn><mi>a</mi></mrow>
+  </mfrac>
+</mrow></math>`;
+
+const host = document.getElementById('rows');
+const css  = document.createElement('style');
+let sheet = '', lines = [];
+
+CANDIDATES.forEach(([stack, note], i) => {
+  const n = i + 1, cls = 'rad' + n;
+  // the fix, exactly as it would ship: font on msqrt, contents back to math
+  sheet += `.${cls} msqrt{font-family:${stack}}
+            .${cls} msqrt *{font-family:math}\n`;
+
+  let state, cl;
+  if (isGeneric(stack))            { state = 'generic family';  cl = 'gen'; }
+  else if (radicalResolves(stack)) { state = 'font present ✓'; cl = 'yes'; }
+  else                             { state = 'font missing ✗ (ignore row)'; cl = 'no'; }
+
+  const row = document.createElement('div');
+  row.className = 'row';
+  row.innerHTML = `<div class="meta">
+      <div class="name">${n}. ${stack.replace(/"/g,'')}</div>
+      <div class="got ${cl}">${state}${note ? ' · ' + note : ''}</div>
+    </div><div class="art ${cls}">${FORMULA}</div>`;
+  host.appendChild(row);
+  lines.push(`${String(n).padStart(2)}. ${state.padEnd(26)} ${stack}`);
+});
+css.textContent = sheet;
+document.head.appendChild(css);
+
+function env(){
+  return 'platform : ' + navigator.platform
+    + '\nUA       : ' + navigator.userAgent
+    + '\nDPR      : ' + window.devicePixelRatio
+    + '\nviewport : ' + window.innerWidth + 'x' + window.innerHeight;
+}
+document.getElementById('env').textContent = env();
+document.getElementById('report').value =
+  'RADICAL JOIN TEST\n' + env()
+  + '\n\nrows that JOIN CLEANLY (100% zoom): \nrows that JOIN CLEANLY (200% zoom): \nnotes: \n\n'
+  + lines.join('\n');
+addEventListener('resize', () => {
+  document.getElementById('env').textContent = env();
+});
+</script>
+</body></html>

--- a/slides/src/code.ts
+++ b/slides/src/code.ts
@@ -72,7 +72,13 @@ function diffFor(doc: BentoDoc, morphKey: string) {
  */
 export function renderCodeInto(pre: HTMLElement, el: CodeElement, doc: BentoDoc): boolean {
   const morphKey = el.morphId ?? el.id
-  const slideIdx = doc.slides.findIndex((s) => s.elements.some((e) => e.id === el.id))
+  // REFERENCE equality, not id: the duplicate-a-slide idiom gives every twin
+  // the SAME element id across slides (that is the default morph pairing), so
+  // an id lookup finds the first twin and every later slide would render the
+  // first slide's tokens — same text, zero travel. The element handed to the
+  // renderer is the model object itself, so identity is exact. (The original
+  // implementation got this right; a rewrite briefly did not.)
+  const slideIdx = doc.slides.findIndex((s) => (s.elements as unknown[]).includes(el))
   if (slideIdx < 0) return false
   const states = diffFor(doc, morphKey)
   const slideStates = states.get(slideIdx)

--- a/slides/src/diff.ts
+++ b/slides/src/diff.ts
@@ -47,9 +47,17 @@ export class Token {
   }
 
   key(): string {
+    // Calls and plain identifiers share an identity bucket. The tokenizer
+    // classes a word by its role — `render(` is a call, `.then(render)` a
+    // plain reference — so the SAME word flips class exactly when a refactor
+    // changes style (callback -> point-free -> await). Keying on the class
+    // made such a word die and respawn instead of travelling; the audience
+    // pairs tokens by their glyphs, not their colour, so identity does too.
+    // Rendering still uses the true class — a paired token recolours at rest.
+    const buckets = this.scopes.map((sc) => (sc === 'f' ? 'x' : sc))
     const json = {
       content: this.content,
-      scopes: this.scopes,
+      scopes: buckets,
       depth: this.depth()
     }
     return JSON.stringify(json)

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1480,8 +1480,8 @@ function sweepSymbolSpans(section: HTMLElement) {
 }
 
 const symCache = new Map<string, Map<string, { x: number; y: number }>>()
-/** Scaffolding keys (fraction bars, radicals) present on a slide, by host. */
-const structCache = new Map<string, Set<string>>()
+/** Scaffolding geometry (fraction bars, radicals) per slide, by host. */
+const structCache = new Map<string, Map<string, { x: number; y: number; w: number; h: number }>>()
 const symKey = (idx: number, flipId: string) => `${idx}${flipId}`
 
 /** Measure and cache every formula on a slide that is currently displayed. */
@@ -1495,9 +1495,31 @@ function cacheSlideSymbols(doc: BentoDoc, section: HTMLElement, idx: number) {
     if (!model) continue
     const offsets = symbolOffsets(host, model.w, model.h)
     if (offsets.size) symCache.set(symKey(idx, host.dataset.flipId!), offsets)
-    structCache.set(symKey(idx, host.dataset.flipId!), new Set(
-      Array.from(host.querySelectorAll<HTMLElement>('[data-msx]')).map((n) => n.dataset.msx!)))
+    structCache.set(symKey(idx, host.dataset.flipId!), structGeometry(host, model.w, model.h))
   }
+}
+
+/**
+ * Where a formula's scaffolding sits and how big it is, in model units. Size
+ * matters as much as position: a fraction bar is as wide as its widest side,
+ * so an equation that keeps its outer fraction across a step can still have
+ * that bar change length completely — 14px to 79px across the derivation's
+ * last beat, snapping in one frame while every symbol around it travelled.
+ */
+function structGeometry(host: HTMLElement, modelW: number, modelH: number) {
+  const out = new Map<string, { x: number; y: number; w: number; h: number }>()
+  const box = host.getBoundingClientRect()
+  if (!box.width || !box.height) return out
+  const sx = box.width / Math.max(modelW, 0.01)
+  const sy = box.height / Math.max(modelH, 0.01)
+  for (const node of Array.from(host.querySelectorAll<HTMLElement>('[data-msx]'))) {
+    const r = node.getBoundingClientRect()
+    out.set(node.dataset.msx!, {
+      x: (r.left - box.left) / sx, y: (r.top - box.top) / sy,
+      w: r.width / sx, h: r.height / sy,
+    })
+  }
+  return out
 }
 
 function symbolOffsets(host: HTMLElement, modelW: number, modelH: number): Map<string, { x: number; y: number }> {
@@ -1532,7 +1554,7 @@ function symbolOffsets(host: HTMLElement, modelW: number, modelH: number): Map<s
  */
 function morphMathSymbols(
   fromAt: Map<string, { x: number; y: number }> | undefined,
-  fromStruct: Set<string> | undefined,
+  fromStruct: Map<string, { x: number; y: number; w: number; h: number }> | undefined,
   to: HTMLElement,
   a: SlideElement,
   b: SlideElement,
@@ -1569,18 +1591,41 @@ function morphMathSymbols(
   // setting the box transparent, which leaves every symbol legible and in
   // place with the bars gone. Pinning is what makes it work: leaves inherit
   // colour, so they must carry their own before the box's is animated.
+  const toStruct = structGeometry(to, b.w, b.h)
+  // TWO passes, and the order is load-bearing. Scaffolding nests — a radical
+  // inside a fraction — and anim renders a fromTo's from-state at creation, so
+  // starting the outer box's fade first leaves the inner one inheriting a
+  // transparent colour at the moment its own ink is read. It then animates
+  // towards transparent and only becomes visible when the tween clears, which
+  // is the pop this is meant to remove, one level down. Read every ink first,
+  // against untouched colours, then start the tweens.
+  const fades: Array<{ box: HTMLElement; ink: string; leaves: HTMLElement[] }> = []
   for (const box of Array.from(to.querySelectorAll<HTMLElement>('[data-msx]'))) {
-    if (fromStruct?.has(box.dataset.msx!)) continue
+    // New scaffolding fades in — and so does scaffolding that SURVIVES but
+    // changes shape, because it cannot travel: transforming a container would
+    // drag its children off their own paths. A bar that merely resizes would
+    // otherwise snap in a single frame while everything inside it glided.
+    const was = fromStruct?.get(box.dataset.msx!)
+    const now = toStruct.get(box.dataset.msx!)
+    const moved = !was || !now
+      || Math.abs(was.x - now.x) > 1 || Math.abs(was.y - now.y) > 1
+      || Math.abs(was.w - now.w) > 1 || Math.abs(was.h - now.h) > 1
+    if (!moved) continue
     // Read the ink from the BOX, not the flip host: the host is the element
     // wrapper and computes to its own colour (black here), while the box
     // inherits the formula's. Fading from the wrong one made the bar arrive
     // as black and snap to white on completion — invisible for the whole fade
     // on a dark slide, which looks exactly like the pop this replaces.
-    const ink = getComputedStyle(box).color
+    fades.push({
+      box,
+      ink: getComputedStyle(box).color,
+      leaves: Array.from(box.querySelectorAll<HTMLElement>('[data-sym]')),
+    })
+  }
+  for (const { box, ink, leaves } of fades) {
     const inkClear = ink.startsWith('rgb(')
       ? ink.replace('rgb(', 'rgba(').replace(')', ', 0)')
       : 'rgba(0, 0, 0, 0)'
-    const leaves = Array.from(box.querySelectorAll<HTMLElement>('[data-sym]'))
     for (const leaf of leaves) leaf.style.color = ink
     anim.fromTo(box, { color: inkClear }, {
       color: ink,

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1475,6 +1475,7 @@ function sweepSymbolSpans(section: HTMLElement) {
     sym.style.opacity = ''
     sym.style.transform = ''
     sym.style.willChange = ''
+    sym.style.color = '' // pinned while a formula's scaffolding fades in
   }
 }
 
@@ -1557,16 +1558,40 @@ function morphMathSymbols(
     })
   })
 
-  // Scaffolding that is new this step fades in IMMEDIATELY, not on the
-  // staggered delay the tokens use. Opacity groups a subtree, so a fraction
-  // fading late would hide the very terms travelling into it — the terms would
-  // vanish and reappear mid-flight, which is precisely the artefact this
-  // engine exists to avoid. Arriving early instead means the bar draws itself
-  // while the numerator is still on its way, and the brief dip at t=0 is over
-  // before anything has moved far.
+  // Scaffolding that is new this step arrives on the SAME beat as the fresh
+  // tokens — but via `color`, never `opacity`.
+  //
+  // A fraction bar and a radical are painted by their box in currentColor, and
+  // opacity groups a whole subtree: fading the box would take the terms
+  // travelling into it along too, hiding them for the first 40% of their
+  // journey and popping them into view mid-flight. Animating colour touches
+  // only what the box itself paints — verified by pinning the leaves and
+  // setting the box transparent, which leaves every symbol legible and in
+  // place with the bars gone. Pinning is what makes it work: leaves inherit
+  // colour, so they must carry their own before the box's is animated.
   for (const box of Array.from(to.querySelectorAll<HTMLElement>('[data-msx]'))) {
     if (fromStruct?.has(box.dataset.msx!)) continue
-    anim.fromTo(box, { opacity: 0 }, { opacity: 1, duration: 0.28, ease: 'power2.out' })
+    // Read the ink from the BOX, not the flip host: the host is the element
+    // wrapper and computes to its own colour (black here), while the box
+    // inherits the formula's. Fading from the wrong one made the bar arrive
+    // as black and snap to white on completion — invisible for the whole fade
+    // on a dark slide, which looks exactly like the pop this replaces.
+    const ink = getComputedStyle(box).color
+    const inkClear = ink.startsWith('rgb(')
+      ? ink.replace('rgb(', 'rgba(').replace(')', ', 0)')
+      : 'rgba(0, 0, 0, 0)'
+    const leaves = Array.from(box.querySelectorAll<HTMLElement>('[data-sym]'))
+    for (const leaf of leaves) leaf.style.color = ink
+    anim.fromTo(box, { color: inkClear }, {
+      color: ink,
+      duration: 0.3,
+      delay: MORPH_DURATION * 0.4,
+      ease: 'power2.out',
+      onComplete() {
+        box.style.color = ''
+        for (const leaf of leaves) leaf.style.color = ''
+      },
+    })
   }
 
   const pairs: Array<{ node: HTMLElement; dx: number; dy: number }> = []

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1612,12 +1612,21 @@ function morphMathSymbols(
     // changes shape, because it cannot travel: transforming a container would
     // drag its children off their own paths. A bar that merely resizes would
     // otherwise snap in a single frame while everything inside it glided.
+    // Absent, or so different it is plainly not the same bar. The key is
+    // positional (tag#occurrence), not semantic, so it can claim an identity
+    // that does not exist: across the derivation's last beat mfrac#0 is
+    // `b OVER 2a` on one side and `-b±√(b²-4ac) OVER 2a` on the other. Those
+    // are two different bars, and stretching one into the other would animate
+    // a fiction. Judge by how much changed instead, generously enough that a
+    // bar which genuinely persists and merely shifts a pixel or two is left
+    // alone rather than blinking for no reason.
     const was = fromStruct?.get(box.dataset.msx!)
     const now = toStruct.get(box.dataset.msx!)
-    const moved = !was || !now
-      || Math.abs(was.x - now.x) > 1 || Math.abs(was.y - now.y) > 1
-      || Math.abs(was.w - now.w) > 1 || Math.abs(was.h - now.h) > 1
-    if (!moved) continue
+    const resized = (x: number, y: number) => Math.abs(x - y) > Math.max(x, y, 1) * 0.15
+    const changed = !was || !now
+      || Math.abs(was.x - now.x) > 6 || Math.abs(was.y - now.y) > 6
+      || resized(was.w, now.w) || resized(was.h, now.h)
+    if (!changed) continue
     // Read the ink from the BOX, not the flip host: the host is the element
     // wrapper and computes to its own colour (black here), while the box
     // inherits the formula's. Fading from the wrong one made the bar arrive

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -951,6 +951,7 @@ export function startPresentation(
       // a tween killed during its delay would otherwise leave the element
       // stuck at its "from" state (invisible) for every future visit.
       anim.killTweensOf(from.querySelectorAll('.bento-el'))
+      sweepSymbolSpans(from)
       const fromSlide = doc.slides[fromIdx]
       for (const el of fromSlide?.elements ?? []) {
         const node = from.querySelector<HTMLElement>(`[data-el-id="${CSS.escape(el.id)}"]`)
@@ -963,6 +964,9 @@ export function startPresentation(
         applyRevealSet(from, null, fromSlide.hover.default)
       }
     }
+    // The incoming section may still carry span state from a PREVIOUS visit
+    // (Reveal keeps sections mounted) — start clean before any fx runs.
+    sweepSymbolSpans(to)
     const forward = toIdx > fromIdx
     // Morph forward into a morph slide, and un-morph when backing out of one.
     const morphing =
@@ -1453,6 +1457,27 @@ function modelByMorphKey(doc: BentoDoc, index: number): Map<string, SlideElement
  * source for where a symbol WAS is a measurement taken while it was visible.
  * Captured on slide entry; read on slide exit.
  */
+/**
+ * Clear runtime inline state from a section's morph symbols. Token and formula
+ * spans carry state no model frame can restore — the symbol morph's transform,
+ * the fresh-token fade's opacity — because applyElementFrame knows elements,
+ * not spans, and the settle guarantee filters to elements with model entries.
+ * An interrupted visit (fast advance, hidden tab, starved render loop) leaves
+ * opacity:0 written inline on spans of a section Reveal keeps MOUNTED, and the
+ * next visit shows code with holes: seen as "confetti() disappeared and came
+ * back after the animations", and reproduced exactly by driving a hidden tab.
+ * Swept on every exit and every entry; the entering morph recreates what it
+ * actually needs.
+ */
+function sweepSymbolSpans(section: HTMLElement) {
+  for (const sym of Array.from(section.querySelectorAll<HTMLElement>('[data-sym]'))) {
+    anim.killTweensOf(sym)
+    sym.style.opacity = ''
+    sym.style.transform = ''
+    sym.style.willChange = ''
+  }
+}
+
 const symCache = new Map<string, Map<string, { x: number; y: number }>>()
 const symKey = (idx: number, flipId: string) => `${idx}${flipId}`
 

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1475,7 +1475,14 @@ function sweepSymbolSpans(section: HTMLElement) {
     sym.style.opacity = ''
     sym.style.transform = ''
     sym.style.willChange = ''
-    sym.style.color = '' // pinned while a formula's scaffolding fades in
+    // Colour is cleared ONLY where the scaffolding fade pinned it. Code tokens
+    // carry their syntax colour as an inline style straight from the renderer,
+    // so clearing colour unconditionally here stripped every highlight in the
+    // deck the first time a slide was swept.
+    if (sym.dataset.inkpin !== undefined) {
+      sym.style.color = ''
+      delete sym.dataset.inkpin
+    }
   }
 }
 
@@ -1626,7 +1633,8 @@ function morphMathSymbols(
     const inkClear = ink.startsWith('rgb(')
       ? ink.replace('rgb(', 'rgba(').replace(')', ', 0)')
       : 'rgba(0, 0, 0, 0)'
-    for (const leaf of leaves) leaf.style.color = ink
+    // Marked, so the slide sweep knows which colours are ours to undo.
+    for (const leaf of leaves) { leaf.style.color = ink; leaf.dataset.inkpin = '' }
     anim.fromTo(box, { color: inkClear }, {
       color: ink,
       duration: 0.3,
@@ -1634,7 +1642,7 @@ function morphMathSymbols(
       ease: 'power2.out',
       onComplete() {
         box.style.color = ''
-        for (const leaf of leaves) leaf.style.color = ''
+        for (const leaf of leaves) { leaf.style.color = ''; delete leaf.dataset.inkpin }
       },
     })
   }

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1470,7 +1470,7 @@ function modelByMorphKey(doc: BentoDoc, index: number): Map<string, SlideElement
  * actually needs.
  */
 function sweepSymbolSpans(section: HTMLElement) {
-  for (const sym of Array.from(section.querySelectorAll<HTMLElement>('[data-sym]'))) {
+  for (const sym of Array.from(section.querySelectorAll<HTMLElement>('[data-sym],[data-msx]'))) {
     anim.killTweensOf(sym)
     sym.style.opacity = ''
     sym.style.transform = ''
@@ -1479,6 +1479,8 @@ function sweepSymbolSpans(section: HTMLElement) {
 }
 
 const symCache = new Map<string, Map<string, { x: number; y: number }>>()
+/** Scaffolding keys (fraction bars, radicals) present on a slide, by host. */
+const structCache = new Map<string, Set<string>>()
 const symKey = (idx: number, flipId: string) => `${idx}${flipId}`
 
 /** Measure and cache every formula on a slide that is currently displayed. */
@@ -1492,6 +1494,8 @@ function cacheSlideSymbols(doc: BentoDoc, section: HTMLElement, idx: number) {
     if (!model) continue
     const offsets = symbolOffsets(host, model.w, model.h)
     if (offsets.size) symCache.set(symKey(idx, host.dataset.flipId!), offsets)
+    structCache.set(symKey(idx, host.dataset.flipId!), new Set(
+      Array.from(host.querySelectorAll<HTMLElement>('[data-msx]')).map((n) => n.dataset.msx!)))
   }
 }
 
@@ -1527,6 +1531,7 @@ function symbolOffsets(host: HTMLElement, modelW: number, modelH: number): Map<s
  */
 function morphMathSymbols(
   fromAt: Map<string, { x: number; y: number }> | undefined,
+  fromStruct: Set<string> | undefined,
   to: HTMLElement,
   a: SlideElement,
   b: SlideElement,
@@ -1551,6 +1556,18 @@ function morphMathSymbols(
       ease: 'power2.out',
     })
   })
+
+  // Scaffolding that is new this step fades in IMMEDIATELY, not on the
+  // staggered delay the tokens use. Opacity groups a subtree, so a fraction
+  // fading late would hide the very terms travelling into it — the terms would
+  // vanish and reappear mid-flight, which is precisely the artefact this
+  // engine exists to avoid. Arriving early instead means the bar draws itself
+  // while the numerator is still on its way, and the brief dip at t=0 is over
+  // before anything has moved far.
+  for (const box of Array.from(to.querySelectorAll<HTMLElement>('[data-msx]'))) {
+    if (fromStruct?.has(box.dataset.msx!)) continue
+    anim.fromTo(box, { opacity: 0 }, { opacity: 1, duration: 0.28, ease: 'power2.out' })
+  }
 
   const pairs: Array<{ node: HTMLElement; dx: number; dy: number }> = []
   for (const sym of Array.from(to.querySelectorAll<HTMLElement>('[data-sym]'))) {
@@ -1703,7 +1720,7 @@ function runMorph(
     const a = fromModel.get(id)
     const b = toModel.get(id)
     if (!a || !b) continue
-    morphMathSymbols(symCache.get(symKey(fromIdx, id)), to, a, b)
+    morphMathSymbols(symCache.get(symKey(fromIdx, id)), structCache.get(symKey(fromIdx, id)), to, a, b)
   }
 
   // Styles morph straight from the model — exact values, no DOM sniffing.

--- a/slides/src/present.ts
+++ b/slides/src/present.ts
@@ -1703,8 +1703,9 @@ function runMorph(
   // frames are in the doc), so the outgoing section's Reveal styling is
   // irrelevant. Each matched node animates from the from-slide's frame to its
   // own via translate+scale about the top-left corner (scale mode like
-  // PowerPoint: text scales instead of reflowing mid-morph). Rotating morphs
-  // pivot slightly differently than center-origin — rare and acceptable.
+  // PowerPoint: text scales instead of reflowing mid-morph), while rotation
+  // pivots about the element's centre so the finished frame is identical to
+  // the one applyElementFrame writes at rest.
   for (const node of matchedTo) {
     const id = node.dataset.flipId!
     const a = fromModel.get(id)
@@ -1724,10 +1725,21 @@ function runMorph(
         const w = a.w + (b.w - a.w) * p
         const h = a.h + (b.h - a.h) * p
         const r = (a.rotation ?? 0) + ((b.rotation ?? 0) - (a.rotation ?? 0)) * p
+        // Rotate about the element's own CENTRE, spelled out around an origin
+        // of 0 0 rather than by moving the origin. Position and scale want the
+        // top-left (PowerPoint scale mode), but the resting frame that
+        // applyElementFrame writes — a plain `rotate()` with the default centre
+        // origin — must be exactly what p=1 lands on, or a rotated element
+        // snaps the instant the tween completes and the origin flips back.
+        // Measured on the choreography scene: 7deg jumped 4.1px across and
+        // 5.1px up, -6deg the other way, on the frame the morph finished. The
+        // triplet below collapses to identity at p=1, so the two frames agree.
+        const cx = b.w / 2
+        const cy = b.h / 2
         node.style.transform =
           `translate(${x - b.x}px, ${y - b.y}px)` +
-          (r ? ` rotate(${r}deg)` : '') +
-          ` scale(${w / Math.max(b.w, 0.01)}, ${h / Math.max(b.h, 0.01)})`
+          ` scale(${w / Math.max(b.w, 0.01)}, ${h / Math.max(b.h, 0.01)})` +
+          (r ? ` translate(${cx}px, ${cy}px) rotate(${r}deg) translate(${-cx}px, ${-cy}px)` : '')
       },
       onComplete() {
         node.style.transformOrigin = ''

--- a/slides/src/preview.ts
+++ b/slides/src/preview.ts
@@ -52,7 +52,7 @@ const BANNED = 'script,style,noscript,iframe,object,embed,link,video,audio,canva
 const DROP_ATTRS = [
   'data-el-id', 'data-flip-id', 'data-slide-id', 'data-link', 'data-group',
   'data-show-on-hover', 'data-chart', 'data-table', 'data-autoplay',
-  'data-r', 'data-c', 'data-sym', 'data-tok', 'contenteditable', 'draggable', 'tabindex',
+  'data-r', 'data-c', 'data-sym', 'data-msx', 'data-tok', 'contenteditable', 'draggable', 'tabindex',
 ]
 
 /**

--- a/slides/src/preview.ts
+++ b/slides/src/preview.ts
@@ -52,7 +52,7 @@ const BANNED = 'script,style,noscript,iframe,object,embed,link,video,audio,canva
 const DROP_ATTRS = [
   'data-el-id', 'data-flip-id', 'data-slide-id', 'data-link', 'data-group',
   'data-show-on-hover', 'data-chart', 'data-table', 'data-autoplay',
-  'data-r', 'data-c', 'data-sym', 'data-msx', 'data-tok', 'contenteditable', 'draggable', 'tabindex',
+  'data-r', 'data-c', 'data-sym', 'data-msx', 'data-tok', 'data-inkpin', 'contenteditable', 'draggable', 'tabindex',
 ]
 
 /**

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -1159,6 +1159,13 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
       node.style.display = 'flex'
       node.style.flexDirection = 'column'
       node.style.justifyContent = VALIGN[el.valign]
+      // Clip at the ELEMENT box — the size the author chose — and never at the
+      // <pre> (see below). Code sets `white-space: pre`, so a long line does
+      // not wrap and would otherwise run across the slide over whatever sits
+      // beside it; bounding it to its own box keeps the author's layout
+      // contract. The box is normally far larger than the lines inside it,
+      // which is exactly the room a morphing token needs.
+      node.style.overflow = 'hidden'
       const inner = document.createElement('pre')
       inner.className = 'bento-text-inner'
       inner.dir = 'auto'
@@ -1171,16 +1178,16 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
       inner.classList.add('bento-code')
       inner.style.whiteSpace = 'pre'
       inner.style.margin = '0'
-      // NOT overflow:hidden. A <pre> is only as tall as its own lines, and a
-      // morphing token starts at its position on the OTHER slide — which is
-      // outside those bounds whenever the block gets shorter. Clipping made a
-      // travelling token vanish for the first half of its journey and pop into
-      // view mid-flight, and only in the direction where the code got shorter:
-      // the taller side had room to contain the same motion, so the reverse
-      // transition looked perfect. Neither text elements nor .bento-el clip,
-      // so code overflowing its own box now behaves like every other element.
-      // Found in a screenshot; the DOM reported the token visible at opacity 1
-      // the whole time, because it was — just painted outside a clipping box.
+      // NOT overflow:hidden here. A <pre> is only as tall as its own lines,
+      // and a morphing token starts at its position on the OTHER slide —
+      // outside those bounds whenever the block gets shorter. Clipping at this
+      // level painted a travelling token 48px below the box and cut it away:
+      // it vanished for the first half of its journey and popped into view
+      // mid-flight, and only in the direction where the code got shorter,
+      // since the taller side had room for the same motion. That asymmetry is
+      // what made it read as a pairing bug rather than a painting one.
+      // Found in a screenshot — the DOM reported opacity 1, a correct 80px
+      // transform and a sensible rect, all true, all outside a clipping box.
       if (!renderCodeInto(inner, el, doc)) {
         // Fallback to unformatted text
         inner.innerText = el.content

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -431,6 +431,22 @@ function tagSymbols(mathml: string): string {
     seen.set(txt, n + 1)
       ; (leaf as HTMLElement).dataset.sym = `${txt}#${n}`
   }
+  // Scaffolding gets its own key, on a SEPARATE attribute. A fraction bar and
+  // a radical are drawn by the mfrac/msqrt box itself, not by any token, so
+  // they carry no data-sym and used to be the one part of a formula that
+  // neither travelled nor faded — they were simply there from frame one while
+  // everything around them animated. They must never enter the symbol morph:
+  // transforming a container would move its children a second time, on top of
+  // their own travel. Keyed by tag occurrence so scaffolding that SURVIVES a
+  // step (the outer fraction of a rearranged equation) is recognised and left
+  // alone, while genuinely new scaffolding can be faded in.
+  const struct = new Map<string, number>()
+  for (const box of Array.from(tpl.content.querySelectorAll('mfrac, msqrt, mroot, menclose, mover, munder, munderover'))) {
+    const tag = box.tagName.toLowerCase()
+    const n = struct.get(tag) ?? 0
+    struct.set(tag, n + 1)
+      ; (box as HTMLElement).dataset.msx = `${tag}#${n}`
+  }
   return tpl.innerHTML
 }
 

--- a/slides/src/render.ts
+++ b/slides/src/render.ts
@@ -1171,7 +1171,16 @@ export function renderElement(el: SlideElement, doc: BentoDoc, opts: RenderOpts 
       inner.classList.add('bento-code')
       inner.style.whiteSpace = 'pre'
       inner.style.margin = '0'
-      inner.style.overflow = 'hidden'
+      // NOT overflow:hidden. A <pre> is only as tall as its own lines, and a
+      // morphing token starts at its position on the OTHER slide — which is
+      // outside those bounds whenever the block gets shorter. Clipping made a
+      // travelling token vanish for the first half of its journey and pop into
+      // view mid-flight, and only in the direction where the code got shorter:
+      // the taller side had room to contain the same motion, so the reverse
+      // transition looked perfect. Neither text elements nor .bento-el clip,
+      // so code overflowing its own box now behaves like every other element.
+      // Found in a screenshot; the DOM reported the token visible at opacity 1
+      // the whole time, because it was — just painted outside a clipping box.
       if (!renderCodeInto(inner, el, doc)) {
         // Fallback to unformatted text
         inner.innerText = el.content

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -17,7 +17,7 @@
 // Never let system-font defaults show: every text sets a face on purpose.
 
 import {
-  newDoc, uid, defaultText, defaultShape, defaultChart, defaultTable,
+  newDoc, uid, defaultText, defaultShape, defaultChart, defaultTable, defaultCode,
   type BentoDoc, type Slide, type SlideElement, type TextElement, type ShapeElement,
   type SvgElement, type TableElement,
 } from './model'
@@ -57,6 +57,7 @@ const T_C = 'sd-tile-c' // paper/white
 const T_D = 'sd-tile-d' // ink panel / card
 /** The formula that rearranges across the morph beat — one id, two slides. */
 const EQ = 'sd-eq'
+const CODE = 'sd-code'
 const TITLE = 'sd-title'
 const KICKER = 'sd-kicker'
 const GLOW = 'sd-glow'
@@ -571,6 +572,104 @@ export function starterDoc(): BentoDoc {
           // \$ escapes the delimiter so this line SHOWS "$…$" instead of
           // rendering it — the first thing anyone copying this deck will hit.
           html: 'Maths is plain <b>\\$…\\$</b> in a text box — the terms morph, not the picture.',
+          fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
+        }),
+      ],
+    }),
+
+    // ── 3c · CODE MORPH (the edit reads as an edit) ────────────────────────
+    // Same mechanism as the formula: tokens carry identities across slides
+    // (Heckel diff on the kernel tokenizer), so a line that moves is SEEN to
+    // move. breathe() travels from fourth call to first — one clear motion,
+    // long enough to read at the deck's default tempo.
+    slide({
+      transition: 'morph',
+      notes:
+        'Code morphs the same way the formula did. The block on the next slide is the same ' +
+        'function with one line moved — press → and watch breathe() travel to the top while ' +
+        'the other calls step down to let it past. Tokens pair by a diff of the code itself, ' +
+        'so an edit reads as an edit, not a redraw: new lines fade in on the same beat, moved ' +
+        'lines travel. The block is a first-class element — 77 languages built in (about 7KB ' +
+        'of rules, no highlighter library), picked in the panel under Language.',
+      elements: [
+        grain(),
+        glow(200, [
+          { at: 0, color: 'rgba(62,86,120,0.24)' },
+          { at: 0.55, color: 'rgba(15,23,36,0)' },
+          { at: 1, color: 'rgba(255,158,138,0.14)' },
+        ]),
+        shape('rect', {
+          id: T_A, x: -110, y: 430, w: 320, h: 320, radius: 96, fill: PEACH,
+          fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_B, x: 1020, y: -140, w: 360, h: 360, radius: 104, fill: STEEL,
+          fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_C, x: 1040, y: 500, w: 260, h: 260, radius: 78, fill: TILE_PAPER, opacity: 0.85,
+          fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
+        }),
+        shape('rect', {
+          id: T_D, x: -70, y: -100, w: 240, h: 240, radius: 68, fill: 'transparent',
+          stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
+        }),
+        kicker('AND THE SAME TRICK ON CODE', { x: 340, y: 150, w: 600, h: 26, align: 'center' }),
+        {
+          ...defaultCode({ id: CODE, x: 390, y: 208, w: 520, h: 330 }),
+          content: "function launch(deck) {\n  polish(deck)\n  rehearse(deck)\n  focus(deck)\n  breathe()\n  present(deck)\n}",
+          grammarName: 'js', fontSize: 27, lineHeight: 1.7, color: '#DCE3EC',
+          align: 'left', valign: 'top',
+        },
+        text({
+          x: 290, y: 560, w: 700, h: 60,
+          html: 'A code block is a first-class element — press <b>→</b> to edit this function.',
+          fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
+        }),
+      ],
+    }),
+
+    slide({
+      transition: 'morph',
+      notes:
+        'One line moved, and it MOVED — breathe() went from fourth call to first, and every ' +
+        'call it passed stepped down one row. Nothing crossfaded and nothing redrew: each ' +
+        'token kept its identity across the edit, exactly like the a, b and c in the formula ' +
+        'two slides back. This is what code walkthroughs look like in a deck — duplicate the ' +
+        'slide, edit the code, and the transition explains the change for you.',
+      elements: [
+        grain(),
+        glow(200, [
+          { at: 0, color: 'rgba(62,86,120,0.24)' },
+          { at: 0.55, color: 'rgba(15,23,36,0)' },
+          { at: 1, color: 'rgba(255,158,138,0.14)' },
+        ]),
+        shape('rect', {
+          id: T_A, x: -60, y: 480, w: 260, h: 260, radius: 80, fill: PEACH,
+          fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_B, x: 1060, y: -100, w: 300, h: 300, radius: 90, fill: STEEL,
+          fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_C, x: 990, y: 460, w: 310, h: 310, radius: 92, fill: TILE_PAPER, opacity: 0.85,
+          fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
+        }),
+        shape('rect', {
+          id: T_D, x: -90, y: -130, w: 280, h: 280, radius: 80, fill: 'transparent',
+          stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
+        }),
+        kicker('BREATHE FIRST', { x: 340, y: 150, w: 600, h: 26, align: 'center' }),
+        {
+          ...defaultCode({ id: CODE, x: 390, y: 208, w: 520, h: 330 }),
+          content: "function launch(deck) {\n  breathe()\n  polish(deck)\n  rehearse(deck)\n  focus(deck)\n  present(deck)\n}",
+          grammarName: 'js', fontSize: 27, lineHeight: 1.7, color: '#DCE3EC',
+          align: 'left', valign: 'top',
+        },
+        text({
+          x: 290, y: 560, w: 700, h: 60,
+          html: 'One line moved — and it <b>moved</b>. The diff is the animation.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -479,7 +479,47 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 3 · MORPH MANIFESTO ────────────────────────────────────────────────
+    // ── 3 · NO MOVING PARTS (staggers + count-ups, arriving by morph) ─────
+    // This was a 'fade' because entrance fx and count-ups once needed a
+    // non-morph arrival. Both have worked on morph arrivals since #197 —
+    // runMorph gives every unpartnered element its fx.enter, and
+    // runMorphArrivalCountUps counts up anything not carried from the previous
+    // slide — so the fade only cost the deck its best tile moment: the four
+    // scattered tiles collapsing into the row of chips at the top-left.
+    slide({
+      background: PEACH,
+      notes:
+        'The four tiles just collapsed into that row of chips — same four shapes, all deck long. ' +
+        'The numbers counted up as the slide entered; ' +
+        'that’s one checkbox on any text element. The little lines show line endings: arrow, dot, bar.',
+      elements: [
+        shape('rect', { id: T_D, x: 96, y: 54, w: 34, h: 34, radius: 9, fill: INK }),
+        shape('rect', { id: T_B, x: 140, y: 54, w: 34, h: 34, radius: 9, fill: STEEL }),
+        shape('rect', { id: T_A, x: 184, y: 54, w: 34, h: 34, radius: 9, fill: PEACH_SOFT }),
+        shape('rect', { id: T_C, x: 228, y: 54, w: 34, h: 34, radius: 9, fill: PAPER }),
+        text({
+          x: 1024, y: 54, w: 160, h: 26, html: '{{page:2}}', align: 'right',
+          fontSize: 13, fontWeight: 700, letterSpacing: 2, color: 'rgba(15,23,36,0.45)',
+        }),
+        shape('rect', { x: 96, y: 108, w: 1088, h: 1.5, radius: 0, fill: 'rgba(15,23,36,0.18)' }),
+        kicker('NO MOVING PARTS', { y: 132, color: INK, fx: { enter: 'fade-up', order: 0 } }),
+        title('Software with nothing<br>to install, break, or expire.', {
+          y: 170, w: 1060, h: 150, color: INK, fontSize: 50,
+          fx: { enter: 'fade-up', order: 1 },
+        }),
+        text({ x: 96, y: 356, w: 352, h: 180, html: '1', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 2, countUp: true } }),
+        text({ x: 464, y: 356, w: 352, h: 180, html: '0', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 3, countUp: true } }),
+        text({ x: 832, y: 356, w: 352, h: 180, html: '100%', fontSize: 130, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 4, countUp: true } }),
+        shape('line', { x: 100, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineEnd: 'arrow', fx: { enter: 'fade', order: 5 } }),
+        shape('line', { x: 468, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineStart: 'dot', lineEnd: 'dot', fx: { enter: 'fade', order: 5 } }),
+        shape('line', { x: 836, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineStart: 'bar', lineEnd: 'bar', fx: { enter: 'fade', order: 5 } }),
+        text({ x: 96, y: 570, w: 352, h: 30, html: 'FILE TO SEND', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
+        text({ x: 464, y: 570, w: 352, h: 30, html: 'SERVERS REQUIRED', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
+        text({ x: 832, y: 570, w: 352, h: 30, html: 'YOURS, FOREVER', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
+      ],
+    }),
+
+    // ── 4 · MORPH MANIFESTO ────────────────────────────────────────────────
     slide({
       notes:
         'The tiles scattered and grew — and picked up GRADIENT fills mid-morph (solid⇄gradient tweening). ' +
@@ -519,7 +559,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 3b · SYMBOL MORPH, SIDE BY SIDE (maths and code, one mechanism) ────
+    // ── 5 · SYMBOL MORPH, SIDE BY SIDE (maths and code, one mechanism) ────
     // The deck's sub-element morph, shown on BOTH content types at once: a
     // quadratic derivation on the left, three eras of JavaScript on the right.
     // Same engine underneath (tokens carry identities across slides and travel
@@ -713,47 +753,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 4 · STATS BEAT (staggers + count-ups, arriving by morph) ───────────
-    // This was a 'fade' because entrance fx and count-ups once needed a
-    // non-morph arrival. Both have worked on morph arrivals since #197 —
-    // runMorph gives every unpartnered element its fx.enter, and
-    // runMorphArrivalCountUps counts up anything not carried from the previous
-    // slide — so the fade only cost the deck its best tile moment: the four
-    // scattered tiles collapsing into the row of chips at the top-left.
-    slide({
-      background: PEACH,
-      notes:
-        'The four tiles just collapsed into that row of chips — same four shapes, all deck long. ' +
-        'The numbers counted up as the slide entered; ' +
-        'that’s one checkbox on any text element. The little lines show line endings: arrow, dot, bar.',
-      elements: [
-        shape('rect', { id: T_D, x: 96, y: 54, w: 34, h: 34, radius: 9, fill: INK }),
-        shape('rect', { id: T_B, x: 140, y: 54, w: 34, h: 34, radius: 9, fill: STEEL }),
-        shape('rect', { id: T_A, x: 184, y: 54, w: 34, h: 34, radius: 9, fill: PEACH_SOFT }),
-        shape('rect', { id: T_C, x: 228, y: 54, w: 34, h: 34, radius: 9, fill: PAPER }),
-        text({
-          x: 1024, y: 54, w: 160, h: 26, html: '04', align: 'right',
-          fontSize: 13, fontWeight: 700, letterSpacing: 2, color: 'rgba(15,23,36,0.45)',
-        }),
-        shape('rect', { x: 96, y: 108, w: 1088, h: 1.5, radius: 0, fill: 'rgba(15,23,36,0.18)' }),
-        kicker('NO MOVING PARTS', { y: 132, color: INK, fx: { enter: 'fade-up', order: 0 } }),
-        title('Software with nothing<br>to install, break, or expire.', {
-          y: 170, w: 1060, h: 150, color: INK, fontSize: 50,
-          fx: { enter: 'fade-up', order: 1 },
-        }),
-        text({ x: 96, y: 356, w: 352, h: 180, html: '1', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 2, countUp: true } }),
-        text({ x: 464, y: 356, w: 352, h: 180, html: '0', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 3, countUp: true } }),
-        text({ x: 832, y: 356, w: 352, h: 180, html: '100%', fontSize: 130, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 4, countUp: true } }),
-        shape('line', { x: 100, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineEnd: 'arrow', fx: { enter: 'fade', order: 5 } }),
-        shape('line', { x: 468, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineStart: 'dot', lineEnd: 'dot', fx: { enter: 'fade', order: 5 } }),
-        shape('line', { x: 836, y: 542, w: 150, h: 8, fill: INK, strokeWidth: 3, lineStart: 'bar', lineEnd: 'bar', fx: { enter: 'fade', order: 5 } }),
-        text({ x: 96, y: 570, w: 352, h: 30, html: 'FILE TO SEND', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
-        text({ x: 464, y: 570, w: 352, h: 30, html: 'SERVERS REQUIRED', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
-        text({ x: 832, y: 570, w: 352, h: 30, html: 'YOURS, FOREVER', fontSize: 14, fontWeight: 700, letterSpacing: 2, color: INK_SOFT, fx: { enter: 'fade', order: 6 } }),
-      ],
-    }),
-
-    // ── 5 · CHARTS ALIVE (+ hidden pie state) ──────────────────────────────
+    // ── 6 · CHARTS ALIVE (+ hidden pie state) ──────────────────────────────
     slide({
       id: S_CHARTS,
       background: PAPER,
@@ -864,7 +864,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 6 · TABLES (real HTML table) ───────────────────────────────────────
+    // ── 7 · TABLES (real HTML table) ───────────────────────────────────────
     slide({
       background: PAPER,
       notes:
@@ -950,7 +950,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 7 · MOMENTUM (line-chart hero) ─────────────────────────────────────
+    // ── 8 · MOMENTUM (line-chart hero) ─────────────────────────────────────
     slide({
       notes:
         'A chart as scenery: full-width live area chart on ink. Drag horizontally inside it to zoom — ' +
@@ -977,7 +977,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 8 · MOTION & LINES ─────────────────────────────────────────────────
+    // ── 9 · MOTION & LINES ─────────────────────────────────────────────────
     slide({
       background: PAPER,
       notes:
@@ -1022,7 +1022,7 @@ export function starterDoc(): BentoDoc {
     }),
 
 
-    // ── 9 · CHOREOGRAPHY (base + two hidden states) ───────────────────────
+    // ── 10 · CHOREOGRAPHY (base + two hidden states) ──────────────────────
     ...(() => {
       type Scene = {
         id: string; step: string; label: string; chip: string; to: string
@@ -1112,7 +1112,7 @@ export function starterDoc(): BentoDoc {
       )
     })(),
 
-    // ── 10 · HOVER FOCUS ────────────────────────────────────────────────────
+    // ── 11 · HOVER FOCUS ───────────────────────────────────────────────────
     slide({
       hover: { type: 'focus-group', dim: 0.22 },
       notes:
@@ -1162,7 +1162,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 11 · MARKDOWN ───────────────────────────────────────────────────────
+    // ── 12 · MARKDOWN ──────────────────────────────────────────────────────
     slide({
       background: PAPER,
       notes:
@@ -1195,7 +1195,7 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 12 · CLOSE ─────────────────────────────────────────────────────────
+    // ── 13 · CLOSE ─────────────────────────────────────────────────────────
     slide({
       notes:
         'The cast reassembles into the logo. Press Esc — this deck is already your copy of the app: ' +

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -502,10 +502,13 @@ export function starterDoc(): BentoDoc {
           fontSize: 13, fontWeight: 700, letterSpacing: 2, color: 'rgba(15,23,36,0.45)',
         }),
         shape('rect', { x: 96, y: 108, w: 1088, h: 1.5, radius: 0, fill: 'rgba(15,23,36,0.18)' }),
-        kicker('NO MOVING PARTS', { y: 132, color: INK, fx: { enter: 'fade-up', order: 0 } }),
+        // No fx on these two: the kicker and title carry the SAME ids as the
+        // slide before, so they morph across and are already in motion. An
+        // fx.enter here would be silently skipped — the entrance only runs for
+        // elements with no partner on the previous slide.
+        kicker('NO MOVING PARTS', { y: 132, color: INK }),
         title('Software with nothing<br>to install, break, or expire.', {
           y: 170, w: 1060, h: 150, color: INK, fontSize: 50,
-          fx: { enter: 'fade-up', order: 1 },
         }),
         text({ x: 96, y: 356, w: 352, h: 180, html: '1', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 2, countUp: true } }),
         text({ x: 464, y: 356, w: 352, h: 180, html: '0', fontSize: 150, fontWeight: 900, fontFamily: DISPLAY, color: INK, fx: { enter: 'fade-up', order: 3, countUp: true } }),

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -580,7 +580,8 @@ export function starterDoc(): BentoDoc {
     // ── 3c · CODE MORPH (one function, three eras of JavaScript) ───────────
     // Same mechanism as the formula: tokens carry identities across slides
     // (Heckel diff on the kernel tokenizer), so an edit reads as an edit.
-    // Three beats every developer has lived: callbacks -> promises -> await.
+    // Three beats every developer has lived: callbacks -> promises (ES2015)
+    // -> async/await (ES2017). Spec milestones, not invented dates.
     // load, deck, render, present and confetti keep ONE identity through all
     // three (probed before authoring); the pyramid collapses, confetti() rises
     // two lines to meet it, and the names return with const/await in the last
@@ -590,7 +591,7 @@ export function starterDoc(): BentoDoc {
       transition: 'morph',
       notes:
         'And the same trick works on code. This function is about to be modernised twice — ' +
-        'press \u2192 and fifteen years of JavaScript happen in front of you. Watch load, render, ' +
+        'press \u2192 and two revisions of the language happen in front of you. Watch load, render, ' +
         'present and confetti: they keep their identity through every rewrite, because tokens ' +
         'pair by a diff of the code itself. Code blocks are first-class elements — 77 languages ' +
         'built in (about 7KB of rules, no highlighter library), picked in the panel.',
@@ -626,7 +627,7 @@ export function starterDoc(): BentoDoc {
         },
         text({
           x: 290, y: 566, w: 700, h: 60,
-          html: 'One function, 2010 style. Press <b>\u2192</b> to modernise it — twice.',
+          html: 'One function, callback style. Press <b>\u2192</b> to modernise it — twice.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],
@@ -635,7 +636,7 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'Promises, mid-2010s. The pyramid flattened: the callback braces dissolved, .then ' +
+        'Promises — native since ES2015. The pyramid flattened: the callback braces dissolved, .then ' +
         'arrived, and confetti() ROSE two lines to meet the collapse — it did not redraw, it ' +
         'travelled. Point-free style really did drop the parameter names, which is why slides ' +
         'and frame faded out rather than moved: the diff is honest about what the edit did. ' +
@@ -681,7 +682,7 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'async/await, 2017 — and it reads like prose. slides and frame came BACK (const and ' +
+        'async/await, ES2017 — and it reads like prose. slides and frame came BACK (const and ' +
         'await faded in around them), while load, deck, render, present and confetti have ' +
         'kept one identity since the first beat. This is what a code walkthrough is in Bento: ' +
         'duplicate the slide, edit the code, and the transition explains the change for you. ' +
@@ -718,7 +719,7 @@ export function starterDoc(): BentoDoc {
         },
         text({
           x: 290, y: 566, w: 700, h: 60,
-          html: 'Same tokens since 2010 — <b>the diff is the animation</b>.',
+          html: 'Same tokens, three rewrites — <b>the diff is the animation</b>.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -577,20 +577,23 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 3c · CODE MORPH (the edit reads as an edit) ────────────────────────
+    // ── 3c · CODE MORPH (one function, three eras of JavaScript) ───────────
     // Same mechanism as the formula: tokens carry identities across slides
-    // (Heckel diff on the kernel tokenizer), so a line that moves is SEEN to
-    // move. breathe() travels from fourth call to first — one clear motion,
-    // long enough to read at the deck's default tempo.
+    // (Heckel diff on the kernel tokenizer), so an edit reads as an edit.
+    // Three beats every developer has lived: callbacks -> promises -> await.
+    // load, deck, render, present and confetti keep ONE identity through all
+    // three (probed before authoring); the pyramid collapses, confetti() rises
+    // two lines to meet it, and the names return with const/await in the last
+    // beat. Point-free promises are deliberate — that era really did drop the
+    // parameter names, so slides/frame fading out is honest, not a diff miss.
     slide({
       transition: 'morph',
       notes:
-        'Code morphs the same way the formula did. The block on the next slide is the same ' +
-        'function with one line moved — press → and watch breathe() travel to the top while ' +
-        'the other calls step down to let it past. Tokens pair by a diff of the code itself, ' +
-        'so an edit reads as an edit, not a redraw: new lines fade in on the same beat, moved ' +
-        'lines travel. The block is a first-class element — 77 languages built in (about 7KB ' +
-        'of rules, no highlighter library), picked in the panel under Language.',
+        'And the same trick works on code. This function is about to be modernised twice — ' +
+        'press \u2192 and fifteen years of JavaScript happen in front of you. Watch load, render, ' +
+        'present and confetti: they keep their identity through every rewrite, because tokens ' +
+        'pair by a diff of the code itself. Code blocks are first-class elements — 77 languages ' +
+        'built in (about 7KB of rules, no highlighter library), picked in the panel.',
       elements: [
         grain(),
         glow(200, [
@@ -614,16 +617,16 @@ export function starterDoc(): BentoDoc {
           id: T_D, x: -70, y: -100, w: 240, h: 240, radius: 68, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('AND THE SAME TRICK ON CODE', { x: 340, y: 150, w: 600, h: 26, align: 'center' }),
+        kicker('AND THE SAME TRICK ON CODE', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
         {
-          ...defaultCode({ id: CODE, x: 390, y: 208, w: 520, h: 330 }),
-          content: "function launch(deck) {\n  polish(deck)\n  rehearse(deck)\n  focus(deck)\n  breathe()\n  present(deck)\n}",
-          grammarName: 'js', fontSize: 27, lineHeight: 1.7, color: '#DCE3EC',
+          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          content: "load(deck, (slides) => {\n  render(slides, (frame) => {\n    present(frame)\n  })\n})\nconfetti()",
+          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
           align: 'left', valign: 'top',
         },
         text({
-          x: 290, y: 560, w: 700, h: 60,
-          html: 'A code block is a first-class element — press <b>→</b> to edit this function.',
+          x: 290, y: 566, w: 700, h: 60,
+          html: 'One function, 2010 style. Press <b>\u2192</b> to modernise it — twice.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],
@@ -632,11 +635,57 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'One line moved, and it MOVED — breathe() went from fourth call to first, and every ' +
-        'call it passed stepped down one row. Nothing crossfaded and nothing redrew: each ' +
-        'token kept its identity across the edit, exactly like the a, b and c in the formula ' +
-        'two slides back. This is what code walkthroughs look like in a deck — duplicate the ' +
-        'slide, edit the code, and the transition explains the change for you.',
+        'Promises, mid-2010s. The pyramid flattened: the callback braces dissolved, .then ' +
+        'arrived, and confetti() ROSE two lines to meet the collapse — it did not redraw, it ' +
+        'travelled. Point-free style really did drop the parameter names, which is why slides ' +
+        'and frame faded out rather than moved: the diff is honest about what the edit did. ' +
+        'One more \u2192 to finish the story.',
+      elements: [
+        grain(),
+        glow(200, [
+          { at: 0, color: 'rgba(62,86,120,0.24)' },
+          { at: 0.55, color: 'rgba(15,23,36,0)' },
+          { at: 1, color: 'rgba(255,158,138,0.14)' },
+        ]),
+        shape('rect', {
+          id: T_A, x: -80, y: 460, w: 290, h: 290, radius: 88, fill: PEACH,
+          fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_B, x: 1044, y: -118, w: 330, h: 330, radius: 96, fill: STEEL,
+          fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
+        }),
+        shape('rect', {
+          id: T_C, x: 1014, y: 480, w: 286, h: 286, radius: 84, fill: TILE_PAPER, opacity: 0.85,
+          fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
+        }),
+        shape('rect', {
+          id: T_D, x: -80, y: -114, w: 260, h: 260, radius: 74, fill: 'transparent',
+          stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
+        }),
+        kicker('PROMISES FLATTEN THE PYRAMID', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
+        {
+          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          content: "load(deck)\n  .then(render)\n  .then(present)\nconfetti()",
+          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
+          align: 'left', valign: 'top',
+        },
+        text({
+          x: 290, y: 566, w: 700, h: 60,
+          html: 'The braces dissolved and <b>confetti() rose to meet the collapse</b>.',
+          fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
+        }),
+      ],
+    }),
+
+    slide({
+      transition: 'morph',
+      notes:
+        'async/await, 2017 — and it reads like prose. slides and frame came BACK (const and ' +
+        'await faded in around them), while load, deck, render, present and confetti have ' +
+        'kept one identity since the first beat. This is what a code walkthrough is in Bento: ' +
+        'duplicate the slide, edit the code, and the transition explains the change for you. ' +
+        'No recording, no screenshots — the deck IS the diff.',
       elements: [
         grain(),
         glow(200, [
@@ -660,16 +709,16 @@ export function starterDoc(): BentoDoc {
           id: T_D, x: -90, y: -130, w: 280, h: 280, radius: 80, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('BREATHE FIRST', { x: 340, y: 150, w: 600, h: 26, align: 'center' }),
+        kicker('AND AWAIT READS LIKE PROSE', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
         {
-          ...defaultCode({ id: CODE, x: 390, y: 208, w: 520, h: 330 }),
-          content: "function launch(deck) {\n  breathe()\n  polish(deck)\n  rehearse(deck)\n  focus(deck)\n  present(deck)\n}",
-          grammarName: 'js', fontSize: 27, lineHeight: 1.7, color: '#DCE3EC',
+          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          content: "const slides = await load(deck)\nconst frame = await render(slides)\npresent(frame)\nconfetti()",
+          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
           align: 'left', valign: 'top',
         },
         text({
-          x: 290, y: 560, w: 700, h: 60,
-          html: 'One line moved — and it <b>moved</b>. The diff is the animation.',
+          x: 290, y: 566, w: 700, h: 60,
+          html: 'Same tokens since 2010 — <b>the diff is the animation</b>.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -725,12 +725,18 @@ export function starterDoc(): BentoDoc {
       ],
     }),
 
-    // ── 4 · STATS BEAT (fade → staggers + count-ups) ───────────────────────
+    // ── 4 · STATS BEAT (staggers + count-ups, arriving by morph) ───────────
+    // This was a 'fade' because entrance fx and count-ups once needed a
+    // non-morph arrival. Both have worked on morph arrivals since #197 —
+    // runMorph gives every unpartnered element its fx.enter, and
+    // runMorphArrivalCountUps counts up anything not carried from the previous
+    // slide — so the fade only cost the deck its best tile moment: the four
+    // scattered tiles collapsing into the row of chips at the top-left.
     slide({
       background: PEACH,
-      transition: 'fade',
       notes:
-        'A hard cut on purpose — rhythm. The numbers counted up as the slide entered; ' +
+        'The four tiles just collapsed into that row of chips — same four shapes, all deck long. ' +
+        'The numbers counted up as the slide entered; ' +
         'that’s one checkbox on any text element. The little lines show line endings: arrow, dot, bar.',
       elements: [
         shape('rect', { id: T_D, x: 96, y: 54, w: 34, h: 34, radius: 9, fill: INK }),

--- a/slides/src/starterdeck.ts
+++ b/slides/src/starterdeck.ts
@@ -57,7 +57,7 @@ const T_C = 'sd-tile-c' // paper/white
 const T_D = 'sd-tile-d' // ink panel / card
 /** The formula that rearranges across the morph beat — one id, two slides. */
 const EQ = 'sd-eq'
-const CODE = 'sd-code'
+const CODE_ID = 'sd-code'
 const TITLE = 'sd-title'
 const KICKER = 'sd-kicker'
 const GLOW = 'sd-glow'
@@ -516,118 +516,76 @@ export function starterDoc(): BentoDoc {
           html: 'Shared ids animate between slides — position, size, color, <b>even gradients</b>.<br>Press ← then → to replay it.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
-        // Sits quietly here and becomes the point of the next slide: same id,
-        // so its SYMBOLS morph across rather than the formula crossfading.
-        text({
-          id: EQ, x: 340, y: 600, w: 600, h: 60, html: '$ax^2 + bx + c = 0$',
-          fontSize: 30, color: 'rgba(185,196,212,0.75)', align: 'center', valign: 'middle',
-        }),
       ],
     }),
 
-    // ── 3b · SYMBOL MORPH (the formula rearranges, term by term) ───────────
+    // ── 3b · SYMBOL MORPH, SIDE BY SIDE (maths and code, one mechanism) ────
+    // The deck's sub-element morph, shown on BOTH content types at once: a
+    // quadratic derivation on the left, three eras of JavaScript on the right.
+    // Same engine underneath (tokens carry identities across slides and travel
+    // to their new positions), two very different surfaces on top — which is
+    // the claim this pair of columns is here to make.
+    //
+    // The maths is the classic three-step derivation, so the beats line up
+    // with the code's callbacks -> promises (ES2015) -> async/await (ES2017):
+    // a, b and c survive all three on the left while load, render, present and
+    // confetti survive all three on the right. Both probed before authoring.
     slide({
       transition: 'morph',
       notes:
-        'The quadratic on the last slide did not crossfade into this one — a, b and c TRAVELLED, ' +
-        'out of ax² + bx + c = 0 and into the fraction, the radical and the discriminant. Tokens ' +
-        'pair by what they are and which occurrence they are, so a term that moves is seen to move. ' +
-        'Everything here is one ordinary text box: type the LaTeX between dollar signs (two for a ' +
-        'display equation like this one) and the document stores exactly that — not a picture, not ' +
-        'a font, no library fetched at runtime. Backslash-escape a dollar to show one literally, ' +
-        'as the caption does.',
+        'Two token streams, one mechanism. Both sides of this slide morph symbol by symbol: the maths is plain \u0024\u2026\u0024 in an ordinary text box, the code is a code element with 77 languages built in (about 7KB of rules, no highlighter library). Press \u2192 and watch BOTH at once \u2014 a, b and c travel through the derivation while the callback pyramid flattens into promises.',
       elements: [
         grain(),
         glow(20, [
-          { at: 0, color: 'rgba(255,158,138,0.20)' },
-          { at: 0.6, color: 'rgba(15,23,36,0)' },
-          { at: 1, color: 'rgba(62,86,120,0.24)' },
-        ]),
-        shape('rect', {
-          id: T_A, x: 1000, y: 420, w: 300, h: 300, radius: 90, fill: PEACH,
-          fillGradient: { angle: 135, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
-        }),
-        shape('rect', {
-          id: T_B, x: -120, y: -110, w: 380, h: 380, radius: 100, fill: STEEL,
-          fillGradient: { angle: 225, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
-        }),
-        shape('rect', {
-          id: T_C, x: -80, y: 470, w: 300, h: 300, radius: 84, fill: TILE_PAPER, opacity: 0.85,
-          fillGradient: { angle: 315, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
-        }),
-        shape('rect', {
-          id: T_D, x: 1030, y: -90, w: 250, h: 250, radius: 70, fill: 'transparent',
-          stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
-        }),
-        kicker('EVEN INSIDE A FORMULA', { x: 340, y: 176, w: 600, h: 26, align: 'center' }),
-        // Display mode ($$) so the fraction, radical and ± set at full size.
-        // a, b and c fly out of the quadratic and into their places here.
-        text({
-          id: EQ, x: 190, y: 240, w: 900, h: 230,
-          html: '$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$',
-          fontSize: 62, color: '#FFFFFF', align: 'center', valign: 'middle',
-        }),
-        text({
-          x: 340, y: 500, w: 600, h: 80,
-          // \$ escapes the delimiter so this line SHOWS "$…$" instead of
-          // rendering it — the first thing anyone copying this deck will hit.
-          html: 'Maths is plain <b>\\$…\\$</b> in a text box — the terms morph, not the picture.',
-          fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
-        }),
-      ],
-    }),
-
-    // ── 3c · CODE MORPH (one function, three eras of JavaScript) ───────────
-    // Same mechanism as the formula: tokens carry identities across slides
-    // (Heckel diff on the kernel tokenizer), so an edit reads as an edit.
-    // Three beats every developer has lived: callbacks -> promises (ES2015)
-    // -> async/await (ES2017). Spec milestones, not invented dates.
-    // load, deck, render, present and confetti keep ONE identity through all
-    // three (probed before authoring); the pyramid collapses, confetti() rises
-    // two lines to meet it, and the names return with const/await in the last
-    // beat. Point-free promises are deliberate — that era really did drop the
-    // parameter names, so slides/frame fading out is honest, not a diff miss.
-    slide({
-      transition: 'morph',
-      notes:
-        'And the same trick works on code. This function is about to be modernised twice — ' +
-        'press \u2192 and two revisions of the language happen in front of you. Watch load, render, ' +
-        'present and confetti: they keep their identity through every rewrite, because tokens ' +
-        'pair by a diff of the code itself. Code blocks are first-class elements — 77 languages ' +
-        'built in (about 7KB of rules, no highlighter library), picked in the panel.',
-      elements: [
-        grain(),
-        glow(200, [
           { at: 0, color: 'rgba(62,86,120,0.24)' },
           { at: 0.55, color: 'rgba(15,23,36,0)' },
-          { at: 1, color: 'rgba(255,158,138,0.14)' },
+          { at: 1, color: 'rgba(255,158,138,0.16)' },
         ]),
         shape('rect', {
-          id: T_A, x: -110, y: 430, w: 320, h: 320, radius: 96, fill: PEACH,
+          id: T_A, x: -130, y: 470, w: 300, h: 300, radius: 92, fill: PEACH,
           fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
         }),
         shape('rect', {
-          id: T_B, x: 1020, y: -140, w: 360, h: 360, radius: 104, fill: STEEL,
+          id: T_B, x: 1060, y: -150, w: 340, h: 340, radius: 100, fill: STEEL,
           fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
         }),
         shape('rect', {
-          id: T_C, x: 1040, y: 500, w: 260, h: 260, radius: 78, fill: TILE_PAPER, opacity: 0.85,
+          id: T_C, x: 1080, y: 520, w: 260, h: 260, radius: 78, fill: TILE_PAPER, opacity: 0.85,
           fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
         }),
         shape('rect', {
-          id: T_D, x: -70, y: -100, w: 240, h: 240, radius: 68, fill: 'transparent',
+          id: T_D, x: -80, y: -120, w: 240, h: 240, radius: 68, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('AND THE SAME TRICK ON CODE', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
+        kicker('ONE MECHANISM, TWO LANGUAGES', { x: 340, y: 128, w: 600, h: 26, align: 'center' }),
+        // Column labels — small, so the two halves read as a comparison.
+        text({
+          x: 96, y: 186, w: 480, h: 24, html: 'MATHS \u2014 plain <b>\\$\u2026\\$</b> in a text box',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        text({
+          x: 640, y: 186, w: 544, h: 24, html: 'CODE \u2014 <b>77 languages</b> built in',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        // LEFT: the derivation. Display mode so fractions and the radical set
+        // at full size; a, b and c travel between the three beats.
+        text({
+          id: EQ, x: 96, y: 226, w: 480, h: 280,
+          html: '$$ax^2 + bx + c = 0$$',
+          fontSize: 30, color: '#FFFFFF', align: 'center', valign: 'middle',
+        }),
+        // RIGHT: the same trick on code, running at the same time.
         {
-          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          ...defaultCode({ id: CODE_ID, x: 640, y: 226, w: 544, h: 280 }),
           content: "load(deck, (slides) => {\n  render(slides, (frame) => {\n    present(frame)\n  })\n})\nconfetti()",
-          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
-          align: 'left', valign: 'top',
+          grammarName: 'js', fontSize: 19, lineHeight: 1.62, color: '#DCE3EC',
+          align: 'left', valign: 'middle',
         },
         text({
-          x: 290, y: 566, w: 700, h: 60,
-          html: 'One function, callback style. Press <b>\u2192</b> to modernise it — twice.',
+          x: 190, y: 560, w: 900, h: 60,
+          html: 'A derivation on the left, two revisions of JavaScript on the right. Press <b>→</b> twice.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],
@@ -636,44 +594,59 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'Promises — native since ES2015. The pyramid flattened: the callback braces dissolved, .then ' +
-        'arrived, and confetti() ROSE two lines to meet the collapse — it did not redraw, it ' +
-        'travelled. Point-free style really did drop the parameter names, which is why slides ' +
-        'and frame faded out rather than moved: the diff is honest about what the edit did. ' +
-        'One more \u2192 to finish the story.',
+        'Left: completing the square \u2014 a, b and c did not crossfade, they moved into their new places. Right: the pyramid flattened and confetti() rose two lines to meet it. Point-free promises really did drop the parameter names, so slides and frame fading out is the diff being honest. One more \u2192.',
       elements: [
         grain(),
         glow(200, [
           { at: 0, color: 'rgba(62,86,120,0.24)' },
           { at: 0.55, color: 'rgba(15,23,36,0)' },
-          { at: 1, color: 'rgba(255,158,138,0.14)' },
+          { at: 1, color: 'rgba(255,158,138,0.16)' },
         ]),
         shape('rect', {
-          id: T_A, x: -80, y: 460, w: 290, h: 290, radius: 88, fill: PEACH,
+          id: T_A, x: -100, y: 500, w: 270, h: 270, radius: 84, fill: PEACH,
           fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
         }),
         shape('rect', {
-          id: T_B, x: 1044, y: -118, w: 330, h: 330, radius: 96, fill: STEEL,
+          id: T_B, x: 1084, y: -128, w: 310, h: 310, radius: 92, fill: STEEL,
           fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
         }),
         shape('rect', {
-          id: T_C, x: 1014, y: 480, w: 286, h: 286, radius: 84, fill: TILE_PAPER, opacity: 0.85,
+          id: T_C, x: 1054, y: 500, w: 286, h: 286, radius: 84, fill: TILE_PAPER, opacity: 0.85,
           fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
         }),
         shape('rect', {
-          id: T_D, x: -80, y: -114, w: 260, h: 260, radius: 74, fill: 'transparent',
+          id: T_D, x: -90, y: -134, w: 260, h: 260, radius: 74, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('PROMISES FLATTEN THE PYRAMID', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
+        kicker('EVERY TERM KEEPS ITS PLACE', { x: 340, y: 128, w: 600, h: 26, align: 'center' }),
+        // Column labels — small, so the two halves read as a comparison.
+        text({
+          x: 96, y: 186, w: 480, h: 24, html: 'MATHS \u2014 plain <b>\\$\u2026\\$</b> in a text box',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        text({
+          x: 640, y: 186, w: 544, h: 24, html: 'CODE \u2014 <b>77 languages</b> built in',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        // LEFT: the derivation. Display mode so fractions and the radical set
+        // at full size; a, b and c travel between the three beats.
+        text({
+          id: EQ, x: 96, y: 226, w: 480, h: 280,
+          html: '$$\\left(x + \\frac{b}{2a}\\right)^2 = \\frac{b^2 - 4ac}{4a^2}$$',
+          fontSize: 30, color: '#FFFFFF', align: 'center', valign: 'middle',
+        }),
+        // RIGHT: the same trick on code, running at the same time.
         {
-          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          ...defaultCode({ id: CODE_ID, x: 640, y: 226, w: 544, h: 280 }),
           content: "load(deck)\n  .then(render)\n  .then(present)\nconfetti()",
-          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
-          align: 'left', valign: 'top',
+          grammarName: 'js', fontSize: 19, lineHeight: 1.62, color: '#DCE3EC',
+          align: 'left', valign: 'middle',
         },
         text({
-          x: 290, y: 566, w: 700, h: 60,
-          html: 'The braces dissolved and <b>confetti() rose to meet the collapse</b>.',
+          x: 190, y: 560, w: 900, h: 60,
+          html: 'Completing the square, and the pyramid flattening — <b>both travelling at once</b>.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],
@@ -682,44 +655,59 @@ export function starterDoc(): BentoDoc {
     slide({
       transition: 'morph',
       notes:
-        'async/await, ES2017 — and it reads like prose. slides and frame came BACK (const and ' +
-        'await faded in around them), while load, deck, render, present and confetti have ' +
-        'kept one identity since the first beat. This is what a code walkthrough is in Bento: ' +
-        'duplicate the slide, edit the code, and the transition explains the change for you. ' +
-        'No recording, no screenshots — the deck IS the diff.',
+        'async/await on the right, the quadratic formula on the left \u2014 and every symbol that survived the rewrite kept its identity the whole way. This is what a walkthrough is in Bento: duplicate the slide, edit the content, and the transition explains the change for you. No recording, no screenshots.',
       elements: [
         grain(),
-        glow(200, [
+        glow(20, [
           { at: 0, color: 'rgba(62,86,120,0.24)' },
           { at: 0.55, color: 'rgba(15,23,36,0)' },
-          { at: 1, color: 'rgba(255,158,138,0.14)' },
+          { at: 1, color: 'rgba(255,158,138,0.16)' },
         ]),
         shape('rect', {
-          id: T_A, x: -60, y: 480, w: 260, h: 260, radius: 80, fill: PEACH,
+          id: T_A, x: -70, y: 520, w: 250, h: 250, radius: 78, fill: PEACH,
           fillGradient: { angle: 45, stops: [{ at: 0, color: PEACH }, { at: 1, color: PEACH_SOFT }] },
         }),
         shape('rect', {
-          id: T_B, x: 1060, y: -100, w: 300, h: 300, radius: 90, fill: STEEL,
+          id: T_B, x: 1100, y: -110, w: 290, h: 290, radius: 88, fill: STEEL,
           fillGradient: { angle: 200, stops: [{ at: 0, color: '#41597A' }, { at: 1, color: STEEL_SOFT }] },
         }),
         shape('rect', {
-          id: T_C, x: 990, y: 460, w: 310, h: 310, radius: 92, fill: TILE_PAPER, opacity: 0.85,
+          id: T_C, x: 1030, y: 480, w: 310, h: 310, radius: 92, fill: TILE_PAPER, opacity: 0.85,
           fillGradient: { angle: 30, stops: [{ at: 0, color: '#FFFFFF' }, { at: 1, color: '#D8D3C6' }] },
         }),
         shape('rect', {
-          id: T_D, x: -90, y: -130, w: 280, h: 280, radius: 80, fill: 'transparent',
+          id: T_D, x: -100, y: -150, w: 280, h: 280, radius: 80, fill: 'transparent',
           stroke: 'rgba(185,196,212,0.4)', strokeWidth: 2, strokeStyle: 'dashed',
         }),
-        kicker('AND AWAIT READS LIKE PROSE', { x: 340, y: 148, w: 600, h: 26, align: 'center' }),
+        kicker('NOTHING HERE REDREW', { x: 340, y: 128, w: 600, h: 26, align: 'center' }),
+        // Column labels — small, so the two halves read as a comparison.
+        text({
+          x: 96, y: 186, w: 480, h: 24, html: 'MATHS \u2014 plain <b>\\$\u2026\\$</b> in a text box',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        text({
+          x: 640, y: 186, w: 544, h: 24, html: 'CODE \u2014 <b>77 languages</b> built in',
+          fontSize: 13, fontWeight: 700, letterSpacing: 1.5, color: 'rgba(185,196,212,0.62)',
+          align: 'left', valign: 'middle',
+        }),
+        // LEFT: the derivation. Display mode so fractions and the radical set
+        // at full size; a, b and c travel between the three beats.
+        text({
+          id: EQ, x: 96, y: 226, w: 480, h: 280,
+          html: '$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$',
+          fontSize: 30, color: '#FFFFFF', align: 'center', valign: 'middle',
+        }),
+        // RIGHT: the same trick on code, running at the same time.
         {
-          ...defaultCode({ id: CODE, x: 330, y: 206, w: 620, h: 330 }),
+          ...defaultCode({ id: CODE_ID, x: 640, y: 226, w: 544, h: 280 }),
           content: "const slides = await load(deck)\nconst frame = await render(slides)\npresent(frame)\nconfetti()",
-          grammarName: 'js', fontSize: 26, lineHeight: 1.62, color: '#DCE3EC',
-          align: 'left', valign: 'top',
+          grammarName: 'js', fontSize: 19, lineHeight: 1.62, color: '#DCE3EC',
+          align: 'left', valign: 'middle',
         },
         text({
-          x: 290, y: 566, w: 700, h: 60,
-          html: 'Same tokens, three rewrites — <b>the diff is the animation</b>.',
+          x: 190, y: 560, w: 900, h: 60,
+          html: 'Same <b>a</b>, <b>b</b>, <b>c</b>. Same <b>load</b>, <b>render</b>, <b>present</b>. The diff is the animation.',
           fontSize: 19, fontWeight: 500, color: MIST, align: 'center', lineHeight: 1.65,
         }),
       ],

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -483,9 +483,15 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
    proper MATH metrics the browser assembles the radical itself and its hook
    does not meet its overbar — visible as a step in the square-root sign, and
    different on every machine. Naming real math fonts first gets a proper one
-   on most systems for zero bytes. It does NOT make rendering identical
-   everywhere; only embedding a math font would, and that is a size decision
-   the deck has not taken. */
+   on most systems for zero bytes.
+
+   Two things this does NOT do, both measured. It does not make rendering
+   identical everywhere — a deck with maths still uses whatever math font the
+   reader owns. And it does not fix the radical's hook meeting its overbar:
+   that step is Chromium painting the rule from the font's MATH constants and
+   missing the glyph's own flag, it varies BY font (STIX notches, Noto Sans
+   Math nearly does not), and no CSS can reach it. Embedding a font was costed
+   and declined — see docs/DECISIONS.md, 2026-08-25. */
 .bento-el math {
   font-family: 'STIX Two Math', 'Cambria Math', 'Latin Modern Math', math;
 }

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -479,11 +479,19 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .bento-el { position: absolute; contain: layout style; }
 
 /* Formulas are left on the browser's own `math` family ON PURPOSE — naming a
-   math font here fixes nothing and was reverted twice. Chrome resolves the
-   generic family to STIX Two Math anyway (measured: identical metrics), and
-   the radical's hook falling short of its overbar is a CHROMIUM regression,
-   not a font choice: perfect in 148, broken in 151, across every font and
-   construction tested. See docs/DECISIONS.md, 2026-08-25. */
+   maths font here fixes nothing and has been reverted three times. The
+   radical's hook falling short of its overbar is Chromium drawing the overbar
+   as its own rule and missing the arm the font's glyph paints, by a fraction
+   of a pixel. It is not the font: generic `math` picks STIX on macOS and
+   Cambria Math on Windows and BOTH break, and forcing Times New Roman only
+   makes the break smaller. It is not our markup, our tagging, the stage
+   transform, the font size, or the height of the radicand (measured: the
+   deck's `b²−4ac` and a flat `b−4ac` get a byte-identical 113.8px radical).
+
+   There IS a mitigation — `msqrt { font-family: serif }` with the contents put
+   back to `math` — and it is deliberately NOT shipped: it is clean on macOS
+   and still broken on Windows. Read docs/DECISIONS.md, 2026-08-25, before
+   touching this; the rig is dist-single/radical-windows-test.html. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -479,13 +479,12 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 .bento-el { position: absolute; contain: layout style; }
 
 /* Formulas are left on the browser's own `math` family ON PURPOSE.
-   Naming real math fonts first was tried and reverted: on macOS it selects
-   STIX Two Math, whose radical shows a visible step where the hook should meet
-   the overbar, while the default face joins the two cleanly. Chromium paints
-   that rule from the font's MATH constants and misses the stretched glyph's
-   own flag, so the defect travels WITH the font — picking a "better" math font
-   made the most visible glyph in a formula worse. Measured side by side at
-   300px; see docs/DECISIONS.md, 2026-08-25. */
+   Naming real math fonts first was tried and reverted. Not because it fixed
+   the radical — nothing here does. Chromium paints the radical rule from the
+   font's MATH constants and misses where the stretched glyph's own flag lands,
+   and BOTH faces available on a stock Mac show the resulting step. Preferring
+   STIX only swapped one notching font for another while changing the
+   typography, so the default stands. See docs/DECISIONS.md, 2026-08-25. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -491,7 +491,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
    There IS a mitigation — `msqrt { font-family: serif }` with the contents put
    back to `math` — and it is deliberately NOT shipped: it is clean on macOS
    and still broken on Windows. Read docs/DECISIONS.md, 2026-08-25, before
-   touching this; the rig is dist-single/radical-windows-test.html. */
+   touching this; the rig is slides/probe/radical-join.html. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,13 +478,12 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
-/* Formulas are left on the browser's own `math` family ON PURPOSE — do not
-   "improve" this by naming a math font. That was tried: preferring
-   'STIX Two Math' selects, on macOS, the one face that renders the radical's
-   hook short of its overbar, leaving a visible step. Tested across nine
-   variants, STIX was the only one that breaks; the browser default joins
-   cleanly in a bare root, inside a fraction, and in the deck's own formula.
-   See docs/DECISIONS.md, 2026-08-25. */
+/* Formulas are left on the browser's own `math` family ON PURPOSE — naming a
+   math font here fixes nothing and was reverted twice. Chrome resolves the
+   generic family to STIX Two Math anyway (measured: identical metrics), and
+   the radical's hook falling short of its overbar is a CHROMIUM regression,
+   not a font choice: perfect in 148, broken in 151, across every font and
+   construction tested. See docs/DECISIONS.md, 2026-08-25. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,6 +478,18 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
+/* Formulas ask for the generic `math` family, which is not a font: the browser
+   resolves it to whatever the viewer's OS happens to supply. On a face without
+   proper MATH metrics the browser assembles the radical itself and its hook
+   does not meet its overbar — visible as a step in the square-root sign, and
+   different on every machine. Naming real math fonts first gets a proper one
+   on most systems for zero bytes. It does NOT make rendering identical
+   everywhere; only embedding a math font would, and that is a size decision
+   the deck has not taken. */
+.bento-el math {
+  font-family: 'STIX Two Math', 'Cambria Math', 'Latin Modern Math', math;
+}
+
 .bento-el-text,
 .bento-el-code
  .bento-text-inner {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,13 +478,13 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
-/* Formulas are left on the browser's own `math` family ON PURPOSE.
-   Naming real math fonts first was tried and reverted. Not because it fixed
-   the radical — nothing here does. Chromium paints the radical rule from the
-   font's MATH constants and misses where the stretched glyph's own flag lands,
-   and BOTH faces available on a stock Mac show the resulting step. Preferring
-   STIX only swapped one notching font for another while changing the
-   typography, so the default stands. See docs/DECISIONS.md, 2026-08-25. */
+/* Formulas are left on the browser's own `math` family ON PURPOSE — do not
+   "improve" this by naming a math font. That was tried: preferring
+   'STIX Two Math' selects, on macOS, the one face that renders the radical's
+   hook short of its overbar, leaving a visible step. Tested across nine
+   variants, STIX was the only one that breaks; the browser default joins
+   cleanly in a bare root, inside a fraction, and in the deck's own formula.
+   See docs/DECISIONS.md, 2026-08-25. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,12 +478,37 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
-/* Formulas are left on the browser's own `math` family ON PURPOSE — naming a
-   math font here fixes nothing and was reverted twice. Chrome resolves the
-   generic family to STIX Two Math anyway (measured: identical metrics), and
-   the radical's hook falling short of its overbar is a CHROMIUM regression,
-   not a font choice: perfect in 148, broken in 151, across every font and
-   construction tested. See docs/DECISIONS.md, 2026-08-25. */
+/* THE RADICAL FIX — do not delete, and do not "simplify" to `serif`.
+   Chromium draws the square-root sign short of its own overbar when the maths
+   font is STIX Two Math, leaving a visible step where the hook should meet the
+   bar. Verified against every other candidate: the plain serif fallback, Noto
+   Sans Math, four STIX variants with patched MATH constants and a hand-built
+   radical all join cleanly; STIX alone breaks, in Chromium 148 AND 151.
+
+   It bites us because Chrome resolves the GENERIC `math` family to STIX on
+   macOS (measured: generic and STIX give identical metrics, 521.9x139.1, while
+   the serif fallback gives 450.9x121.6). So a deck picks up the one bad face
+   without ever naming it. Other engines resolve `math` elsewhere and look fine,
+   which is why this reproduces in Chrome and not in every browser.
+
+   The stack below names real maths fonts first and falls back to serif, so it
+   changes NOTHING except where STIX would have been chosen: Windows keeps
+   Cambria Math, a TeX install keeps Latin Modern Math, and macOS — which has
+   neither — lands on serif instead of STIX. Windows and Linux are unverified,
+   but they are unchanged by construction rather than by assumption.
+
+   Scoped to msqrt, with the contents put back, because `serif` has no MATH
+   table: applied to a whole formula it stops brackets stretching around a
+   fraction (measured: 315px -> 94px) and shrinks the large operators. Only the
+   radical's own glyph and rule come from the fallback; everything inside it,
+   and everything around it, stays in the maths font. See docs/DECISIONS.md,
+   2026-08-25. */
+.bento-el math msqrt {
+  font-family: 'Cambria Math', 'Latin Modern Math', serif;
+}
+.bento-el math msqrt * {
+  font-family: math;
+}
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,37 +478,12 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
-/* THE RADICAL FIX — do not delete, and do not "simplify" to `serif`.
-   Chromium draws the square-root sign short of its own overbar when the maths
-   font is STIX Two Math, leaving a visible step where the hook should meet the
-   bar. Verified against every other candidate: the plain serif fallback, Noto
-   Sans Math, four STIX variants with patched MATH constants and a hand-built
-   radical all join cleanly; STIX alone breaks, in Chromium 148 AND 151.
-
-   It bites us because Chrome resolves the GENERIC `math` family to STIX on
-   macOS (measured: generic and STIX give identical metrics, 521.9x139.1, while
-   the serif fallback gives 450.9x121.6). So a deck picks up the one bad face
-   without ever naming it. Other engines resolve `math` elsewhere and look fine,
-   which is why this reproduces in Chrome and not in every browser.
-
-   The stack below names real maths fonts first and falls back to serif, so it
-   changes NOTHING except where STIX would have been chosen: Windows keeps
-   Cambria Math, a TeX install keeps Latin Modern Math, and macOS — which has
-   neither — lands on serif instead of STIX. Windows and Linux are unverified,
-   but they are unchanged by construction rather than by assumption.
-
-   Scoped to msqrt, with the contents put back, because `serif` has no MATH
-   table: applied to a whole formula it stops brackets stretching around a
-   fraction (measured: 315px -> 94px) and shrinks the large operators. Only the
-   radical's own glyph and rule come from the fallback; everything inside it,
-   and everything around it, stays in the maths font. See docs/DECISIONS.md,
-   2026-08-25. */
-.bento-el math msqrt {
-  font-family: 'Cambria Math', 'Latin Modern Math', serif;
-}
-.bento-el math msqrt * {
-  font-family: math;
-}
+/* Formulas are left on the browser's own `math` family ON PURPOSE — naming a
+   math font here fixes nothing and was reverted twice. Chrome resolves the
+   generic family to STIX Two Math anyway (measured: identical metrics), and
+   the radical's hook falling short of its overbar is a CHROMIUM regression,
+   not a font choice: perfect in 148, broken in 151, across every font and
+   construction tested. See docs/DECISIONS.md, 2026-08-25. */
 
 .bento-el-text,
 .bento-el-code

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -478,23 +478,14 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
 
 .bento-el { position: absolute; contain: layout style; }
 
-/* Formulas ask for the generic `math` family, which is not a font: the browser
-   resolves it to whatever the viewer's OS happens to supply. On a face without
-   proper MATH metrics the browser assembles the radical itself and its hook
-   does not meet its overbar — visible as a step in the square-root sign, and
-   different on every machine. Naming real math fonts first gets a proper one
-   on most systems for zero bytes.
-
-   Two things this does NOT do, both measured. It does not make rendering
-   identical everywhere — a deck with maths still uses whatever math font the
-   reader owns. And it does not fix the radical's hook meeting its overbar:
-   that step is Chromium painting the rule from the font's MATH constants and
-   missing the glyph's own flag, it varies BY font (STIX notches, Noto Sans
-   Math nearly does not), and no CSS can reach it. Embedding a font was costed
-   and declined — see docs/DECISIONS.md, 2026-08-25. */
-.bento-el math {
-  font-family: 'STIX Two Math', 'Cambria Math', 'Latin Modern Math', math;
-}
+/* Formulas are left on the browser's own `math` family ON PURPOSE.
+   Naming real math fonts first was tried and reverted: on macOS it selects
+   STIX Two Math, whose radical shows a visible step where the hook should meet
+   the overbar, while the default face joins the two cleanly. Chromium paints
+   that rule from the font's MATH constants and misses the stretched glyph's
+   own flag, so the defect travels WITH the font — picking a "better" math font
+   made the most visible glyph in a formula worse. Measured side by side at
+   300px; see docs/DECISIONS.md, 2026-08-25. */
 
 .bento-el-text,
 .bento-el-code


### PR DESCRIPTION
Two new slides after the symbol morph (3c) — the deck's narrative is literally *"and the same trick works on code"*, since formulas and code tokens ride the same `data-sym` mechanism.

One clear motion at the deck's default tempo: **`breathe()` travels from fourth call to first** — three line-heights, ~138px in slide space — while the calls it passes step down a row. Every token pairs (verified with the diff probe before the content went in; zero ink inserts), the four `sd-tile-*` shapes carry through both slides, notes keep the feature-tour voice, the fade beat stays undisturbed.

### The bug this flushed out

The pair uses the **duplicate-a-slide idiom** — same element id `sd-code` on both slides, which is the deck's own default-pairing story — and that exposed a real regression from the #259 token-source rewrite: `renderCodeInto` resolved its slide by element *id*, so both twins resolved to the first slide and slide two rendered slide one's tokens. Same text, zero travel, completely silent. Fixed with reference equality (the element handed to the renderer is the model object), which is what the original #259 code did. The scenario matrix never caught it because its elements had unique ids + shared `morphId`; the starter deck is now the standing regression for the shared-id path.

Verified in the built shell by rendered geometry: breathe travels up, polish steps down one row, 22 tokens move, all four tiles morph on the same beat, no ghost sections. Shell 664KB (zopfli).
