### PR TITLE
type gets its own changelog before it needs one

### DIFF
--- a/type/CHANGELOG.md
+++ b/type/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to **bento/type**. The app version is baked into every
+shell as `APP_VERSION` (from `type/package.json`) and checked against the
+signed release manifest; a shipped file updates itself through that channel.
+
+This file is per-app on purpose. The notes ride inside the **signed** update
+manifest and are what someone reads while deciding whether to rewrite their
+file — so an app must never describe another app's changes. The repository
+root `CHANGELOG.md` is **bento/slides'**; nothing about bento/type belongs
+there.
+
+The format (`bento/type`, version `1`) is additive and stable — every version
+below opens files from every earlier version, and unknown fields are preserved.
+Versions follow `0.MINOR.PATCH` while pre-1.0.
+
+## [Unreleased]
+
+bento/type has not been released yet. Work before the first release is
+summarised in that release's entry rather than tracked here — add a block
+below once a change is user-visible in a shipped file.


### PR DESCRIPTION
bento/type had no changelog. Root `CHANGELOG.md` is **bento/slides'** (`slides/` has none of its own), `spaces/` and `dash/` have had theirs for weeks, and `type/` was missed when the apps multiplied. `docs/PARALLEL-WORK.md` §3 names `CHANGELOG.md` as the first conflict magnet and already said each app gets its own — this closes the gap it named.

One new file, 21 lines. **No `type/src` file touched.**

## Why now rather than when type needs it

The maintainer is about to work type and spaces concurrently, a slides release is in flight with **PR #400 open on the root file**, and type is one user-facing change away from having nowhere correct to write. An empty file now costs nothing; the same file created mid-conflict costs a rebase on someone else's branch.

## The preamble carries the reason, not just the rule

Lifted from `spaces/CHANGELOG.md`, where it was already stated and where `PARALLEL-WORK.md` never repeated it:

> The notes ride inside the **signed** update manifest and are what someone reads while deciding whether to rewrite their file — so an app must never describe another app's changes.

That makes a cross-app entry a **correctness defect**, not untidiness: a user reading notes about changes their document did not get, inside a signed artifact. Worth stating in the file someone actually has open when they are about to append.

## What I did not do

- **No invented entries.** type is `0.1.0` with no tag. `[Unreleased]` is empty and says so; pre-release work belongs in the first release's entry. The user-facing meaning of type's four commits is **bento/type's to state, not mine.**
- **Did not move root → `slides/CHANGELOG.md`.** `PARALLEL-WORK.md` points at that as the eventual shape, but doing it now would collide head-on with #400 and with a release in flight. Filed as a follow-up rather than folded in; the amended §3 in #401 records that the root file is slides' and has not moved yet, so nobody reads the gap as an accident.

Verified against `origin/main` = `220f7e7`.
