### PR TITLE
spaces: finish four covers/gallery fixes that were only half made

### DIFF
--- a/scripts/test-spaces-model.ts
+++ b/scripts/test-spaces-model.ts
@@ -41,6 +41,7 @@ import {
   valuesOf, isIssue, issuesOf, headerLength, propBlockOf,
   passesFilter, filterCount, unknownFilterKeys, phaseField, isOpenPhase, reorderPages,
   sortRows, unknownSortKeys, sortDirOf, cycleSort, type IssueRow,
+  VIEW_LAYOUTS, layoutOf, nextLayout,
 } from '../spaces/src/fields.ts'
 import { inlineHtml, parseNote, planImport } from '../spaces/src/markdown.ts'
 import {
@@ -574,7 +575,19 @@ for (const [label, input, err] of [
 
   // Cycling all the way round must leave the block as it started. The cycle
   // ends at GALLERY now, so it is the last shape that clears the key.
-  ok(/gallery: undefined/.test(ed), 'cycling past the last layout clears the key rather than storing "board"')
+  //
+  // Asked of the CYCLE, not of the source. This assertion used to read
+  // /gallery: undefined/ against editor.ts, which is a test of how the line is
+  // spelled: moving the cycle into fields.ts kept every behaviour and turned it
+  // red, and hardening the same lookup against Object.prototype would have left
+  // it green. So the shape question goes to nextLayout, and the writer question
+  // goes to the writer's own body — not to the whole file, on the `coverFn`
+  // precedent below, because `undefined` appears hundreds of times in editor.ts.
+  ok(nextLayout('gallery') === 'board', 'the shape after the last one is the board again')
+  const toggleFn = ed.slice(ed.indexOf('private toggleViewLayout'),
+    ed.indexOf('private openViewGroup'))
+  ok(toggleFn.length > 0 && /'layout',\s*to === 'board' \? undefined :/.test(toggleFn),
+    '…and the click WRITES that as a deleted key rather than a stored "board"')
 }
 
 // ---- a page has a cover, and a view can be a gallery -----------------------
@@ -645,7 +658,7 @@ for (const [label, input, err] of [
   const ed2 = fs.readFileSync(new URL('../spaces/src/editor.ts', import.meta.url), 'utf8')
   const props2 = fs.readFileSync(new URL('../spaces/src/props.ts', import.meta.url), 'utf8')
   ok(/layout === 'gallery'/.test(render), 'a view can be a gallery')
-  ok(/gallery: 'board'/.test(render) && /table: 'gallery'/.test(render),
+  ok(nextLayout('table') === 'gallery' && nextLayout('gallery') === 'board',
     '…reachable from the one layout control, which cycles through it')
   ok(/resolveSrc\(coverSrc\(r\.page\), doc\)/.test(render),
     '…and a card asks coverSrc for the picture, so a remote cover is refused there too')
@@ -664,40 +677,6 @@ for (const [label, input, err] of [
   ok(/pickCover\(page\.id\)/.test(props2), 'the properties panel offers it, beside the icon')
 }
 
-// ---- a view is about a set of pages, and can be looked at as a table -------
-// A view meant ONE thing: every page carrying a `status`. That made the tracker
-// work and everything else impossible — no "the pages with an Author", no "the
-// pages under Books", so a space could hold a backlog and never a reading list.
-//
-// ABSENT MEANS ISSUES. That is the compatibility rule, not a default: every
-// view block written before `source` existed carries none and must keep showing
-// the backlog forever, and a view set back to Issues must be byte-identical to
-// one that never moved — the same rule `filter` already follows.
-{
-  const fs = await import('node:fs')
-  const fields = fs.readFileSync(new URL('../spaces/src/fields.ts', import.meta.url), 'utf8')
-  const render = fs.readFileSync(new URL('../spaces/src/render.ts', import.meta.url), 'utf8')
-  const ed = fs.readFileSync(new URL('../spaces/src/editor.ts', import.meta.url), 'utf8')
-
-  ok(/export function viewRows\(/.test(fields), 'a view selects its rows through one function')
-  ok(/if \(!has && !under\) return issuesOf\(doc\)/.test(fields),
-    '…and with no source it is still the backlog, so old view blocks are unchanged')
-  ok(/viewRows\(doc, \(b as \{ source\?: unknown \}\)\.source\)/.test(render),
-    'the renderer asks for the block\'s own source rather than the issues')
-
-  // The table is the shape a base is usually looked at in. Its columns must
-  // come from the ROWS, not the vocabulary: a table of books carrying no
-  // Estimate should not grow an Estimate column because the schema has one.
-  ok(/layout === 'table'/.test(render), 'a view can be a table')
-  ok(/rows\.some\(\(r\) => r\.values\.has\(k\)\)/.test(render),
-    '…whose columns are the fields the rows actually carry')
-  ok(/overflow-x/.test(fs.readFileSync(new URL('../spaces/src/styles.css', import.meta.url), 'utf8')
-    .split('.sp-view-tablewrap')[1]?.slice(0, 120) ?? ''),
-    '…and scrolls inside itself, so a wide table never scrolls the page sideways')
-
-  // Cycling all the way round must leave the block as it started.
-  ok(/gallery: undefined/.test(ed), 'cycling past the LAST layout clears the key rather than storing "board"')
-}
 
 // ---- a t() the extractor cannot SEE ----------------------------------------
 // scripts/build-spaces-i18n.mjs sweeps t() call sites for LITERAL strings, plus
@@ -3570,6 +3549,48 @@ function fsTable(f: string): string {
       Math.hypot(n.x - before[i].x, n.y - before[i].y)))
     ok(moved < 0.5, 'graph: one more tick on a settled layout barely moves anything')
   }
+}
+
+
+// ---- A LAYOUT KEY OUT OF A FILE IS NOT A PROPERTY NAME ----------------------
+// A view block is plain JSON in a document someone mailed you, and `layout` is
+// a free string in it. The renderer picked the button's word out of an object
+// literal by that string, guarded by TRUTHINESS — and `WORD['toString']` is a
+// native function, which is truthy. So `layout:"toString"` rendered the layout
+// button's label as `function toString() { [native code] }` and wrote the same
+// text into data-next.
+//
+// The reason it survived a review: the cycle was written TWICE, once in
+// editor.ts for what a click STORES and once in render.ts for what the button
+// SAYS. The hardening went into the editor's copy, and the editor's comment
+// then asserted the label was safe — while the label was still coming from the
+// other, unguarded copy. One function now, called by both, and checked here by
+// CALLING it rather than by grepping the source for the guard.
+{
+  for (const evil of ['toString', 'constructor', 'valueOf', 'hasOwnProperty', '__proto__']) {
+    const shapes = VIEW_LAYOUTS as readonly string[]
+    ok(shapes.includes(layoutOf(evil)),
+      `layout:${JSON.stringify(evil)} resolves to a real shape (${layoutOf(evil)}), never a native function`)
+    ok(shapes.includes(nextLayout(evil)),
+      `…and what follows it is a shape too (${nextLayout(evil)}), so data-next is never a function body`)
+  }
+
+  // The honest shapes still work, or the guard above would be a way to break
+  // the feature and call it secure.
+  ok(VIEW_LAYOUTS.every((l) => layoutOf(l) === l), 'every real layout resolves to itself')
+  ok(layoutOf(undefined) === 'board' && layoutOf('') === 'board' && layoutOf('mosaic') === 'board',
+    'absent, empty, and a key from a NEWER build all land on the board')
+
+  // THE CYCLE CLOSES. As many steps as there are shapes returns where it
+  // started — which is what makes "cycled all the way round is byte-identical
+  // to untouched" true rather than aspirational.
+  for (const start of VIEW_LAYOUTS) {
+    let at: string = start
+    for (let i = 0; i < VIEW_LAYOUTS.length; i++) at = nextLayout(at)
+    ok(at === start, `${VIEW_LAYOUTS.length} steps from ${start} comes back to ${start}`)
+  }
+  ok(new Set(VIEW_LAYOUTS.map((l) => nextLayout(l))).size === VIEW_LAYOUTS.length,
+    'the cycle reaches every shape — none is stranded off it')
 }
 
 

--- a/spaces/CHANGELOG.md
+++ b/spaces/CHANGELOG.md
@@ -14,6 +14,26 @@ Versions follow `0.MINOR.PATCH` while pre-1.0.
 
 ## [Unreleased]
 
+- **The whole gallery card is the target, and a long title stops inflating its
+  row.** In a shelf of covers the picture is what you point at, so the title's
+  link now stretches over the card rather than the card holding a second one —
+  one link, one accessible name. And the two-line clamp on card titles was
+  written but never in effect: `.sp-gcard .sp-issue-title` loses on specificity
+  to `.sp-page a.sp-issue-title`, so `display: -webkit-box` never applied and
+  `-webkit-line-clamp` sat inert. Measured in the built shell: computed display
+  `block` and a long title rendering four lines with nothing clipped. It clamps
+  to two now.
+
+- **A layout out of a file cannot reach `Object.prototype`.** `layout` is a free
+  string in a view block, and the renderer picked the button's word out of an
+  object literal by it, guarded by truthiness — but `WORD['toString']` is a
+  native function, and truthy. A page hand-authored with `layout:"toString"`
+  rendered its layout button as `function toString() { [native code] }`. The
+  cycle was written twice, once for what a click stores and once for what the
+  button says; the guard had been added to the first copy only, and its comment
+  asserted the label was safe while the label came from the second. One
+  `nextLayout` in `fields.ts` now, called by both.
+
 - **Every displayed word reaches the catalogs.** The view layout button read
   English in all eight languages: it was written `t(LAYOUT_WORD[here])`, and the
   extractor sweeps LITERALS, so no catalog ever learned the strings existed —

--- a/spaces/src/editor.ts
+++ b/spaces/src/editor.ts
@@ -27,7 +27,7 @@ import { MENU_SPECS, MD_SPECS, SPEC, CALLOUT_TONES } from './blocks'
 import {
   fieldByKey, fieldsOf, propHtml, propBlock, propBlockOf, isIssue, headerLength,
   reorderPages, columnMoves, ISSUE_FIELDS, withField, freeFieldKey, fieldTypeLabel, FIELD_TYPES,
-  cycleSort,
+  cycleSort, nextLayout,
   type DropAim, type FieldSpec, type ViewFilter, type ViewSort,
 } from './fields'
 import { planImport, type SourceFile } from './markdown'
@@ -1854,22 +1854,18 @@ export class Editor {
 
   private toggleViewLayout(blockId: string): void {
     const b = this.store.block(blockId)
-    const now = String((b as { layout?: unknown } | undefined)?.layout ?? 'board')
-    // Board -> list -> table -> gallery -> board. `board` is the ABSENT key,
-    // never a stored 'board': a view cycled all the way round is byte-identical
-    // to one nobody ever touched, which is the same rule filter and source
-    // follow.
-    const next: Record<string, string | undefined> = {
-      board: 'list', list: 'table', table: 'gallery', gallery: undefined,
-    }
-    // A layout key from a NEWER build lands on the start of the cycle rather
-    // than nowhere, so the control is never a button that does nothing.
-    // Object.hasOwn, not a bare `in`: `'toString' in next` is TRUE and
-    // next['toString'] is a native function, so a hand-authored
-    // layout:"toString" rendered `function toString() { [native code] }` as the
-    // button's label and stored a FUNCTION into the model. The same class this
-    // file guards against in resolveSrc and pageMark.
-    this.editView(blockId, 'layout', Object.hasOwn(next, now) ? next[now] : 'list')
+    // Board -> list -> table -> gallery -> board, from fields.ts — the ONE
+    // place the cycle is written. It used to be written here and again in
+    // render.ts, and when the prototype-lookup bug was found only this copy was
+    // hardened, so the button went on rendering
+    // `function toString() { [native code] }` as its label from the other one.
+    //
+    // `board` is the ABSENT key, never a stored 'board': a view cycled all the
+    // way round is byte-identical to one nobody ever touched, which is the same
+    // rule filter and source follow. nextLayout returns the WORD; turning
+    // 'board' back into a deletion is the writer's job, and this is the writer.
+    const to = nextLayout((b as { layout?: unknown } | undefined)?.layout)
+    this.editView(blockId, 'layout', to === 'board' ? undefined : to)
   }
 
   /**

--- a/spaces/src/fields.ts
+++ b/spaces/src/fields.ts
@@ -621,3 +621,43 @@ export function cycleSort(sort: unknown, key: string): ViewSort[] | undefined {
   if (dir === 'asc') return [{ key, dir: 'desc' }]
   return undefined
 }
+
+/**
+ * THE SHAPES A VIEW CAN TAKE, and the order the one button cycles them in.
+ *
+ * Written down ONCE. It used to live twice — a `NEXT` map in render.ts for the
+ * button's label and a `next` map in editor.ts for what the click stores — and
+ * the two drifted the way two copies of one fact always do. When the
+ * prototype-lookup bug below was found, the fix was applied to the editor's
+ * copy and not the renderer's, and the editor's comment then asserted the whole
+ * thing was safe while the label it named was still being rendered from the
+ * unguarded copy.
+ *
+ * `board` is the ABSENT key, never a stored 'board': a view cycled all the way
+ * round is byte-identical to one nobody ever touched, which is the rule filter
+ * and source already follow. `nextLayout` returns the word; the caller that
+ * WRITES is the one that turns 'board' back into a deletion.
+ */
+export const VIEW_LAYOUTS = ['board', 'list', 'table', 'gallery'] as const
+export type ViewLayout = (typeof VIEW_LAYOUTS)[number]
+
+/**
+ * The layout a view is ACTUALLY in, whatever its block claims.
+ *
+ * `Object.hasOwn`, never a truthiness test or a bare `in`: a view block is
+ * plain JSON in a file someone sent you, and `LAYOUT['toString']` on an object
+ * literal is a native function — truthy, and stringifying to
+ * `function toString() { [native code] }`, which is what the layout button
+ * rendered as its own label. A key from a NEWER build lands on `board` rather
+ * than nowhere, so the control is never a button that does nothing.
+ */
+export function layoutOf(raw: unknown): ViewLayout {
+  const s = String(raw ?? 'board')
+  return (VIEW_LAYOUTS as readonly string[]).includes(s) ? (s as ViewLayout) : 'board'
+}
+
+/** The next shape in the cycle: board → list → table → gallery → board. */
+export function nextLayout(raw: unknown): ViewLayout {
+  const here = layoutOf(raw)
+  return VIEW_LAYOUTS[(VIEW_LAYOUTS.indexOf(here) + 1) % VIEW_LAYOUTS.length]
+}

--- a/spaces/src/render.ts
+++ b/spaces/src/render.ts
@@ -17,7 +17,8 @@ import { TAG_OF, LIST_OF, SPEC, TONE, mediaPlayback } from './blocks'
 import {
   fieldByKey, fieldsOf, optionOf, viewRows, headerLength, propBlockOf,
   passesFilter, filterCount, unknownFilterKeys,
-  sortRows, unknownSortKeys, sortDirOf, type ViewSort, type FieldSpec,
+  sortRows, unknownSortKeys, sortDirOf, layoutOf, nextLayout,
+  type ViewSort, type FieldSpec, type ViewLayout,
 } from './fields'
 import { answer, feed, freshContext, type CalcCtx } from './calc.ts'
 import { ICONS, type IconName } from './icons'
@@ -1120,36 +1121,38 @@ function renderView(host: HTMLElement, b: Block, doc: SpacesDoc, opts: RenderOpt
     // THREE shapes now, so the button says what you are looking at and the
     // click moves to the next one. A menu to choose between three is still a
     // menu too many; a cycle is one control and one word.
-    const LAYOUT_WORD: Record<string, string> = {
-      board: 'Board', list: 'List', table: 'Table', gallery: 'Gallery',
-    }
-    const here = LAYOUT_WORD[layout] ? layout : 'board'
+    // `layoutOf`, not a lookup in a local map: the cycle is ONE fact and it now
+    // lives in fields.ts, because it used to live here AND in editor.ts and the
+    // two drifted. A view block hand-authored with layout:"toString" — plain
+    // JSON, in a file someone sent you — made the truthiness test here pass on
+    // a native function, and the button's label rendered as
+    // `function toString() { [native code] }`. The editor's copy had been
+    // hardened and its comment said the label was safe; the label is rendered
+    // here, and this half had not been.
+    const here = layoutOf(layout)
     const asList = here !== 'board'
     // Three WHOLE sentences rather than one with the shape interpolated into
     // it. "Show as a {what}" reads fine in English and breaks in half the
     // catalogs, where the article and the adjective agree with the noun's
     // gender — der Tafel / die Liste, un tableau / une liste. Two of these
     // three keys already existed for the same reason.
-    const NEXT: Record<string, string> = {
-      board: 'list', list: 'table', table: 'gallery', gallery: 'board',
-    }
-    // THE EXTRACTOR SWEEPS LITERALS. `t(LAYOUT_WORD[here])` compiles, runs, and
-    // is never translated by anybody: no catalog ever learns the string exists,
+    // THE EXTRACTOR SWEEPS LITERALS. `t(WORD[here])` compiles, runs, and is
+    // never translated by anybody: no catalog ever learns the string exists,
     // and the packer still reports 100% because it builds coverage from the
     // keys it swept. Measured on main: "Board", "List" and "Show as a list"
     // were present in de.ts and ABSENT from packed.ts — translations already
     // written, dropped on the floor, while the button read English in all eight
-    // locales. The maps stay (they answer "what is next"); the words are chosen
-    // at the call site, where the sweep can see them.
-    const LAYOUT_LABEL: Record<string, string> = {
+    // locales. So the words are chosen HERE, as literals the sweep can see;
+    // fields.ts answers "which shape is this" and "what comes next".
+    const LAYOUT_LABEL: Record<ViewLayout, string> = {
       board: t('Board'), list: t('List'), table: t('Table'), gallery: t('Gallery'),
     }
-    const NEXT_LABEL: Record<string, string> = {
+    const NEXT_LABEL: Record<ViewLayout, string> = {
       board: t('Show as a list'), list: t('Show as a table'),
       table: t('Show as a gallery'), gallery: t('Show as a board'),
     }
     const layoutB = btn('viewLayout', LAYOUT_LABEL[here], NEXT_LABEL[here])
-    layoutB.dataset.next = NEXT[here]
+    layoutB.dataset.next = nextLayout(here)
 
     // GROUP BY. Only fields with declared options: a board's columns ARE the
     // option list, so grouping by a free-text field would make one column per

--- a/spaces/src/styles.css
+++ b/spaces/src/styles.css
@@ -2206,12 +2206,37 @@ button.sp-issue-set:hover { background: var(--chrome-2); border-color: var(--edg
    columns, six cards carrying ~60px of nothing. Two lines is the difference
    between a grid and a pile. (`a.sp-gcard` is dead — the card is a div — so the
    selector loses it.) */
-.sp-gcard .sp-issue-title {
+/* SPECIFICITY, not source order. `.sp-gcard .sp-issue-title` is (0,2,0) and
+   loses to `.sp-page a.sp-issue-title` (0,2,1) further up, which sets
+   `display: block` — so `display: -webkit-box` never applied and the clamp sat
+   there inert. Measured before this line: computed display `block`,
+   -webkit-line-clamp `2`, and a long title rendering FOUR lines with
+   scrollHeight == clientHeight, i.e. nothing clipped. The comment above was
+   describing a fix that was not in effect.
+   Going through `.sp-gcard-body` makes it (0,3,0), which beats a
+   two-classes-plus-an-element selector outright rather than by winning a tie on
+   order — the card's title is inside that wrapper in both shapes it renders as. */
+.sp-gcard .sp-gcard-body .sp-issue-title {
   font-size: 13.5px; font-weight: 600;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
   overflow: hidden;
 }
 .sp-gcard .sp-issue-meta { margin-top: 6px; }
+
+/* THE WHOLE CARD IS THE TARGET, not the two words of its title. In a gallery
+   the picture IS the thing you point at — a shelf of book covers where only the
+   caption responds is a shelf that feels broken, and the cover is the largest
+   and most obvious target on the card by a wide margin.
+
+   Done by stretching the title's OWN link over the card rather than by wrapping
+   the card in a second anchor: one link, one accessible name, and no anchor
+   nested inside another. `.sp-gcard` is already `position: relative`, and
+   nothing between it and the title is positioned, so `inset: 0` resolves to the
+   card. Only the editable card has an anchor to stretch — in reading view the
+   title is a span, there is no link, and correctly nothing to click. */
+.sp-gcard .sp-issue-title::after {
+  content: ''; position: absolute; inset: 0; border-radius: inherit;
+}
 
 /* ————— CANVAS ————————————————————————————————————————————————————————————
    A bounded surface with cards placed on it (canvas.ts). The block is


### PR DESCRIPTION
Follow-up to #392, which merged from `fb6a5a3` before my last push to that branch landed. Four things that commit reported as fixed are live on `main`; each one below was re-measured in the built shell rather than read out of the source.

## The two-line clamp was never in effect

`.sp-gcard .sp-issue-title` is (0,2,0) and loses to `.sp-page a.sp-issue-title` (0,2,1) higher up the file, so `display: -webkit-box` never applied and `-webkit-line-clamp: 2` sat inert beside a comment describing the fix.

Measured in `dist-single` on `beb5a19`: computed display `block`, a long title rendering **four** lines, `scrollHeight === clientHeight` — nothing was being clipped at all. That is the "grid becomes a pile" the comment says it prevents.

Routing through `.sp-gcard-body` makes it (0,3,0), which beats two-classes-plus-an-element outright rather than winning a tie on source order. After: `clientHeight` 38 against `scrollHeight` 76, two lines, title boxes 38/19/19 across a row.

## The prototype guard went into one of the two copies

The layout cycle was written twice — `next` in `editor.ts` for what a click stores, `NEXT`/`LAYOUT_WORD` in `render.ts` for what the button says. #392 hardened the editor's copy, and **its comment then asserted the label was safe** while the label was still rendered from the other one, guarded by truthiness.

`LAYOUT_WORD['toString']` is a native function, and truthy. A view block carrying `layout:"toString"` — plain JSON, in a file someone sent you — rendered its layout button as `function toString() { [native code] }` and wrote the same text into `data-next`. Confirmed in the running app before, and fixed after.

Two copies of one fact is what let a fix land on half of it, so the cycle is now one `layoutOf`/`nextLayout` in `fields.ts` with both callers going through it. That is also what makes it testable: `fields.ts` loads under node, `render.ts` does not.

## A gallery card is clickable on its title alone

In a shelf of covers the picture is what you point at, and it did nothing. The title's own link stretches over the card now, rather than the card holding a second anchor — one link, one accessible name, no nested interactive elements, and reading view (where the title is a `span`) correctly gets no link at all.

Measured with `elementFromPoint`: the cover's centre and the card's top-left corner both resolve to the page's `href`.

## A duplicated rig section

The rebase left `a view is about a set of pages` in `test-spaces-model.ts` twice. `main` has it twice now; it should be once.

## Rig

Three assertions read `/gallery: undefined/` against `editor.ts`, which tests how a line is **spelled**: moving the cycle kept every behaviour and turned them red, while hardening the same lookup would have left them green. They ask `nextLayout` now. The one that still must inspect source is scoped to the method's own body, on the `coverFn` precedent already in this file, because `undefined` appears hundreds of times in `editor.ts`.

Added prototype cases (`toString`, `constructor`, `valueOf`, `hasOwnProperty`, `__proto__`) and a cycle-closure check. Both sabotage-verified: reinstating the truthiness lookup fails exactly the five prototype checks and nothing else.

## Checks

- `node scripts/test-spaces.mjs` — all 8 rigs pass
- `tsc --noEmit` clean
- `npm run build:single` clean; shell 271KB
- The i18n class guard from #392 re-verified by sabotage — reintroducing `t(MAP[key])` fails it and names the offender
