### PR TITLE
Release 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ pre-1.0.
 
 ## [Unreleased]
 
+## [1.0.19] — 2026-09-04
+
 - **Bento Slides works on a phone.** Eight changes land together, because
   individually none of them was enough: a deck opened on a handset could be
   looked at and rearranged, but not written.

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bento-slides",
   "private": true,
-  "version": "1.0.18",
+  "version": "1.0.19",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump and changelog date for slides 1.0.19. Two files, no code.

## The changelog was checked against the commits, not against itself

That is the check that missed code morphing before v1.0.18. **41 commits** touch `slides/` or `kernel/` since that tag, against **18 entries**. Two commits looked unaccounted for and both resolve cleanly:

- **#292** (formatting bar, real lists and headings) — covered *inside* the phone bundle rather than as its own entry.
- **#351** (first-party pptx importer) — kernel-only groundwork; nothing under `slides/src/` references it, so it ships no slides behaviour to announce.

## The signed notes, read from `--dry-run`

Not from the changelog in the editor — these are permanent for this version:

```
• Bento Slides works on a phone.
• Code on a slide — and it morphs.
• A deck can set its own morph tempo.
• Deck-wide brand colours.
• The web demo says where your deck went.
• Every deck you save is smaller.
```

Six feature lead-ins, all 1.0.19, none of them a fix introducing the release.

## One thing the dry run caught

`@gfx/zopfli` was missing from the release worktree and the build **refused** rather than falling back to zlib — which would have shipped a shell about 4% larger under a release tag. Fixed by installing it, not by setting `ZOPFLI=0`.

Dry run otherwise clean: splice conformance gate passed, 22 language packs at 720–721 strings, shell 677KB compressed.

---

**Merging this is not mine.** The release zone cuts what has already landed; per the contract that act is the maintainer's, delegated to `integrator`. Once it lands I take the tag, build, sign, publish and verify.

https://claude.ai/code/session_01FqzzY5iHopxZNvScbuqk2v