### PR TITLE
kernel: read the release public key and sync host from AppConfig

### DIFF
--- a/kernel/src/app.ts
+++ b/kernel/src/app.ts
@@ -6,7 +6,9 @@
 // Only three values are app-specific across the whole kernel: the id the
 // release manifest is signed with, the display name that appears in window
 // titles and save dialogs, and where updates are fetched from. Everything
-// else in the kernel is genuinely app-agnostic.
+// else in the kernel is genuinely app-agnostic. Two OPTIONAL values exist for
+// a fork that runs its own release channel and relay: the signing public key
+// and the default sync host. Absent, the platform defaults apply unchanged.
 //
 // Deliberately NOT a general "kernel init" — modules that need no config
 // (anim, charts) take none, so there is no import-order trap and no false
@@ -24,6 +26,16 @@ export interface AppConfig {
   appName: string
   /** Release manifest URL. Dev override: localStorage 'bento-update-url'. */
   manifestUrl: string
+  /** Release-signing PUBLIC key (P-256 JWK) that manifests and pack indexes
+   *  are verified against. Optional: absent, the kernel uses the platform key
+   *  embedded in update.ts. A fork that publishes its own signed channel sets
+   *  this so its shipped files never accept a manifest signed by another key
+   *  (appId already refuses another app; this refuses another PUBLISHER). */
+  publicKeyJwk?: { kty: 'EC'; crv: 'P-256'; x: string; y: string }
+  /** Default relay host for collaboration (wss://…). Optional: absent, the
+   *  kernel uses DEFAULT_SYNC_HOST in sync/online.ts. The localStorage
+   *  'bento-sync-url' dev override wins over both. */
+  syncHost?: string
 }
 
 let config: AppConfig | null = null

--- a/kernel/src/sync/online.ts
+++ b/kernel/src/sync/online.ts
@@ -17,6 +17,7 @@ import { offlineEnabled } from '../update.ts'
 // Every request in the app goes through the one chokepoint (kernel/src/net.ts)
 // so the offline switch cannot be forgotten — see GHSA-5c3x-xqp6-g94r.
 import { netWebSocket } from '../net.ts'
+import { appConfig } from '../app.ts'
 
 /** the app's store, structurally — see session.ts HostStore */
 type Store = HostStore
@@ -144,12 +145,16 @@ export async function mintCollab(): Promise<CollabCreds> {
   }
 }
 
-/** dev override for the relay host (e.g. ws://localhost:8787) */
+/** The relay host: the localStorage dev override (e.g. ws://localhost:8787),
+ *  else the host the app configured (a fork running its own relay), else the
+ *  platform default. Rigs that never call configureApp() get the default. */
 export function syncHost(): string {
+  let configured: string | undefined
+  try { configured = appConfig().syncHost } catch { /* not configured: platform default */ }
   try {
-    return lsGet('bento-sync-url') || DEFAULT_SYNC_HOST
+    return lsGet('bento-sync-url') || configured || DEFAULT_SYNC_HOST
   } catch {
-    return DEFAULT_SYNC_HOST
+    return configured || DEFAULT_SYNC_HOST
   }
 }
 

--- a/kernel/src/update.ts
+++ b/kernel/src/update.ts
@@ -132,7 +132,9 @@ export async function verifySigned(raw: string, what = 'signed file'): Promise<u
     throw new Error(`the ${what} is malformed`)
 
   const key = await crypto.subtle.importKey(
-    'jwk', PUBLIC_KEY_JWK as JsonWebKey,
+    // A fork with its own release channel supplies its key via configureApp();
+    // the platform key below is the default so upstream builds are unchanged.
+    'jwk', (appConfig().publicKeyJwk ?? PUBLIC_KEY_JWK) as JsonWebKey,
     { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify'],
   )
   const ok = await crypto.subtle.verify(


### PR DESCRIPTION
## kernel: read the release public key and sync host from AppConfig

`kernel/src/update.ts` hardcodes `PUBLIC_KEY_JWK` and `kernel/src/sync/online.ts` hardcodes `DEFAULT_SYNC_HOST`. Both are per-publisher values, not per-kernel ones: a downstream build that runs its own signed release channel and its own relay has to patch the kernel to change them, and then carries that patch across every merge.

This adds two **optional** fields to `AppConfig`:

- `publicKeyJwk` — the P-256 public JWK manifests and pack indexes are verified against. Absent, `update.ts` uses the embedded platform key exactly as today.
- `syncHost` — the default relay host. Absent, `sync/online.ts` uses `DEFAULT_SYNC_HOST` exactly as today. The `bento-sync-url` localStorage dev override still wins over both.

Nothing changes for the apps in this repo: none of them set the fields, and every existing rig passes unchanged. `test-release-channel.mjs` still swaps the embedded constant by regex, because the constant is still there as the default.

Why optional and why in `AppConfig`: `app.ts` already says only three values are app-specific across the kernel. These two are publisher-specific, which is the same axis, and `configureApp()` is the one call every app already makes before any kernel module runs. `syncHost()` reads the config lazily and tolerates an unconfigured kernel, so rigs that never call `configureApp()` are unaffected.

Verified: `tsc -b`, `tsc -p ../kernel`, `npm run build:single`, `shell-gate.mjs`, `test-release-channel.mjs --app slides`, `test-sync-session.ts`, `test-relay-protocol.ts`, `test-offline.ts`, `test-storage.ts`, `test-autosave.ts`.
