### PR TITLE
anim: MathML elements can be animated too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
         working-directory: slides
         run: npm ci
 
+      - name: Which targets anim treats as elements
+        # The element/plain-object split ran on HTMLElement||SVGElement, which
+        # excludes MathML — formula symbols became plain-object tweens, with
+        # opacity assigned as a JS property and no style ever written.
+        run: node scripts/test-anim-elements.ts
+
       - name: Transforms are not silently ignored
         # A CSS transform does nothing to a non-replaced inline element: it is
         # accepted, style.transform reads back verbatim, and the box never

--- a/kernel/src/anim.ts
+++ b/kernel/src/anim.ts
@@ -298,7 +298,15 @@ export class Tween {
     this.started = true
     const t = this.target
     const from = this.from ?? {}
-    const isEl = t instanceof HTMLElement || t instanceof SVGElement
+    // MathML counts. <mi>/<mn>/<mo> are MathMLElement — neither HTMLElement
+    // nor SVGElement — so naming only those two silently routed every formula
+    // symbol into the plain-object branch below, where `opacity` became a JS
+    // property on the node and no style was ever written. The symbols still
+    // MOVED, because morphMathSymbols writes style.transform itself rather
+    // than going through a channel, so only the fade was missing: new terms in
+    // a formula appeared instantly while new code tokens faded in beside them.
+    // Any Element carrying a style object is animatable.
+    const isEl = t instanceof Element && 'style' in t
     for (const [key, toVal] of Object.entries(this.vars)) {
       if (CONTROL.has(key) || toVal === undefined) continue
       this.channels.add(key)

--- a/scripts/test-anim-elements.ts
+++ b/scripts/test-anim-elements.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Bento authors
+// Which targets anim treats as ELEMENTS.
+//
+//   node scripts/test-anim-elements.ts
+//
+// WHAT THIS PROVES. anim splits targets in two: elements get style channels
+// (opacity, transform…), everything else is a plain-object tween used for
+// count-up state. The split ran on `instanceof HTMLElement || SVGElement`,
+// which silently excludes MathML — <mi>, <mn> and <mo> are MathMLElement.
+//
+// Nothing errored. Formula symbols fell into the plain-object branch, where
+// `opacity` was assigned as a JS PROPERTY of the node and no style was ever
+// written. They still moved, because the symbol morph writes style.transform
+// itself rather than going through a channel, so exactly one thing was
+// missing: new terms in a formula appeared instantly while new code tokens
+// faded in next to them. Visible only when both ran side by side.
+
+import { anim } from '../kernel/src/anim.ts'
+
+const FAILS: string[] = []
+const check = (name: string, cond: boolean) => {
+  if (!cond) FAILS.push(name)
+  console.log(`${cond ? '  ok  ' : ' FAIL '} ${name}`)
+}
+
+// Minimal DOM stand-ins: anim only needs instanceof Element and a style bag.
+class FakeElement { style: Record<string, string> = {} }
+class FakeHTML extends FakeElement {}
+class FakeSVG extends FakeElement {}
+class FakeMathML extends FakeElement {}     // <mi>, <mn>, <mo>
+const g: any = globalThis
+g.Element = FakeElement
+g.HTMLElement = FakeHTML
+g.SVGElement = FakeSVG
+g.MathMLElement = FakeMathML
+g.getComputedStyle = () => ({ opacity: '1', transform: 'none', display: 'block math' })
+// anim starts a rAF ticker even in manual mode; headless needs a stub.
+g.requestAnimationFrame = () => 0
+g.cancelAnimationFrame = () => {}
+
+anim.setManual(true)
+
+const fadeIn = (el: any) => {
+  anim.fromTo(el, { opacity: 0 }, { opacity: 1, duration: 1 })
+  anim.tick(0.001)
+}
+
+// 1. THE REGRESSION — a MathML token must receive a STYLE, not a property.
+{
+  const mi = new FakeMathML()
+  fadeIn(mi)
+  check('MathML token gets style.opacity', typeof mi.style.opacity === 'string')
+  check('MathML token is NOT assigned a bare property', (mi as any).opacity === undefined)
+  anim.tick(1.2)
+  check('MathML token lands at its to-value', Math.abs(parseFloat(mi.style.opacity) - 1) < 0.01)
+}
+
+// 2. The two kinds that always worked keep working.
+for (const [name, El] of [['HTMLElement', FakeHTML], ['SVGElement', FakeSVG]] as const) {
+  const el: any = new (El as any)()
+  fadeIn(el)
+  check(`${name} gets style.opacity`, typeof el.style.opacity === 'string')
+}
+
+// 3. NEGATIVE CONTROL — plain objects must still tween as properties, or the
+//    count-up state animation breaks.
+{
+  const state: any = { p: 0 }
+  anim.fromTo(state, { p: 0 }, { p: 1, duration: 1 })
+  anim.tick(0.5)
+  check('plain object still tweens its property', state.p > 0 && state.p <= 1)
+  check('plain object gets no style bag', state.style === undefined)
+}
+
+// 4. An Element WITHOUT a style bag must not be mistaken for an animatable
+//    element (defensive: the check is `instanceof Element && 'style' in t`).
+{
+  class Bare extends FakeElement {}
+  const bare: any = new Bare()
+  delete (bare as any).style
+  let threw = false
+  try { anim.fromTo(bare, { opacity: 0 }, { opacity: 1, duration: 1 }); anim.tick(0.1) }
+  catch { threw = true }
+  check('style-less Element does not throw', !threw)
+}
+
+anim.setManual(false)
+console.log(FAILS.length ? `\n${FAILS.length} FAILED` : '\nall passed')
+process.exit(FAILS.length ? 1 : 0)


### PR DESCRIPTION
The element/plain-object split in `anim` ran on `instanceof HTMLElement || SVGElement`. **MathML is neither** — `<mi>`, `<mn>`, `<mo>` are `MathMLElement` — so every formula symbol was routed into the plain-object branch, where `opacity` was assigned as a JS *property* of the node and no style was ever written.

No error. `getTweensOf` still reported a live tween on the element.

### Why it hid for so long

Formula symbols **do** move — the symbol morph writes `style.transform` itself rather than going through a channel. So exactly one thing was missing: the staggered fade for symbols with no partner on the previous slide. A formula gaining a term showed it appearing instantly while everything else glided, which reads as "that's just how maths morphs".

It only became obvious when maths and code ran **side by side** in the starter deck and the same beat reported:

```
maths[moved:7 faded:0]   code[moved:8 faded:13]
```

Same function, same code path, same delay — one column fading, the other not.

### The fix

```ts
const isEl = t instanceof Element && 'style' in t
```

Covers HTML, SVG and MathML, and doesn't require `MathMLElement` to exist as a global.

### Verification

`scripts/test-anim-elements.ts`, wired into CI, with the negative control that matters — reverting the one-line change fails **exactly** the three MathML assertions:

```
 FAIL  MathML token gets style.opacity
 FAIL  MathML token is NOT assigned a bare property
 FAIL  MathML token lands at its to-value
  ok   HTMLElement gets style.opacity
  ok   SVGElement gets style.opacity
  ok   plain object still tweens its property
```

Plain-object tweens (the count-up state path) are explicitly covered so the split's other side can't regress.

Kernel-zone, standalone per `docs/PARALLEL-WORK.md`. Fixes the polish gap noted on #365.
