### PR TITLE
Swatch borders follow the theme, not a light-mode literal

### DIFF
--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2488,7 +2488,7 @@ input.ed-toggle { width: 16px; height: 16px; accent-color: #5E7699; cursor: poin
 .ed-swatches { display: flex; gap: 3px; flex-wrap: wrap; justify-content: flex-end; }
 .ed-swatch {
   width: 14px; height: 14px; padding: 0; border-radius: 3px; cursor: pointer;
-  border: 1px solid rgb(30 42 58 / 0.25);
+  border: 1px solid var(--line);
 }
 .ed-swatch:hover { transform: scale(1.15); }
 .ed-swatch.is-on { outline: 2px solid var(--blue); outline-offset: 1px; }


### PR DESCRIPTION
One line missed in #317's rebase: the palette swatch border was authored as `rgb(30 42 58 / 0.25)` before the dark-mode work merged underneath it — ink at fixed opacity on a surface that now follows the theme, so on a dark panel the border all but disappears. This is the exact pattern the 1.0.18 dark-mode fix removed everywhere else. `var(--line)` is what every other hairline in the panel uses.

(I made this fix during the #317 rebase but applied it after the rebase commits, so the push carried the commits and not the working tree. Caught by the dirty file blocking the post-merge checkout.)