### PR TITLE
Reconstruct CHANGELOG [Unreleased] — the code morph was missing from it entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ pre-1.0.
 
 ## [Unreleased]
 
+- **Code on a slide — and it morphs.** A slide can hold a code snippet, syntax
+  highlighted, and when the same snippet appears on two slides in a row the code
+  *travels* between them. A line that moved moves; a call that changed position
+  slides to where it went, and the lines it passes step out of its way. Nothing
+  blanks and redraws.
+
+  This is the deck's existing morph pointed at source code. Show a refactor as
+  three slides and an audience watches the edit happen rather than comparing two
+  static screenshots — the starter deck now walks through fifteen years of
+  JavaScript, callbacks to promises to `async`/`await`, and the code rearranges
+  itself at each step.
+
+  Symbols with no counterpart on the previous slide fade in, staggered, once the
+  movement is already under way, so a newly introduced line arrives as part of
+  the same beat instead of snapping in. A word whose *role* changes while its
+  text does not — `render(` becoming `.then(render)` — keeps its identity and
+  travels, because turning a call into a reference is a refactor, not a rename.
+
+  Highlighting is built in, covers 75 languages plus diffs and Markdown, and
+  costs a deck about 10 KB. It is deliberately the cheaper of two tiers: the
+  format keeps its seam for full grammars carried as per-deck assets, and
+  nothing here closes that door.
+
+- **A deck can set its own morph tempo.** The default 0.65 seconds is tuned for
+  the ordinary case — a title sliding in, a shape growing, a journey of several
+  hundred pixels. A code symbol moves about one line height, and at that tempo
+  the whole journey is over in roughly 300 ms: measurably an animation, watchably
+  a blink. A deck built around small, precise movement can now choose a slower
+  beat, and decks that say nothing are unchanged.
+
+  This one is a document setting (`present.morphSeconds`, clamped to 0.1–6
+  seconds) with no control in the panel yet — reachable today by editing the
+  deck's JSON through **Copy document JSON** / **Replace from JSON…**.
+
 - **Deck-wide brand colours.** The Slide panel gains a **Theme** section — a
   background, a text colour and six accents — and every colour control now
   offers those swatches above its picker. Pick one and the deck *remembers where
@@ -39,6 +73,19 @@ pre-1.0.
   history and the recovery snapshot belong to the browser, not the file, so they
   stay behind on bento.page when the deck moves to your disk.
 
+- **Every deck you save is smaller.** The runtime each file carries is now packed
+  harder — about 26 KB off a Bento Slides file, for nothing given up. It is the
+  same compression format as before, searched more thoroughly at build time, so
+  files you already saved keep working and an older copy of Bento still updates
+  itself against a new shell exactly as it did.
+
+- **Saving into any of several granted folders.** With the browser extension
+  installed, you can grant Bento more than one folder and a deck saves back to
+  whichever one it came from. Two decks that share a filename in different
+  folders both save correctly now; previously that ambiguity made Bento decline
+  the save. Granting a large folder no longer costs anything either, so a whole
+  home directory is as cheap as a single decks folder.
+
 - **Fix: several buttons were unreadable in dark mode.** White text on a
   near-white button — the main action in a dialog, the toast that confirms a
   save, the active chip in a settings row, and the ＋ between slides. The
@@ -58,6 +105,31 @@ pre-1.0.
   says. Bento's own check read the value and was right; it simply never got
   asked. Present since audio and video arrived.
 
+- **Fix: a fading slide painted over the morph behind it.** When a slide set to
+  *fade* handed off to a morph, the outgoing slide dissolved on top of the
+  animation — a 450 ms curtain over a 600 ms move — so the elements appeared to
+  jump straight to their new arrangement. They had been travelling the whole
+  time, underneath. Slides that hand off to a morph now cut instead.
+
+- **Fix: a formula's new symbols appeared instantly instead of fading in.** A
+  formula gaining a term showed that term snapping into place while every other
+  symbol glided. Bento's animation engine recognised HTML and SVG elements but
+  not MathML ones, so the fade was quietly written to the wrong place and never
+  reached the screen. Formula symbols now arrive on the same staggered beat as
+  everything else.
+
+- **Fix: the palette swatches had a border you could not see on a dark panel.**
+  The new theme swatches shipped with a border colour pinned to a light-mode
+  value while the panel behind it followed the interface theme — the same
+  mismatch the dark-mode fix above removes everywhere else. The border now
+  follows the theme too.
+
+- **Fix: the toast after saving an editor copy said only "Editor".** In seven of
+  the eight built-in languages the message that confirms an editor copy was
+  saved carried the translation of the neighbouring one-word "Editor" label
+  instead of its own sentence, so a German user saving an editor copy saw a
+  toast reading `Bearbeiter` and nothing else. All eight now say what actually
+  happened. Downloadable language packs were never affected.
 
 ## [1.0.18] — 2026-08-15
 


### PR DESCRIPTION
Release-readiness for the next bento/slides release. **Documentation only — one file, 72 insertions, zero deletions.** No version is cut: `[Unreleased]` stays `[Unreleased]`.

## The defect

25 commits touch `slides/` or `kernel/` since `v1.0.18` (tagged 2026-08-16). `[Unreleased]` carried four entries, and the headline feature of the whole period was absent — `grep -i "morph.*code\|tokeniz" CHANGELOG.md` returned nothing, yet seven commits landed code morphing. It shipped: `slides/src/code.ts` and `kernel/src/tokenize.ts` are on `main`, `scripts/test-tokenize.ts` guards it, and the **starter deck uses it** — so every new user meets the feature on first open and the release notes would not have mentioned it.

## What is now in `[Unreleased]`

Six new entries, in house voice, features before fixes:

| entry | commits |
|---|---|
| Code on a slide — and it morphs | `6b5e80d` `b6a4b2f` `f0f3aad` `51ccbdb` `2242f23` `82e9a43` `d1f3e96` |
| A deck can set its own morph tempo | `74790df` |
| Every deck you save is smaller | `6b4e1b2` |
| Saving into any of several granted folders | `a5bc3f1` |
| Fix: a fading slide painted over the morph behind it | `f5ed51d` |
| Fix: a formula's new symbols appeared instantly | `bcdf542` |
| Fix: palette swatch border invisible on a dark panel | `b9f3866` |
| Fix: the editor-copy toast said only "Editor" | `4bb9ba8` |

## Judgement calls, and why

**Grouped** the seven code-morph commits into one entry — they are one feature arriving in pieces, and a reader wants the feature, not its assembly order.

**Morph tempo is its own entry** because it is deck-wide, not code-only. It is written explicitly as a *document field with no panel control*: `morphSeconds` appears only in `model.ts` and `present.ts`, so claiming a UI for it would have been false.

**Excluded as internal**, no user-visible change:
- `e1cdfab` sync layers move to the kernel — refactor, behaviour identical
- `42acd5c` anim warns on ignored transforms — console warning for people *writing* Bento
- `9515ed9` transitive bumps — the commit shows the built shell **byte-identical** (685328 both ways) and neither package ships
- `284f765` tray → home rename — identifiers a slides user never sees

**`a5bc3f1` (multi-folder grant) is the one I would most like a second opinion on.** It is mostly `home/webext` work, but it edits `kernel/src/app.ts` and `kernel/src/save.ts` and changes what happens when a slides user saves — notably that two same-named decks in different folders both save, where the old behaviour declined. I wrote it strictly from the saving user's point of view; the fuller story belongs in home-webext's notes rather than here. Happy to drop it if that zone is covering it.

## Nothing was settled by guessing

`f5ed51d` looked like it might be a starter-deck authoring change rather than an engine one. It is `slides/src/present.ts`, 18 lines, engine — so the fix applies to any deck with a fade in front of a morph, and that is how it is worded. No question is outstanding for Bento (Slides).

Verified against `origin/main` = `220f7e7`.
