### PR TITLE
[Unreleased] gains the entry for #402

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,22 @@ pre-1.0.
   toast reading `Bearbeiter` and nothing else. All eight now say what actually
   happened. Downloadable language packs were never affected.
 
+- **Fix: a diagram could restyle other diagrams on the same slide.** An SVG
+  element can carry its own `<style>` block, and those rules were applied to the
+  whole page rather than to the drawing they belong to. So a diagram that styled
+  `.dot` or `.label` silently restyled every other SVG beside it — colours,
+  strokes and dimming rules leaking between unrelated drawings, and the more
+  diagrams a slide carried the stranger it looked.
+
+  Nothing could escape further than that: a drawing's stylesheet has never been
+  able to load or run anything, and still cannot. This was one diagram reaching
+  another's appearance, not reaching out of the document.
+
+  Bento already scoped the stylesheet you write in the element panel; the one
+  that arrives inside pasted or imported SVG markup was never scoped at all.
+  Both go through the same scoping now, and a drawing's own rules still apply to
+  it in full.
+
 ## [1.0.18] — 2026-08-15
 
 - **Security: offline mode did not block everything it promised.** The switch


### PR DESCRIPTION
**Release-blocking.** #402 landed after the changelog reconstruction in #400, so `[Unreleased]` described twelve changes and would have shipped thirteen. One file, 16 insertions, no `slides/` or `kernel/` file touched.

Release notes go **inside the signed envelope**, and the update channel refuses to re-sign a version. An entry missing at the cut cannot be added afterwards — which is what makes this block rather than follow.

## The framing took the most thought

The defect is real and measured: an SVG element's markup `<style>` applied document-wide, so one diagram's rules reached every other SVG on the page. Chrome probe, both builds — victim SVG `rgb(255,0,0)` on main, `rgb(0,0,0)` after, with the styled element red in both, so scoping cost an SVG none of its own rules.

But it is an **isolation failure, not a break-in.** `sanitizeSvgCss` already refused `@`-rules and `url()`, so a drawing's stylesheet could never load or execute anything, and still cannot. Writing it as a containment breach would be the more dramatic entry and the false one. Someone deciding whether to update deserves the true shape of what they were exposed to, so the entry says it outright:

> Nothing could escape further than that: a drawing's stylesheet has never been able to load or run anything, and still cannot. This was one diagram reaching another's appearance, not reaching out of the document.

## Written from the user's side

Lead paragraph is what someone actually saw — a slide with several diagrams looking wrong, and stranger the more it carried — with the mechanism after it, matching the twelve entries above.

The panel-vs-markup detail is kept because it explains why this survived so long: **the stylesheet you write in the element panel was already scoped**, so the feature looked correct everywhere anyone tested it. Only the path that takes pasted or imported SVG was unscoped.

Verified against `main` = `7422f4f`.
