### PR TITLE
Five rigs reported passes for work they were not doing

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5895,3 +5895,61 @@ the two disagree, believe CI.
 shells and the name undersells it, but it is invoked by name from
 `scripts/test-spaces.mjs` and referenced in this log, and renaming it was more
 churn than the overlap warranted. The file's own header says it is generic.
+
+## 2026-08-29 — five rigs reported passes for work they were not doing
+
+**A green rig is an instrument, and these lied.** The same family as the
+"instruments that lie" list in `CLAUDE.md` — a transform read back from an
+inline element, rAF in a hidden tab, a DOM sampler polling mid-animation — with
+one difference that makes it worse: those instruments were consulted
+deliberately by someone who suspected a problem. A rig is consulted by CI, on
+every push, by people who have stopped suspecting anything.
+
+**The findings, verified against the tree and PR #399's diff on 2026-08-29.**
+Five rigs across four zones, found within one day of each other:
+
+| rig | what it reported | what was true |
+|---|---|---|
+| `test-tray-bridge.ts` | **52/52 pass** | the #277 arbitrary-write fix was DELETED; its shape checks pinned the `<a download>` call site, the NEIGHBOUR of the fix, while `exportCopy`'s `safeFileName` gate and path-containment guard were read by nothing |
+| `test-tray-index.mjs` | "absent, skipped", in green, **for weeks** | the tray→home rename moved the corpus and the path did not; **eleven cases** went untested |
+| `test-doc-index.mjs` | never ran | unregistered in CI, and the same rename left it importing `../tray/doc-index.mjs` |
+| `test-spaces.mjs` | never ran | unregistered **from the day it was written** |
+| `test-slide-store.ts` | never ran | never registered |
+
+**Two distinct failure modes, and the second is quieter.** A rig can assert the
+wrong thing — pinning code adjacent to the fix rather than the fix. Or it can
+assert nothing at all while still printing a pass, because its input moved or it
+was never wired to CI. The second is harder to notice precisely because there is
+no wrong assertion left to be wrong. #399's own comment on `test-doc-index.mjs`
+puts it best: **a rig nobody runs cannot report its own import failure.**
+
+**Presence is not the property; ordering is.** The load-bearing check added to
+`exportCopy` is not that `safeFileName` and the containment guard exist — both
+can exist and still run AFTER the write. It asserts
+`indexOf('write(to: tmp)') > indexOf('hasPrefix(')`. This is the part that
+transfers to any rig: a guard's presence is cheap to assert and frequently
+means nothing.
+
+**The check adopted, which costs two minutes:** delete the guard the rig exists
+to protect, run the rig, and watch. If it still passes, the rig is reading
+something adjacent to the fix. **Do it when you write the rig, not after someone
+reverts it.** Measured, not assumed: `exportCopy` gained FOUR checks and THREE
+of them fire on the revert that was actually run (53/56). That gap is the point
+rather than an embarrassment — four independent assertions, not one assertion
+spelled four ways, and the one that stayed silent did so because of how those
+particular guards were stripped.
+
+**A skip that protects nothing costs the whole check.** `test-tray-index.mjs`
+skipped a missing corpus for a good reason — it arrived with the Android work,
+and a rig that fails until an unrelated branch lands is a rig people learn to
+ignore. The reason expired when the corpus landed and the skip did not. A path
+that is SUPPOSED to exist is a failure when it does not, and a rig must
+distinguish ABSENT from MOVED.
+
+**Status.** PR #399 is in flight as this is written; it registers the unrun rigs
+and closes the two mis-asserting ones. The findings above are properties of the
+tree at `220f7e7` and stay true whatever shape that PR lands in. Found by
+bento-team-home-ios, with bento-team-home-android hitting it from the other
+side; the `CLAUDE.md` counterpart — the two-minute check, in the file people
+read BEFORE writing a rig — is queued for the maintainer and is not discharged
+by this entry.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5946,10 +5946,34 @@ ignore. The reason expired when the corpus landed and the skip did not. A path
 that is SUPPOSED to exist is a failure when it does not, and a rig must
 distinguish ABSENT from MOVED.
 
-**Status.** PR #399 is in flight as this is written; it registers the unrun rigs
-and closes the two mis-asserting ones. The findings above are properties of the
-tree at `220f7e7` and stay true whatever shape that PR lands in. Found by
-bento-team-home-ios, with bento-team-home-android hitting it from the other
-side; the `CLAUDE.md` counterpart — the two-minute check, in the file people
-read BEFORE writing a rig — is queued for the maintainer and is not discharged
-by this entry.
+**And the practice is now enforced, not just recommended.** A two-minute habit
+decays; the same PR adds the mechanical half. `scripts/test-spaces.mjs
+--manifest` runs in CI and asserts the list both ways — every `test-spaces-*`
+file on disk is listed in `RIGS`, and every rig in `RIGS` has a step in the
+workflow — failing with **"A rig nobody runs is not a rig. Add a step for each,
+or remove it from RIGS."** Read that beside the diagnosis above and the pair is
+the whole entry: one line names the failure, the other refuses to let it recur.
+Both halves are the point. A rig that catches this class of defect is worth more
+than a paragraph asking people to remember it, and any app growing a rig suite
+should copy the manifest check rather than the habit.
+
+**Status.** PR #399 (branch `ops-rig-repairs`) is in flight as this is written;
+it registers the unrun rigs, closes the two mis-asserting ones, and adds the
+manifest check. The findings above are properties of the tree at `220f7e7` and
+stay true whatever shape that PR lands in.
+
+**Attribution, corrected once in the writing of this entry.** The two
+`test-tray-*` findings are bento-team-home-ios's, with bento-team-home-android
+hitting the same class from the other side. The three unrun rigs and both quoted
+lines came through #399 and are **bento-team-ops'** — an earlier draft of this
+paragraph credited the whole finding to home-ios, which was wrong. Worth
+recording how it was settled, because it will come up again: `git log` cannot
+answer it. Every session on this repo commits as the maintainer, so authorship
+metadata resolves to one person for all of us; the zone and the branch are the
+only evidence that distinguishes anybody. Cite the PR, which is checkable, over
+the session, which is not.
+
+**The `CLAUDE.md` counterpart is not discharged by this entry.** The two-minute
+check belongs in the file people read BEFORE writing a rig; this log is what
+they read after wondering why a standard exists. That text is queued for the
+maintainer.


### PR DESCRIPTION
Records a defect class found across four zones in one day: **rigs that print a pass while testing nothing.**

One entry appended to `docs/DECISIONS.md`. Documentation only, 58 lines, no code touched.

## Why this is worth an entry

It is the same family as the "instruments that lie" list in `CLAUDE.md` — a transform read back from an inline element, rAF in a hidden tab, a DOM sampler polling mid-animation — with one difference that makes it worse. **Those instruments are consulted deliberately, by someone who already suspects a problem. A rig is consulted by CI, on every push, by people who have stopped suspecting.**

## The findings

Verified against the tree and #399's diff, not taken on report:

| rig | reported | true |
|---|---|---|
| `test-tray-bridge.ts` | **52/52 pass** | the #277 arbitrary-write fix was deleted; shape checks pinned the `<a download>` call site — the *neighbour* of the fix |
| `test-tray-index.mjs` | "absent, skipped", green, **for weeks** | the tray→home rename moved the corpus, the path did not; **eleven cases** untested |
| `test-doc-index.mjs` | never ran | unregistered in CI, and the rename broke its import |
| `test-spaces.mjs` | never ran | unregistered **from the day it was written** |
| `test-slide-store.ts` | never ran | never registered |

**Two failure modes, kept apart in the entry.** A rig can assert the wrong thing, or assert nothing at all while still printing green. The second is quieter — there is no wrong assertion left to be wrong. #399's own comment says it best: *a rig nobody runs cannot report its own import failure.*

## The correction verification caught

The draft I was sent said `exportCopy` gained **three** checks. It gained **four** — #399's comment says "these four checks close" the defect. Three is how many *fire* on the revert that was actually run (53/56).

Both numbers are in the entry **as a pair**, because "four added, three firing" is evidence the assertions are independent rather than one assertion spelled four ways. That is a sharper thing to teach than either number alone, and it only surfaced because the count was checked.

## Placement is deliberately split

This is the **durable record** — what was found, and the standard adopted — so a future session does not re-derive it.

The counterpart belongs in `CLAUDE.md`, which is what someone reads *before* writing a rig; a lesson only prevents the next instance if it is in the file people read first. **That text is prepared and queued for the maintainer, and this entry does not discharge it.** My harness bars me from editing `CLAUDE.md` at another session's request — a peer cannot authorise a change to the file governing agent behaviour, whoever owns it.

## On #399 being unmerged

The entry is built on properties of the tree at `220f7e7` that stay true whatever shape that PR lands in, and it says so rather than describing an unmerged diff as settled.

Found by bento-team-home-ios, with home-android hitting it from the other side.
