### PR TITLE
spaces: ask the remote question about the URL that will actually be fetched

### DIFF
--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -27,7 +27,7 @@
 //      docId on every open.
 
 import {
-  parseDoc, buildIndex, docContentKey, homePage, FORMAT, isRemote,
+  parseDoc, buildIndex, docContentKey, homePage, FORMAT, isRemote, loadsRemotely, assetValue,
   effectiveParents, descendantsOf,
   tableOf, writeTable, tableFallbackHtml, TABLE_MAX_COLS, TABLE_MAX_ROWS,
   linkCard, linkCardHtml,
@@ -307,13 +307,69 @@ for (const [label, input, err] of [
   }
   ok(!isRemote(''), 'an empty src is not a remote fetch')
 
+  // ---- and the same question, asked one indirection deeper -----------------
+  // isRemote answers about the string an author WROTE. `asset:k` is local by
+  // inspection and `doc.assets.k` is whatever the file says it is, so the gate
+  // that decides whether to show the consent placeholder was answering the
+  // wrong question. Measured on a shipped build before this: a document with
+  // `assets: { k: "http://…" }` and an image `src: "asset:k"` issued a real GET
+  // on open, with no placeholder — the tracking pixel the paragraph above says
+  // is prevented.
+  //
+  // BEHAVIOUR, not a source grep. Two assertions in this file were shown to
+  // pass through live regressions because they matched text rather than
+  // running anything, so this one runs the predicate against real documents.
+  {
+    // assetValue reads doc.assets and nothing else, so the fixture is that.
+    const withAssets = (assets: Record<string, string>) => ({ assets }) as never
+
+    const hostile = withAssets({ k: 'http://tracker.example/p.png' })
+    ok(loadsRemotely('asset:k', hostile),
+      'an asset: key whose VALUE is a URL is a remote load, however local the key looks')
+    ok(isRemote(assetValue('asset:k', hostile)),
+      '…because the asset table is resolved before the question is asked')
+
+    const protoRel = withAssets({ k: '//tracker.example/p.png' })
+    ok(loadsRemotely('asset:k', protoRel), 'protocol-relative in the asset table is remote too')
+
+    const embedded = withAssets({ k: 'data:image/png;base64,AAAA' })
+    ok(!loadsRemotely('asset:k', embedded), 'an asset holding embedded bytes is still local')
+
+    const missing = withAssets({})
+    ok(!loadsRemotely('asset:nope', missing), 'an asset key that resolves to nothing loads nothing')
+
+    // the prototype-chain reach the resolver already guards, kept honest here
+    const proto = withAssets({})
+    ok(!loadsRemotely('asset:toString', proto), 'asset:toString does not reach Object.prototype')
+    ok(assetValue('asset:toString', proto) === '', '…and resolves to the empty string, not a function')
+
+    // a plainly written URL is unchanged by any of this
+    ok(loadsRemotely('http://tracker.example/p.png', missing), 'a written URL is still remote')
+    ok(!loadsRemotely('data:image/png;base64,AAAA', missing), 'a written data: URI is still local')
+  }
+
   // and the renderer must actually consult it
   const fs = await import('node:fs')
   const ren = fs.readFileSync(new URL('../spaces/src/render.ts', import.meta.url), 'utf8')
-  ok(/isRemote\(rawSrc\)\s*&&\s*!opts\.allowRemote/.test(ren),
+  // EVERY gate asks the resolved question. Counting them is the point: the
+  // hole was one call site out of five asking `isRemote` about the written
+  // string, and a regex that merely finds "a gate exists" would have passed
+  // throughout. If a sixth surface starts loading something, this count is
+  // what fails.
+  const gates = (ren.match(/loadsRemotely\(/g) ?? []).length
+  ok(gates >= 5, `every surface that loads asks the resolved question (${gates} gates)`)
+  ok(!/isRemote\(rawSrc\)/.test(ren),
+    'no gate asks about the WRITTEN src — that is the hole an asset: key hid in')
+  ok(/loadsRemotely\(rawSrc, doc\)\s*&&\s*!opts\.allowRemote/.test(ren),
     'render.ts gates remote images on the reader\'s consent')
   ok(!/allowRemote/.test(fs.readFileSync(new URL('../spaces/src/model.ts', import.meta.url), 'utf8')),
     'consent is NOT a document field — it belongs to the reader, not the file')
+
+  // The link card's thumbnail is the surface with no gate at all: linkCard()
+  // takes a BLOCK, so it cannot know what an asset: key resolves to, and it was
+  // trusted to have already dropped anything remote.
+  ok(/c\.image && !loadsRemotely\(c\.image, doc\)/.test(ren),
+    'a link card thumbnail is checked where the document is in scope, not where it is built')
 }
 
 // ---- an encrypted space is never written to disk in the clear ---------------
@@ -2177,7 +2233,7 @@ function fsTable(f: string): string {
     'a clip fetches metadata, never the whole file, for a page nobody pressed play on')
   // the remote gate is the image gate, and a clip needs it MORE: a <video> asks
   // its host for byte ranges the moment it is parsed
-  ok(/isRemote\(rawSrc\)[\s\S]{0,200}remotePlaceholder/.test(render),
+  ok(/loadsRemotely\(rawSrc, doc\)[\s\S]{0,200}remotePlaceholder/.test(render),
     'a linked clip is not loaded until the reader agrees, naming the host')
 
   const preview = src('preview.ts')

--- a/spaces/src/model.ts
+++ b/spaces/src/model.ts
@@ -748,6 +748,46 @@ export function isRemote(src: string): boolean {
   return !src.startsWith('asset:') && !src.startsWith('data:')
 }
 
+/**
+ * What an `asset:` src actually points at, or the src itself.
+ *
+ * hasOwn, not a bare index: `assets['toString']` returns a FUNCTION, which is
+ * truthy, so a `?? ''` never fires and the stringified function is what gets
+ * assigned. Same class as the icon lookup — an author-supplied key reaching a
+ * lookup table through the prototype chain.
+ */
+export function assetValue(src: string, doc: SpacesDoc): string {
+  if (!src.startsWith('asset:')) return src
+  const key = src.slice(6)
+  const table = doc.assets
+  return table && Object.hasOwn(table, key) ? String(table[key] ?? '') : ''
+}
+
+/**
+ * Does loading this src reach off the machine — after the asset table has had
+ * its say?
+ *
+ * `isRemote` answers about the string an author WROTE, and that was the whole
+ * test until now. It has a hole one indirection deep: `asset:k` is local by
+ * inspection, and `doc.assets.k` is whatever the file says it is. A document
+ * carrying
+ *
+ *     "assets": { "k": "http://tracker.example/p.png" }
+ *
+ * and an image `src: "asset:k"` fetched it on open — measured on a shipped
+ * build, with the request in the network log. The consent placeholder never
+ * appeared, because the gate had already decided the src was local.
+ *
+ * Nothing can be promised about what is INSIDE a file somebody mails you. What
+ * the app owes its reader is narrower and keepable: it makes no request on a
+ * document's behalf until the reader asks for it. That promise is only as good
+ * as the question this function answers, so it is asked about the URL that will
+ * actually be fetched rather than the one that was typed.
+ */
+export function loadsRemotely(src: string, doc: SpacesDoc): boolean {
+  return isRemote(assetValue(src, doc))
+}
+
 // ---- tables ----------------------------------------------------------------
 // A table is CONTENT (working/design/spaces-design.md §2.6): no formulas, no
 // recalculation, no cross-document references. The line the suite draws is

--- a/spaces/src/render.ts
+++ b/spaces/src/render.ts
@@ -9,7 +9,7 @@
 // story, native ⌘F, print fidelity and lossless markdown export at once, from
 // one decision.
 
-import { type SpacesDoc, type Page, type Block, isRemote, tableOf, linkCard } from './model'
+import { type SpacesDoc, type Page, type Block, loadsRemotely, assetValue, tableOf, linkCard } from './model'
 import { sanitizeInline, inertBody, esc } from './sanitize'
 import { tokenize } from './highlight'
 import { t, locale } from './i18n'
@@ -200,9 +200,9 @@ export function renderBlock(b: Block, doc: SpacesDoc, opts: RenderOpts = {}, cal
       // as `asset:`. Only hand- or agent-authored documents carry URLs, and for
       // those the reader gets a placeholder naming the host and a button. One
       // click, per image, informed — the model every mail client settled on.
-      if (isRemote(rawSrc) && !opts.allowRemote?.(rawSrc)) {
+      if (loadsRemotely(rawSrc, doc) && !opts.allowRemote?.(rawSrc)) {
         fig.appendChild(remotePlaceholder(rawSrc, b, opts,
-          t('Image from {host}', { host: remoteHost(rawSrc) }), t('Load this image')))
+          t('Image from {host}', { host: remoteHost(resolveSrc(rawSrc, doc)) }), t('Load this image')))
         if (b.caption) {
           const cap = document.createElement('figcaption')
           cap.innerHTML = sanitizeInline(String(b.caption))
@@ -286,7 +286,7 @@ export function renderBlock(b: Block, doc: SpacesDoc, opts: RenderOpts = {}, cal
       // <video> asks its host for byte ranges the moment the element is
       // parsed, so an autoplaying tracker is not even needed: opening the
       // space is the ping. Same rule, same host named, different words.
-      if (isRemote(rawSrc) && !opts.allowRemote?.(rawSrc)) {
+      if (loadsRemotely(rawSrc, doc) && !opts.allowRemote?.(rawSrc)) {
         const host = remoteHost(rawSrc)
         fig.appendChild(remotePlaceholder(rawSrc, b, opts,
           play.kind === 'audio' ? t('Audio from {host}', { host }) : t('Video from {host}', { host }),
@@ -335,7 +335,7 @@ export function renderBlock(b: Block, doc: SpacesDoc, opts: RenderOpts = {}, cal
         const poster = String(b.poster ?? '')
         // a remote poster is the same tracking pixel as a remote image, so it
         // goes through the same consent
-        if (poster && !(isRemote(poster) && !opts.allowRemote?.(poster))) {
+        if (poster && !(loadsRemotely(poster, doc) && !opts.allowRemote?.(poster))) {
           const resolved = resolveSrc(poster, doc)
           if (resolved) v.poster = resolved
         }
@@ -387,10 +387,13 @@ export function renderBlock(b: Block, doc: SpacesDoc, opts: RenderOpts = {}, cal
         card.classList.add('sp-dead')
       }
 
-      // THE THUMBNAIL IS LOCAL OR IT IS ABSENT. `linkCard` has already dropped
-      // a remote one — this cannot be re-tested here, because a check that can
-      // be forgotten in one of four surfaces is a check that will be.
-      if (c.image) {
+      // THE THUMBNAIL IS LOCAL OR IT IS ABSENT. `linkCard` drops one that was
+      // WRITTEN remote, and that is as far as it can see: it takes a block, not
+      // a document, so it cannot know what an `asset:` key resolves to. The
+      // asset table is exactly where a remote URL hid, so the resolved check has
+      // to happen at the one place that holds both the src and the document —
+      // here, which is also the only place that loads anything.
+      if (c.image && !loadsRemotely(c.image, doc)) {
         const img = document.createElement('img')
         img.src = resolveSrc(c.image, doc)
         img.alt = ''
@@ -778,17 +781,10 @@ export function paintCode(code: HTMLElement, text: string, lang?: unknown): bool
   return changed
 }
 
+/** What this src loads. One implementation, in model.ts, beside the predicate
+ *  that decides whether loading it leaves the machine. */
 export function resolveSrc(src: string, doc: SpacesDoc): string {
-  // hasOwn, not a bare index: `assets['toString']` returns a FUNCTION, which is
-  // truthy, so the `?? ''` never fired and the stringified function was assigned
-  // to img.src. Same class as the icon lookup — an author-supplied key reaching
-  // a lookup table through the prototype chain.
-  if (src.startsWith('asset:')) {
-    const key = src.slice(6)
-    const table = doc.assets
-    return table && Object.hasOwn(table, key) ? table[key] : ''
-  }
-  return src
+  return assetValue(src, doc)
 }
 
 
@@ -865,7 +861,7 @@ function mediaStill(b: Block, doc: SpacesDoc, opts: RenderOpts, kind: 'video' | 
   const box = document.createElement('div')
   box.className = 'sp-media-still'
   const poster = String(b.poster ?? '')
-  if (poster && !(isRemote(poster) && !opts.allowRemote?.(poster))) {
+  if (poster && !(loadsRemotely(poster, doc) && !opts.allowRemote?.(poster))) {
     const resolved = resolveSrc(poster, doc)
     if (resolved) {
       const img = document.createElement('img')


### PR DESCRIPTION
A document can make the app fetch from a third party on open. **Reproduced on `main` at `d7df5bc`, before any of the current feature work — this ships today.**

```json
"assets": { "k": "http://tracker.example/p.png" }
block:    { "type": "image", "src": "asset:k" }
```

No placeholder, no consent, a real `GET` the moment the page rendered. I watched it in the network log. What leaks is the reader’s IP and the moment they opened your document, to whoever authored the file.

## What was wrong

The consent design is right and stays: a remote image is not blocked, it waits behind a placeholder naming the host — one click per image, the model every mail client settled on.

But the gate asked `isRemote()` about the string the **author wrote**. `asset:k` is local by inspection; `doc.assets.k` is whatever the file says it is. `resolveSrc` handed the table value back verbatim and nothing looked at it again.

## The fix

The question is now asked about the URL that will actually be fetched. `assetValue()` and `loadsRemotely()` sit in `model.ts` beside `isRemote`, `render.ts` delegates `resolveSrc` to that one implementation, and **all five loading surfaces** ask it — image, media, two poster paths, and the link-card thumbnail. The placeholder names the **resolved** host, so the reader is told the site they are really being asked to trust.

**The link card had no gate at all.** `linkCard()` drops a thumbnail written remote, and that is as far as it can see — it takes a block, not a document. The check moved to the renderer, the only place holding both, and the only place that loads anything.

## What this does not claim

Nothing can be promised about what is *inside* a file somebody mails you. The promise is narrower and keepable: **the app makes no request on a document’s behalf until the reader asks.** The About dialog already tells readers the update check is the only network this app makes *on its own* — that sentence is true again.

## The assertions are behavioural

Two existing checks here were source greps for `isRemote(rawSrc)`, and a review demonstrated that greps of this kind pass through live regressions. The new ones run the predicate against real documents — hostile table, protocol-relative, embedded bytes, missing key, `asset:toString` reaching `Object.prototype`. The surviving source checks **count the gates**, so a sixth loading surface that forgets is a failure rather than a silence.

**Verified by reverting the fix three ways:**

| revert | fails |
| --- | --- |
| predicate back to `isRemote(src)` | the hostile-table and protocol-relative assertions |
| one gate back to the written string | the gate count (4), and “no gate asks about the WRITTEN src” |
| link card back to ungated | the gate count, and the link-card assertion |

Then in the browser: the hostile asset draws `Image from localhost:5197`, an embedded asset still renders, **network log empty**.

838/838 model, all eight rigs, shell-gate clean. +0 B of features; size drift shown is the stacked work already on main.