### PR TITLE
fix(editor): keep the layout picker inside the viewport

### DIFF
--- a/slides/src/editor/editor.ts
+++ b/slides/src/editor/editor.ts
@@ -1755,17 +1755,15 @@ export class Editor {
       }
       pick.appendChild(grid)
     }
+    // Open beside the anchor, clamped on-screen. The bottom-of-sidebar button
+    // used to open the picker upward from itself, which pushed a picker with
+    // a handful of custom layouts above the viewport (measured: top = -7px at
+    // a 600px-tall window). The height is read after appending so the clamp
+    // uses the real box; the stylesheet caps it to the viewport and scrolls.
     const r = anchor.getBoundingClientRect()
-    if (anchor.classList.contains('ed-add-slide')) {
-      // bottom-of-sidebar button: open upward from it
-      pick.style.left = `${Math.max(8, r.left)}px`
-      pick.style.bottom = `${window.innerHeight - r.top + 8}px`
-    } else {
-      // insert-gap or panel button: open beside the anchor, clamped on-screen
-      pick.style.left = `${Math.max(8, Math.min(r.right + 10, window.innerWidth - 440))}px`
-      pick.style.top = `${Math.max(8, Math.min(r.top - 40, window.innerHeight - 460))}px`
-    }
+    pick.style.left = `${Math.max(8, Math.min(r.right + 10, window.innerWidth - 440))}px`
     document.body.appendChild(pick)
+    pick.style.top = `${Math.max(8, Math.min(r.top - 40, window.innerHeight - pick.offsetHeight - 8))}px`
     const close = (ev: PointerEvent) => {
       if (!pick.contains(ev.target as Node)) {
         pick.remove()

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1343,7 +1343,7 @@ a.ed-btn { text-decoration: none; }  /* the update block's "What's new" link is 
   box-shadow: 0 12px 32px rgb(15 23 36 / 0.18);
   padding: 12px 14px;
   max-width: 420px;
-  max-height: 70vh;
+  max-height: calc(100vh - 16px);
   overflow-y: auto;
 }
 .ed-layoutpick-title {


### PR DESCRIPTION
The New-slide button at the bottom of the sidebar opened the layout picker upward from itself. Once a deck carries a few custom layouts the picker is taller than the space above the button and its top lands above the viewport: measured top = −7 px at a 600 px-tall window, with the first row of thumbnails clipped under the topbar.

Every anchor now opens beside itself, clamped on-screen. The picker is appended first so the clamp uses its real height, and `.ed-layoutpick` caps at `calc(100vh - 16px)` (it already scrolls) so very short windows scroll inside the picker instead of losing rows.

Measured after the change at 1280×600: top 150, bottom 592, every layout reachable, no internal scroll. At 1280×400: top 8, bottom 392, scrolls internally; choosing a layout after scrolling inserts the slide and closes the picker. The insert-gap and panel anchors keep their placement; only the clamp floor changes from a fixed 460 px to the measured height.

Found in the Beta Mobility fork (six custom layouts in every template).