### PR TITLE
Bump two build-time transitives out of advisory range

### DIFF
--- a/slides/package-lock.json
+++ b/slides/package-lock.json
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1511,7 +1511,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
**What & why**

`npm audit` in `slides/` reported two advisories, both transitive under vite:

| package | | severity | advisory |
|---|---|---|---|
| nanoid | 3.3.16 → 3.3.18 | high (CVSS 5.9) | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — a custom generator loops forever when `size` is zero |
| postcss | 8.5.19 → 8.5.26 | moderate | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset |

vite itself is unchanged at 7.3.6, and `package.json` is untouched. Seven lines
of lockfile.

**This is hygiene, not a fix for anything a reader could reach.** Neither
package ships: `nanoid` gets zero hits in the built shell, and postcss is a
compile-time processor whose own code never lands in a file. The postcss
advisory needs attacker-controlled CSS to be processed, and the only CSS
postcss sees is ours — the one place Bento scopes CSS it did not write is
`scopeCss` in `slides/src/render.ts`, which is our own function running in the
browser, with no postcss involved.

**How I verified it**

- The built shell is **byte-identical** before and after — 685328 bytes both
  ways, `cmp` clean. That is the real evidence that nothing we ship moved.
- `npm audit` now reports 0 vulnerabilities.
- Guards pass locally: `test-validate` 44/44, `test-preview` 28/28,
  `test-codediff`, `test-anim-elements`, `test-anim-inline`.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] `npm run build:single` succeeds (from `slides/`)
- [ ] Ran `node scripts/test-sync.ts` if I touched `slides/src/sync/` — n/a
- [ ] New UI strings added to every catalog — n/a
- [x] Document format changes are additive and backward-compatible — n/a, no format change
- [x] Did not bump the version or cut a release