### PR TITLE
Register all three shells for size tracking, and say why two mechanisms stay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,21 +213,6 @@ jobs:
             --outfile="$RUNNER_TEMP/test-spaces-roundtrip.mjs"
           node "$RUNNER_TEMP/test-spaces-roundtrip.mjs"
 
-      - name: Spaces shell size
-        # A budget nobody measures is a wish. DECISIONS.md set a 100KB ceiling,
-        # the round finished at 108KB, and the same entry claimed the ceiling
-        # was "checked per feature from here" while shipping no mechanism — so
-        # the breach was found by a reviewer reading the number rather than by
-        # the build that caused it.
-        #
-        # bento/spaces has NO CEILING as of 2026-08-24 (the maintainer's call;
-        # at 98.6% it had started deciding which fixes were affordable). This
-        # step still runs and still prints the size and the drift from the
-        # recorded reference — it just no longer fails on it. Shells that keep
-        # enforce:true in scripts/size-budgets.json DO still fail here, which is
-        # why the step is not simply deleted. Rationale in docs/DECISIONS.md.
-        run: node scripts/test-spaces-size.mjs
-
       - name: Spaces model rig
         # Properties that fail SILENTLY, and that a shipped file cannot be
         # talked out of once it exists:
@@ -263,6 +248,32 @@ jobs:
 
       - name: Splice conformance gate (dash)
         run: node scripts/shell-gate.mjs dash/dist-single/Bento_Dash.bento.html
+
+      - name: Shell sizes
+        # TWO MECHANISMS, DELIBERATELY. This one and the advisory PR build-size
+        # comment (.github/workflows/pr-build-size*.yml) answer different
+        # questions, and deleting either as "duplicate measurement" loses a
+        # class of regression:
+        #
+        #   this step  — ABSOLUTE and PERSISTENT. A shell with enforce:true has
+        #     a ceiling and FAILS here; a shell with enforce:false prints its
+        #     drift from a committed `reference` and never fails. It is the only
+        #     thing that sees SLOW drift — forty merged commits at 300 B each,
+        #     where every single PR looked fine on its own.
+        #   the PR comment — RELATIVE and PER-PR. It reports this PR against its
+        #     own base and never fails. It is the only thing that attributes a
+        #     jump to the change that caused it, and it is blind to accumulated
+        #     drift.
+        #
+        # Neither subsumes the other. Rationale in docs/DECISIONS.md.
+        #
+        # Placed after ALL THREE builds on purpose: the rig skips a shell that
+        # is not built, so while this sat in the spaces section it silently
+        # measured nothing for dash. bento/spaces has NO CEILING as of
+        # 2026-08-24 (the maintainer's call; at 98.6% it had started deciding
+        # which fixes were affordable) — the step still prints its size and
+        # drift, it just no longer fails on it.
+        run: node scripts/test-spaces-size.mjs
 
       - name: Language pack verification rig
         # Packs come off the network, so the signature + hash-pin chain is the

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5746,3 +5746,54 @@ The picker was split from `openFieldPicker` into `fieldPicker(f, cur, anchor,
 write)` — a picker over a WRITER rather than a block id, because a cell can
 stand for a value that has no block yet. The header strip, the board's card chip
 and a cell are now one control with three writers, not three controls.
+
+## 2026-08-28 — two size mechanisms, and why deleting either loses a regression
+
+**Both stay.** #279 added an advisory PR build-size comment while
+`scripts/test-spaces-size.mjs` already measured shell size in CI. That looks
+like duplicated measurement and it is not, so this entry exists to stop the
+next person tidying one away.
+
+**They answer different questions.**
+
+| | the CI rig (size-budgets.json) | the PR comment (#279) |
+|---|---|---|
+| measured against | a committed `reference`, or a `max` ceiling | the PR's own base commit |
+| horizon | absolute, persistent, across all history | relative, one PR |
+| can fail a build | yes, when `enforce:true` | never, advisory only |
+| catches | SLOW drift — forty merges at 300 B each | a single change's jump |
+| blind to | which change caused it | accumulated drift; every PR looks fine |
+
+The second row is the whole point. Forty merged commits costing 300 bytes each
+is 12KB nobody chose, and **every one of those PRs shows a harmless +300 in its
+comment**. Only a number compared against a fixed point sees it. Equally, the
+rig can say a shell grew 12KB since the reference but not which PR to blame;
+the comment can. Neither is redundant.
+
+**Two real defects were found while reconciling them, both silent.**
+
+1. **Only bento/spaces was ever registered.** `size-budgets.json` listed one
+   shell, so slides and dash had NO persistent size record at all. The rig has
+   always been generic — it walks every entry — it just had nothing to walk.
+   Both are now registered as `enforce:false` watermarks.
+2. **dash was structurally unmeasurable.** The CI step sat in the spaces
+   section, *ahead of the dash build*, and the rig SKIPS a shell that is not
+   built — so it printed `skip dash — not built` and moved on. A guard that
+   reports "nothing to do" in a passing build is invisible. The step now runs
+   after all three builds.
+
+**Why watermarks and not ceilings for the two new entries.** Same reason spaces
+gave up its own: at 98.6% of its limit it had started declining worthwhile
+fixes, which is the ceiling costing more than it saves. And a ceiling picked
+with no history behind it is a guess that fails somebody else's PR. Growth
+still has to pass a human, because the number is printed every run.
+
+**References come from CI, never a local build.** Most of a shell is one
+deflated block and zlib's output differs across node versions — one commit
+measured 130,095 B on node 26 locally against 131,246 B on CI's node 24. When
+the two disagree, believe CI.
+
+**Naming, left alone deliberately.** `test-spaces-size.mjs` now covers three
+shells and the name undersells it, but it is invoked by name from
+`scripts/test-spaces.mjs` and referenced in this log, and renaming it was more
+churn than the overlap warranted. The file's own header says it is generic.

--- a/scripts/size-budgets.json
+++ b/scripts/size-budgets.json
@@ -10,12 +10,14 @@
     "slides": {
       "path": "slides/dist-single/Bento_Slides.bento.html",
       "enforce": false,
-      "//": "TRACKED, no ceiling. Registered 2026-08-28: until then only bento/spaces was listed, so slides had no persistent size record at all and years of 300-byte commits would have been invisible to CI. enforce:false was chosen over a ceiling for the reason spaces gave up its own — a tight limit starts declining worthwhile fixes — and because a ceiling picked without history behind it is a guess that fails somebody else's PR. `reference` is set from a CI run, never a local one: most of the shell is one deflated block and zlib's output differs by ~1KB between node versions. Move it when a change buys real bytes and say what bought them."
+      "reference": 685328,
+      "//": "TRACKED, no ceiling. Registered 2026-08-28: until then only bento/spaces was listed, so slides had no persistent size record at all and years of 300-byte commits would have been invisible to CI. enforce:false was chosen over a ceiling for the reason spaces gave up its own — a tight limit starts declining worthwhile fixes — and because a ceiling picked without history behind it is a guess that fails somebody else's PR. `reference` is set from a CI run, never a local one: most of the shell is one deflated block and zlib's output differs by ~1KB between node versions. Move it when a change buys real bytes and say what bought them. Reference 685328 B measured on CI (node 24) in the run that registered this shell, not locally."
     },
     "dash": {
       "path": "dash/dist-single/Bento_Dash.bento.html",
       "enforce": false,
-      "//": "TRACKED, no ceiling. Registered 2026-08-28, same reasoning as slides. Note dash was unmeasurable before this: the CI step sat in the spaces section, ahead of the dash build, and the rig SKIPS a shell that is not built — so it printed nothing for dash and said so quietly. The step now runs after all three builds."
+      "reference": 165201,
+      "//": "TRACKED, no ceiling. Registered 2026-08-28, same reasoning as slides. Note dash was unmeasurable before this: the CI step sat in the spaces section, ahead of the dash build, and the rig SKIPS a shell that is not built — so it printed nothing for dash and said so quietly. The step now runs after all three builds. Reference 165201 B measured on CI (node 24) in the run that registered this shell, not locally."
     }
   }
 }

--- a/scripts/size-budgets.json
+++ b/scripts/size-budgets.json
@@ -1,11 +1,21 @@
 {
-  "//": "Sizes for the single-file shells. A shell with enforce:true has a hard ceiling — raise `max` IN THE COMMIT that needs the bytes and say what bought them. A shell with enforce:false is tracked, not capped: the rig reports its drift from `reference` and never fails. Checked by scripts/test-spaces-size.mjs.",
+  "//": "Sizes for the single-file shells. A shell with enforce:true has a hard ceiling — raise `max` IN THE COMMIT that needs the bytes and say what bought them. A shell with enforce:false is tracked, not capped: the rig reports its drift from `reference` and never fails. Checked by scripts/test-spaces-size.mjs (generic despite the name — it walks every shell listed here and skips any that is not built). THIS IS NOT THE SAME TOOL AS THE PR BUILD-SIZE COMMENT and neither replaces the other: this file is absolute and persistent, so it is the only thing that catches SLOW drift across many merged PRs; the comment is relative to a PR's own base, so it is the only thing that pins a jump on the change that caused it. See docs/DECISIONS.md.",
   "shells": {
     "spaces": {
       "path": "spaces/dist-single/Bento_Spaces.bento.html",
       "enforce": false,
       "reference": 258454,
       "//": "bento/spaces has NO HARD CEILING — the maintainer's call, and it is a reasonable one: the app was declining worthwhile fixes over a few hundred bytes, which is the ceiling costing more than it saves. `reference` is a WATERMARK, not a limit: the rig prints the size and the drift since this number and never fails on it, so growth nobody chose is still visible in every run — that was always the point (see the note at the top of test-spaces-size.mjs), and it survives without the block. Move `reference` when a change buys real bytes, and say what bought them. Set enforce:true to put the ceiling back. Previous ceiling was 262144 (256 KiB). 256 KiB, raised from 240 KiB by the collaboration build-out. Measured on this branch, node 26: 238,862 B before, 250,594 B after, +11,732 B. Split, by building the same tree twice with the OLD packed catalog swapped back in: CODE is +2,308 B (share.ts, the People panel with roles and per-member Remove, the five honest connection states, the view-only lock) and LANGUAGE is +9,424 B — 31 new strings x 8 locales, four fifths of the raise. That ratio is the same one the previous note recorded and it is the honest cost of an app that opens in eight languages out of one file; twenty-four of the thirty-one strings were LIFTED from the bento/slides catalogs rather than reworded, which is what kept it to this. Headroom stays deliberate: the shell is mostly one compressed block and the packer's output differs across node versions (one commit measured 130,095 B on node 26 locally and 131,246 B on CI node 24), so a tight ceiling fails in CI for no reason. Earlier history: 166,482 B before the M3/M4 content work, the formatting UI, dark mode, the rebuilt About and the starter space, 238,862 B after."
+    },
+    "slides": {
+      "path": "slides/dist-single/Bento_Slides.bento.html",
+      "enforce": false,
+      "//": "TRACKED, no ceiling. Registered 2026-08-28: until then only bento/spaces was listed, so slides had no persistent size record at all and years of 300-byte commits would have been invisible to CI. enforce:false was chosen over a ceiling for the reason spaces gave up its own — a tight limit starts declining worthwhile fixes — and because a ceiling picked without history behind it is a guess that fails somebody else's PR. `reference` is set from a CI run, never a local one: most of the shell is one deflated block and zlib's output differs by ~1KB between node versions. Move it when a change buys real bytes and say what bought them."
+    },
+    "dash": {
+      "path": "dash/dist-single/Bento_Dash.bento.html",
+      "enforce": false,
+      "//": "TRACKED, no ceiling. Registered 2026-08-28, same reasoning as slides. Note dash was unmeasurable before this: the CI step sat in the spaces section, ahead of the dash build, and the rig SKIPS a shell that is not built — so it printed nothing for dash and said so quietly. The step now runs after all three builds."
     }
   }
 }


### PR DESCRIPTION
Sorts out the overlap between the new advisory PR build-size comment (#279) and
the existing CI size rig.

**They are not duplicates, and the entry in `docs/DECISIONS.md` says why.**

| | CI rig (`size-budgets.json`) | PR comment (#279) |
|---|---|---|
| measured against | committed `reference`, or a `max` ceiling | the PR's own base commit |
| horizon | absolute, persistent | relative, one PR |
| can fail a build | yes, when `enforce:true` | never |
| catches | slow drift — forty merges at 300 B each | one change's jump |
| blind to | which change caused it | accumulated drift |

Forty merged commits at 300 B each is 12KB nobody chose, and every one of those
PRs shows a harmless `+300` in its comment. Only a fixed reference sees it.
Equally the rig cannot say which PR to blame, and the comment can.

**Two silent defects found while reconciling them**

1. **Only bento/spaces was ever registered.** slides and dash had no persistent
   size record at all. The rig was always generic — it walks every entry — it
   simply had nothing to walk. Both are now tracked as `enforce:false`
   watermarks.
2. **dash was structurally unmeasurable.** The step sat in the spaces section,
   *ahead of the dash build*, and the rig skips a shell that is not built — so
   it printed `skip dash — not built` inside a passing run. The step now runs
   after all three builds.

**Watermarks, not ceilings**, for the same reason spaces gave up its own: at
98.6% of its limit it had started declining worthwhile fixes. A ceiling picked
with no history behind it is a guess that fails somebody else's PR. The number
is still printed every run, so growth passes a human.

**`reference` is deliberately unset for the two new entries.** The first CI run
prints the real sizes and I will commit them from *those* numbers — zlib's
output differs by ~1KB between node versions, and CI's is the one that counts.
So expect one follow-up commit before this is ready.

No rename: `test-spaces-size.mjs` now covers three shells and the name
undersells it, but it is invoked by name from `scripts/test-spaces.mjs`, and
that churn is not what this PR is for.

**Checklist**
- [x] Read the relevant parts of CLAUDE.md / docs before changing them
- [x] Rig runs clean locally (`track spaces`, `track slides`, `skip dash` — dash not built locally)
- [x] Did not bump the version or cut a release