### PR TITLE
Reference equality fix.

### DIFF
--- a/slides/src/code.ts
+++ b/slides/src/code.ts
@@ -78,7 +78,7 @@ export function renderCodeInto(pre: HTMLElement, el: CodeElement, doc: BentoDoc)
   // first slide's tokens — same text, zero travel. The element handed to the
   // renderer is the model object itself, so identity is exact. (The original
   // implementation got this right; a rewrite briefly did not.)
-  const slideIdx = doc.slides.findIndex((s) => (s.elements as unknown[]).includes(el))
+  const slideIdx = doc.slides.findIndex((s) => s.elements.some((e) => e === el))
   if (slideIdx < 0) return false
   const states = diffFor(doc, morphKey)
   const slideStates = states.get(slideIdx)


### PR DESCRIPTION
- `e.id === el.id` will be true for all copied slides when using the copy to morph workflow.
- Instead what we should be comparing is `e === el`. (given `String`s are immutable)

<!-- Thanks for contributing! Keep PRs focused — one concern each. -->

**What & why**
- Minor bug fix for code copy slide workflow.

**How I verified it**
- `npm run dev` and tested it locally.
- `npm run build:single` and verified the changes.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [ ] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/`
- [ ] New UI strings added to every catalog in `slides/src/i18n/`
- [ ] Document format changes are additive and backward-compatible
- [ ] Did not bump the version or cut a release (maintainers sign releases)
