### PR TITLE
Sweep the last of the old name out of comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
         # appendingPathComponent was an arbitrary write inside the container —
         # including over another deck the user would later open and trust.
         # Source-shape checks; the Swift half self-skips without a toolchain.
-        run: node scripts/test-tray-bridge.ts
+        run: node scripts/test-home-bridge.ts
 
       - name: tray mark is one source
         # tray-icon.svg is the only drawing of the mark. Everything else is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ names provisional.
   never contain `</script>`. File System Access API first, download fallback.
 - `src/preview.ts` + kernel `registerPreview` — **static first-page preview for
   file-manager thumbnails**. Thumbnailers (iOS Files, macOS QuickLook/Finder,
-  Bento Tray) render HTML with JS OFF, so every deck used to thumbnail as the
+  bento/home) render HTML with JS OFF, so every deck used to thumbnail as the
   same boot splash. Every save now writes a still render of page one into the
   shell as a plain `[data-bento-preview]` element, followed IMMEDIATELY by a
   parser-blocking `<script data-bento-preview>` that deletes both. The

--- a/kernel/src/save.ts
+++ b/kernel/src/save.ts
@@ -143,7 +143,7 @@ function serializeBody(shell: Document, body: string, doc: KernelDoc): string {
 // --- static first-page preview (file-manager thumbnails) ---------------------
 //
 // THE PROBLEM. A Bento file is one HTML document, and thumbnailers — iOS
-// Files, macOS QuickLook/Finder, the Bento Tray app — render HTML with
+// Files, macOS QuickLook/Finder, the bento/home app — render HTML with
 // JavaScript DISABLED (verified: `qlmanage -t` renders <noscript> content).
 // Until our runtime boots, every deck genuinely IS the same bytes plus the
 // boot splash, so every deck thumbnailed as the same dark box.

--- a/scripts/test-home-bridge.ts
+++ b/scripts/test-home-bridge.ts
@@ -4,7 +4,7 @@
 // iOS tray bridge rig — the untrusted-name filter, the handle routing, and the
 // JS reply encoder.
 //
-//   node scripts/test-tray-bridge.ts
+//   node scripts/test-home-bridge.ts
 //
 // WHAT THIS PROVES. These functions guard the boundary where a DOCUMENT — which
 // this host treats as untrusted, since it opens any self-contained HTML file —
@@ -153,7 +153,7 @@ while let line = readLine(strippingNewline: true) {
 }
 `
 
-const work = mkdtempSync(join(tmpdir(), 'bento-tray-rig-'))
+const work = mkdtempSync(join(tmpdir(), 'bento-home-rig-'))
 writeFileSync(join(work, 'harness.swift'), harness)
 execFileSync('swiftc', ['-swift-version', '5', '-o', join(work, 'harness'), join(work, 'harness.swift')],
   { stdio: 'inherit' })

--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -1418,7 +1418,7 @@ function fsTable(f: string): string {
 // ---- a saved space shows its content to readers that run no script --------
 // The runtime ships deflated and inflates at boot, so with scripting off
 // nothing boots and the splash is never removed: every saved space appeared as
-// the bento boot animation to macOS QuickLook, iOS Files, Bento Tray and any
+// the bento boot animation to macOS QuickLook, iOS Files, bento/home and any
 // preview pane that renders HTML without executing it. Reported from the field.
 {
   const fsv = await import('node:fs')

--- a/spaces/src/main.ts
+++ b/spaces/src/main.ts
@@ -43,7 +43,7 @@ configureApp({
 })
 
 // Every save writes a still render of the home page into the shell, for the
-// readers that run no script: macOS QuickLook, iOS Files, Bento Tray, and any
+// readers that run no script: macOS QuickLook, iOS Files, bento/home, and any
 // preview pane that renders HTML without executing it. Without this the runtime
 // never inflates, the splash is never removed, and a saved space shows a boot
 // animation where its content should be. See preview.ts.

--- a/spaces/src/preview.ts
+++ b/spaces/src/preview.ts
@@ -5,7 +5,7 @@
 // WHAT THIS IS FOR. The shell's runtime ships DEFLATED and is inflated by a
 // loader at boot. With scripting off nothing inflates, nothing boots, and the
 // splash is never removed — so a saved space appeared as the bento boot screen
-// to macOS QuickLook, iOS Files, Bento Tray, and any preview pane that renders
+// to macOS QuickLook, iOS Files, bento/home, and any preview pane that renders
 // HTML without running it. A file whose whole promise is "this is the document"
 // showed a loading animation instead of the document.
 //

--- a/spaces/src/sanitize.ts
+++ b/spaces/src/sanitize.ts
@@ -29,7 +29,7 @@ const ALLOWED = new Set([
  * stripping every internal link — while on a static host it becomes
  * `https://…#p/abc` and passes. Measured. The bug would be invisible in the
  * environment an author develops in and total in the two environments the
- * format exists for (file://, and bento/tray on iOS).
+ * format exists for (file://, and bento/home on iOS).
  *
  * `#p/` is an intra-space page link. There is deliberately no second fragment
  * form: an undefined entry in this list is a one-way data hazard, because an


### PR DESCRIPTION
The last of the old name, in prose. No behaviour changes.

- `kernel/src/save.ts`, `CLAUDE.md`, `scripts/test-spaces-model.ts`, `spaces/src/{main,preview,sanitize}.ts` — comments naming the thumbnailer host
- `scripts/test-tray-bridge.ts` → `scripts/test-home-bridge.ts`, plus its CI reference and its own temp-dir prefix

Rigs pass: `test-home-bridge` 52/52, `test-webext-background` 83/83, `test-webext-i18n` 100/100, packer exit 0.

## Deliberately not touched

- **`scripts/test-webext-background.ts:442`** still asserts the IndexedDB name is `bento-tray`. That guard exists to stop the name drifting and silently orphaning every stored folder grant; nobody outside the extension sees it, so renaming it would mean editing a gate to admit a cosmetic change.
- **`docs/DECISIONS.md` and `CHANGELOG.md`** keep their `tray/` references. They record what was true when written, and a history log that gets rewritten stops being one.

## Not in this PR, and still user-facing

`slides` advertises the extension by its old name in nine languages — `slides/src/editor/returngate.ts:47,49` plus every `slides/src/i18n/*.ts` and the compiled `packed.ts`. That is the slides session's zone; noted separately.

Three of the files here are in `spaces/`, which is active. They are single comment lines, so a conflict would be trivial, but worth knowing.
