### PR TITLE
ci: the size step stops claiming to enforce a ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,13 +199,19 @@ jobs:
             TZ=$tz node scripts/test-spaces-calc.ts
           done
 
-      - name: Spaces shell size ceiling
+      - name: Spaces shell size
         # A budget nobody measures is a wish. DECISIONS.md set a 100KB ceiling,
         # the round finished at 108KB, and the same entry claimed the ceiling
         # was "checked per feature from here" while shipping no mechanism — so
         # the breach was found by a reviewer reading the number rather than by
-        # the build that caused it. Raising the ceiling is fine and expected;
-        # raising it SILENTLY is what this stops.
+        # the build that caused it.
+        #
+        # bento/spaces has NO CEILING as of 2026-08-24 (the maintainer's call;
+        # at 98.6% it had started deciding which fixes were affordable). This
+        # step still runs and still prints the size and the drift from the
+        # recorded reference — it just no longer fails on it. Shells that keep
+        # enforce:true in scripts/size-budgets.json DO still fail here, which is
+        # why the step is not simply deleted. Rationale in docs/DECISIONS.md.
         run: node scripts/test-spaces-size.mjs
 
       - name: Spaces model rig


### PR DESCRIPTION
spaces lost its hard ceiling in #378, but the CI step was still called **"Spaces shell size ceiling"**. A step that names a guarantee it no longer provides is worse than no step — the next person reads the log, sees a ceiling checked, and believes something the build is not doing.

Renamed to **"Spaces shell size"**, and the comment now says what is true: the step still runs and still prints the size and the drift from the recorded reference, it just no longer fails on it — and shells that keep `enforce: true` **do** still fail here, which is why it is not simply deleted. Rationale points at `docs/DECISIONS.md`.

**Nothing functional.** The required status check is the *job* (`validate`), not the step, so branch protection is untouched. The whole diff is one name and its comment, with no job key changed, no tabs/CRLF introduced, 102 steps and no duplicate names. No stale references to the old name anywhere in the repo.

Held back from #378 because I had concluded that a PR touching `.github/workflows/` never gets a CI run created. **That was wrong** — the run was slow, not absent, and it passed in 3m55s. Landing the rename separately was the right outcome for the wrong reason.