### PR TITLE
[Unreleased] gains the sticky-move fix, and the phone chrome it was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,13 @@ pre-1.0.
   the save. Granting a large folder no longer costs anything either, so a whole
   home directory is as cheap as a single decks folder.
 
+- **The toolbar is centred on a phone, and the Save button has its outline
+  back.** At phone widths the deck title had 90px to sit in and now has 220px,
+  because the folded bar centres and gives the title the room it frees. The Save
+  button had lost its right-hand border and rounded corner below 700px, where
+  the caret beside it is hidden — so it read as an unfinished edge rather than a
+  button.
+
 - **Fix: several buttons were unreadable in dark mode.** White text on a
   near-white button — the main action in a dialog, the toast that confirms a
   save, the active chip in a settings row, and the ＋ between slides. The
@@ -228,6 +235,20 @@ pre-1.0.
   system that does report the old code still lands on it, and so a file already
   carrying the pack keeps working. Turkmen (`tk`) was checked at the same time
   and needed no change: `tk-TM` is what a Turkmen system reports.
+- **Fix: a single click could leave an element stuck to the cursor, and the
+  click that freed it moved the element.** Click once to select something and it
+  would occasionally follow the pointer around the slide as though you were
+  dragging it. The click that finally released it committed the move, so the
+  element stayed where the pointer happened to be — a selection turning into an
+  edit, with nothing on screen to say so and no reason to reach for undo.
+
+  This one is not about phones. It is a race between how fast the click arrives
+  and how fast the machine can respond to it, so it bites slower hardware of any
+  kind: the person who reported it hit it roughly one click in five on an older
+  desktop and never once on a current laptop. If your deck has quietly lost its
+  layout and you have never pinched a phone screen, this is the more likely
+  cause. Measured on the same machine before and after: 22 of 24 clicks stuck,
+  then 0 of 24.
 
 ## [1.0.18] — 2026-08-15
 


### PR DESCRIPTION
Found by reconciling the 41 commits since `v1.0.18` **against** the changelog, rather than reading the changelog for gaps — the only direction that can find a missing entry. Credit to bento-team-slides for running it.

One file, 21 insertions. Verified against `origin/main` = `a01ea0e`.

## #366 gets its own Fix entry

`4a6e250`, closes issue #260 (confirmed CLOSED). A single click could leave an element stuck to the cursor, and **the click that freed it committed the move** — a selection silently becoming an edit, with nothing on screen to say so.

Same test I used to give #278 its own entry and to deny #274 one: **split a fix out when its damage is invisible.** Nobody scanning "why did my deck lose its layout" would find this inside another entry.

**The placement was the real decision.** It must not go inside the phone entry, because it is not a phone bug — it is a race between the click and the render, so it bites slow hardware of any kind. The reporter hit it roughly 1 in 5 clicks on an older desktop and never once on a current laptop. Filed under phones, a desktop user would read the pinch entry, see "phones, two fingers", and conclude it was not their bug. So the entry says outright that this one is not about phones — that sentence is what makes it findable by the person who needs it.

Measurement included the way #413's was: **22 of 24 clicks stuck before, 0 of 24 after**, same machine.

## #294 and #295 get one short shared entry

Both are phone chrome and both are **visible** — a deck title with 90px instead of 220px, a Save button missing its right border below 700px where the caret is hidden. By the same test neither earns a Fix line of its own.

But "all notable changes" does not mean "only the invisible ones", and both were uncovered entirely: the single `toolbar` hit in the section is #274's *scrolling* subhead, a different change. Verified the dark-toast half of #295 **is** already covered by the unreadable-in-dark-mode entry, so only the outline half is new.

## Timing

Written before the maintainer's relay asking for #366 arrived. The relay changed nothing about the entry.

https://claude.ai/code/session_01Jcfdy8A69nonyATtm8vRy8
