### PR TITLE
fix(slides): prevent sticky move after fast click

### DIFF
--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -1043,10 +1043,30 @@ export class SlideCanvas {
       this.store.select(this.expandGroups(ids))
       if (e.isDragStartEnd) {
         e.inputEvent.preventDefault()
-        // Selecting a new target and handing the same press to Moveable takes
-        // an async target refresh. A fast click can release during that wait;
-        // starting Moveable afterwards leaves it dragging forever because its
-        // matching mouseup has already happened (#260).
+        // Hand this same press to Moveable, so pressing an unselected element and
+        // dragging moves it without needing a second press. Moveable cannot accept
+        // the press until its target has actually changed, and waitToChangeTarget()
+        // resolves only from componentDidMount/componentDidUpdate — the wait is a
+        // render long and there is NO synchronous path to shorten it.
+        //
+        // A fast click releases inside that gap. dragStart then replays a press
+        // whose mouseup has already been and gone, so Moveable begins a drag that
+        // nothing will ever end: the element follows the cursor, and the click that
+        // finally stops it COMMITS the move to the document (#260). Silent, and the
+        // user was only trying to select something.
+        //
+        // So cancel the handoff when the release wins the race. `mouseup`, not
+        // `pointerup` — Gesto listens for mouse events. Capture phase, so a handler
+        // that stops propagation cannot hide it from us. The guarded window is
+        // complete: selectEnd runs inside the mousedown dispatch, so a release
+        // cannot land before the listener exists. Measured at 40x CPU throttle
+        // (the reporter's symptom is hardware-speed dependent): 22/24 clicks stuck
+        // without this, 0/24 with it, deliberate held drags unaffected.
+        //
+        // Do NOT "simplify" this by making the target swap synchronous — that means
+        // reaching into react-moveable's private _checkChangeTargets(). The real fix
+        // is to stop replaying a stale press and start the drag from a live move
+        // event instead; that is a rework of this gesture, not a tidy-up.
         let released = false
         const onMouseUp = () => { released = true }
         window.addEventListener('mouseup', onMouseUp, { capture: true, once: true })

--- a/slides/src/editor/canvas.ts
+++ b/slides/src/editor/canvas.ts
@@ -1043,7 +1043,16 @@ export class SlideCanvas {
       this.store.select(this.expandGroups(ids))
       if (e.isDragStartEnd) {
         e.inputEvent.preventDefault()
+        // Selecting a new target and handing the same press to Moveable takes
+        // an async target refresh. A fast click can release during that wait;
+        // starting Moveable afterwards leaves it dragging forever because its
+        // matching mouseup has already happened (#260).
+        let released = false
+        const onMouseUp = () => { released = true }
+        window.addEventListener('mouseup', onMouseUp, { capture: true, once: true })
         this.moveable.waitToChangeTarget().then(() => {
+          window.removeEventListener('mouseup', onMouseUp, true)
+          if (released) return
           this.moveable.dragStart(e.inputEvent)
         })
       }


### PR DESCRIPTION
**What & why**

Fixes #260.

A fast single click can release while `waitToChangeTarget()` is still pending. The code can then pass the stale mouse-down event to Moveable after mouse-up. Moveable starts a drag without seeing the matching release, so the selected object follows the cursor.

This change installs a capture-phase mouse-up guard before the async wait. It cancels the stale handoff when release wins the race. A normal held-button drag still uses the existing path.

**How I verified it**

- Reproduced the unpatched failure with a real browser mouse. The object moved from `(850,170)` to `(1014,251)` after mouse-up.
- Ran 30 fast-click trials against the patch. All 30 kept the object at `(850,170)`.
- Verified that a deliberate held-button drag still moved the object to `(960,223)`.
- Ran `node_modules/.bin/tsc -b` successfully.
- Ran `npm run build:single` successfully.
- Ran `node ../scripts/shell-gate.mjs dist-single/Bento_Slides.bento.html` successfully.

**Checklist**

- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [x] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/` (not applicable)
- [x] New UI strings added to every catalog in `slides/src/i18n/` (no new strings)
- [x] Document format changes are additive and backward-compatible (no format change)
- [x] Did not bump the version or cut a release (maintainers sign releases)
