### PR TITLE
spaces: the page tree says where you are, to everyone

### DIFF
--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -427,6 +427,23 @@ for (const [label, input, err] of [
   }
 }
 
+// ---- the page tree says where you are, to everyone -------------------------
+// `sp-here` renders the current page at weight 600 against 400. A sighted
+// reader gets that for free; a screen reader was told nothing, so the tree read
+// as a flat list of links with no indication which one you were on. Weight is
+// not an announcement. There are TWO places that set the class — the tree and
+// the archived list — and an attribute added to one of them is the kind of
+// half-fix that looks done.
+{
+  const fs = await import('node:fs')
+  const ed = fs.readFileSync(new URL('../spaces/src/editor.ts', import.meta.url), 'utf8')
+  const setsClass = (ed.match(/sp-here/g) ?? []).length
+  const setsAria = (ed.match(/setAttribute\('aria-current', 'page'\)/g) ?? []).length
+  ok(setsAria >= 2, `every row that can be current announces it (${setsAria} call sites)`)
+  ok(setsAria >= setsClass - 1,
+    'no place styles itself as current without saying so — sp-here and aria-current stay paired')
+}
+
 // ---- find & replace: the number shown IS the number changed ----------------
 // Replace-all is destructive and lands in one commit, so the count in the
 // readout, the count in the confirmation and the count of things that change

--- a/spaces/src/editor.ts
+++ b/spaces/src/editor.ts
@@ -987,7 +987,14 @@ export class Editor {
       li.style.paddingInlineStart = `${depth * 14}px`
       const a = document.createElement('a')
       a.href = `#p/${page.id}`
-      a.className = 'sp-treelink' + (page.id === s.pageId ? ' sp-here' : '')
+      const here = page.id === s.pageId
+      a.className = 'sp-treelink' + (here ? ' sp-here' : '')
+      // WEIGHT IS NOT AN ANNOUNCEMENT. sp-here says "you are here" in 600
+      // against 400, which a sighted reader gets for free and a screen reader
+      // is told nothing about — the tree reads as a flat list of links with no
+      // indication of which one you are on. aria-current is the one attribute
+      // that carries it.
+      if (here) a.setAttribute('aria-current', 'page')
       const ico = el('span', 'sp-tree-ico')
       ico.innerHTML = pageIcon(page.icon)
       const label = document.createElement('span')
@@ -1047,7 +1054,9 @@ export class Editor {
         const li = document.createElement('li')
         const a = document.createElement('a')
         a.href = `#p/${page.id}`
-        a.className = 'sp-treelink sp-arch-row' + (page.id === s.pageId ? ' sp-here' : '')
+        const hereA = page.id === s.pageId
+        a.className = 'sp-treelink sp-arch-row' + (hereA ? ' sp-here' : '')
+        if (hereA) a.setAttribute('aria-current', 'page')
         const ico = el('span', 'sp-tree-ico')
         ico.innerHTML = pageIcon(page.icon)
         const label = document.createElement('span')


### PR DESCRIPTION
From auditing the surfaces I had never looked at — sidebar, search, find & replace, import, board.

**The finding.** The current page is marked in the tree by `sp-here`: weight 600 against 400. A sighted reader gets that for free; a screen reader was told nothing, so the tree read as a flat list of links with no indication of which one you were on. Weight is not an announcement — `aria-current="page"` is the attribute that carries it.

Both call sites, because there are two: the tree and the archived list. An attribute added to one of them is the kind of half-fix that looks done, so the rig checks the count and fails if they drift apart — **verified by dropping the archived one**, which fails both assertions.

Confirmed in the browser: exactly one `aria-current="page"`, on the same element as `sp-here`, and it *moves* on navigation rather than accumulating.

**32 bytes.**

## The rest of the audit came back clean

Worth recording, because it changes the picture:

- **Search** — autofocus, page + snippet results, a real "Nothing found" state
- **Find & replace** — both fields, prev/next with shortcuts, live "234 found", and Next correctly marks the current match, updates to "1 of 234" and scrolls to it
- **Board** — columns with status dots and counts, cards with status/priority pills, drag targets, horizontal scroll
- **Import** — clear explanation, a destination picker, three source choices

So the haphazardness really was concentrated in the chrome — the topbar, the menus, the popovers — and that is now fixed. These surfaces did not need work.

One refinement noted and *not* done: find highlights only the current match, where most editors also tint the others faintly. That is a preference, not a defect, and it costs bytes we do not have.

Gates: 790/790 model, 175/175 agent, 90/90 calc ×4 timezones, 45/45 journal ×5, undo 25/25, invite 34/34, shell-gate clean. Size 258,454 B — 98.6%.